### PR TITLE
New state estimators (Merge after MOLA 1.5.0 is installable via apt)

### DIFF
--- a/.github/workflows/build-ros.yml
+++ b/.github/workflows/build-ros.yml
@@ -22,17 +22,29 @@ jobs:
           # Humble Hawksbill (May 2022 - May 2027)
           - docker_image: ubuntu:jammy
             ros_distribution: humble
-            ros_version: 2
+            use_ros_testing: false
+
+          - docker_image: ubuntu:jammy
+            ros_distribution: humble
+            use_ros_testing: true
 
           # Jazzy (2024 - ??)
           - docker_image: ubuntu:noble
             ros_distribution: jazzy
-            ros_version: 2
+            use_ros_testing: false
+
+          - docker_image: ubuntu:noble
+            ros_distribution: jazzy
+            use_ros_testing: true
 
           # Rolling Ridley (No End-Of-Life)
           - docker_image: ubuntu:noble
             ros_distribution: rolling
-            ros_version: 2
+            use_ros_testing: false
+
+          - docker_image: ubuntu:noble
+            ros_distribution: rolling
+            use_ros_testing: true
 
     container:
       image: ${{ matrix.docker_image }}
@@ -51,7 +63,7 @@ jobs:
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
-          use-ros2-testing: true
+          use-ros2-testing: ${{ matrix.use_ros_testing }}
 
       - name: Install rosdep dependencies
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ find_package(mrpt-tclap REQUIRED)
 find_mola_package(mola_kernel)
 find_mola_package(mp2p_icp)
 find_mola_package(mp2p_icp_filters)
-find_mola_package(mola_navstate_fuse)
 find_mola_package(mola_pose_list)
 
 # -----------------------
@@ -42,7 +41,6 @@ mola_add_library(
     mola::mola_kernel
     mola::mp2p_icp
     mola::mp2p_icp_filters
-    mola::mola_navstate_fuse
     mola::mola_pose_list
 # PRIVATE_LINK_LIBRARIES
 #  mrpt::maps
@@ -50,7 +48,6 @@ mola_add_library(
     mola_kernel
     mp2p_icp
     mp2p_icp_filters
-    mola_navstate_fuse
     mrpt-maps
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ install(
     pipelines
     ros2-launchs
     rviz2
+    state-estimator-params
   DESTINATION
     share/${PROJECT_NAME}
 )

--- a/docs/mola_lo_pipelines.rst
+++ b/docs/mola_lo_pipelines.rst
@@ -296,7 +296,7 @@ These settings only have effects if launched via :ref:`MOLA-LO GUI applications 
 
 Motion model
 ^^^^^^^^^^^^^^^^^^^^^^
-A constant velocity motion model is used by default, provided by the ``mola_navstate_fuse`` module.
+A constant velocity motion model is used by default, provided by the ``mola_state_estimation_simple`` module.
 
 - ``MOLA_MAX_TIME_TO_USE_VELOCITY_MODEL`` (Default: 0.75 s): Maximum time between LiDAR frames to use the velocity model. Larger delays will cause using the latest vehicle pose as initial guess.
 - ``MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC`` (Default: 1.0 m/s²): Linear acceleration standard deviation.

--- a/module/src/LidarOdometry.cpp
+++ b/module/src/LidarOdometry.cpp
@@ -47,6 +47,7 @@
 #include <mrpt/maps/CColouredPointsMap.h>
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/CObservationGPS.h>
+#include <mrpt/obs/CObservationIMU.h>
 #include <mrpt/obs/CObservationOdometry.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CRawlog.h>
@@ -63,16 +64,12 @@
 #include <mrpt/system/filesystem.h>
 #include <mrpt/system/string_utils.h>
 
+// GUI:
+#include <mrpt/gui/CDisplayWindowGUI.h>
+
 // STD:
 #include <chrono>
 #include <thread>
-
-// fix for older mrpt versions:
-#include <mrpt/config.h>
-#if MRPT_VERSION <= 0x020d00  // < v2.13.0
-// YAML API:
-#define asSequenceRange asSequence
-#endif
 
 using namespace mola;
 
@@ -336,9 +333,12 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
   if (c.has("initial_localization"))
     params_.initial_localization.initialize(c["initial_localization"]);
 
-  ENSURE_YAML_ENTRY_EXISTS(c, "navstate_fuse_params");
-  state_.navstate_fuse.setMinLoggingLevel(this->getMinLoggingLevel());
-  state_.navstate_fuse.initialize(c["navstate_fuse_params"]);
+  // Watch for legacy (mola_lidar_odometry version <0.5.0) organization:
+  if (c.has("navstate_fuse_params")) {
+    THROW_EXCEPTION(
+      "It seems you are using a legacy mola_lo pipeline config file. Please, refer to release "
+      "notes for mola_lidar_odometry 0.5.0");
+  }
 
   ENSURE_YAML_ENTRY_EXISTS(c, "icp_settings_with_vel");
   load_icp_set_of_params(params_.icp[AlignKind::RegularOdometry], c["icp_settings_with_vel"]);
@@ -476,6 +476,19 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
     bool loadOk =
       state_.reconstructed_simplemap.loadFromFile(params_.simplemap.load_existing_simple_map);
     ASSERT_(loadOk);
+  }
+
+  // Attach to the state estimation module, which since MOLA-LO v0.5.0,
+  // must run as a separate MOLA module:
+  {
+    auto mods = findService<mola::NavStateFilter>();
+    ASSERTMSG_(
+      mods.size() == 1,
+      "No state estimation MOLA module (mola::NavStateFilter) was found. Please, check your MOLA "
+      "system .yaml file");
+    state_.navstate_fuse = std::dynamic_pointer_cast<NavStateFilter>(mods[0]);
+    ASSERT_(state_.navstate_fuse);
+    MRPT_LOG_DEBUG("Attached to the state estimation module");
   }
 
   // end of initialization:
@@ -799,13 +812,14 @@ void LidarOdometry::onLidarImpl(const CObservation::Ptr & obs)
       initPose.cov = *il.initial_pose_cov;
     }
 
-    state_.navstate_fuse.reset();  // needed after a re-localization to forget the past
+    ASSERT_(state_.navstate_fuse);
+    state_.navstate_fuse->reset();  // needed after a re-localization to forget the past
 
     // Fake an evolution to be able to have an initial velocity estimation:
     const auto t1 = mrpt::Clock::fromDouble(mrpt::Clock::toDouble(this_obs_tim) - 0.2);
     const auto t2 = mrpt::Clock::fromDouble(mrpt::Clock::toDouble(this_obs_tim) - 0.1);
-    state_.navstate_fuse.fuse_pose(t1, initPose, NAVSTATE_LIODOM_FRAME);
-    state_.navstate_fuse.fuse_pose(t2, initPose, NAVSTATE_LIODOM_FRAME);
+    state_.navstate_fuse->fuse_pose(t1, initPose, NAVSTATE_LIODOM_FRAME);
+    state_.navstate_fuse->fuse_pose(t2, initPose, NAVSTATE_LIODOM_FRAME);
 
     MRPT_LOG_INFO_STREAM("Initial re-localization done with pose: " << initPose.mean);
 
@@ -827,7 +841,7 @@ void LidarOdometry::onLidarImpl(const CObservation::Ptr & obs)
   ProfilerEntry tleMotion(profiler_, "onLidar.2b.estimated_navstate");
 
   state_.last_motion_model_output =
-    state_.navstate_fuse.estimated_navstate(this_obs_tim, NAVSTATE_LIODOM_FRAME);
+    state_.navstate_fuse->estimated_navstate(this_obs_tim, NAVSTATE_LIODOM_FRAME);
 
   const bool hasMotionModel = state_.last_motion_model_output.has_value();
 
@@ -854,7 +868,7 @@ void LidarOdometry::onLidarImpl(const CObservation::Ptr & obs)
     initPose.mean = mrpt::poses::CPose3D::Identity();
     initPose.cov.setDiagonal(1e-12);
 
-    state_.navstate_fuse.fuse_pose(this_obs_tim, initPose, NAVSTATE_LIODOM_FRAME);
+    state_.navstate_fuse->fuse_pose(this_obs_tim, initPose, NAVSTATE_LIODOM_FRAME);
   } else {
     // Register point clouds using ICP:
     // ------------------------------------
@@ -1062,7 +1076,7 @@ void LidarOdometry::onLidarImpl(const CObservation::Ptr & obs)
 
       if (state_.step_counter_post_relocalization == 0) {
         // Do integrate info:
-        state_.navstate_fuse.fuse_pose(
+        state_.navstate_fuse->fuse_pose(
           this_obs_tim, out.found_pose_to_wrt_from, NAVSTATE_LIODOM_FRAME);
       } else {
         // Skip during post-relocalization:
@@ -1071,7 +1085,7 @@ void LidarOdometry::onLidarImpl(const CObservation::Ptr & obs)
 
     } else {
       // Bad ICP:
-      state_.navstate_fuse.reset();
+      state_.navstate_fuse->reset();
     }
 
     // Update trajectory too:
@@ -1380,7 +1394,8 @@ void LidarOdometry::onIMUImpl(const CObservation::Ptr & o)
   MRPT_LOG_DEBUG_STREAM(
     "onIMU called for timestamp=" << mrpt::system::dateTimeLocalToString(imu->timestamp));
 
-  state_.navstate_fuse.fuse_imu(*imu);
+  ASSERT_(state_.navstate_fuse);
+  state_.navstate_fuse->fuse_imu(*imu);
 }
 
 void LidarOdometry::onWheelOdometry(const CObservation::Ptr & o)
@@ -1415,7 +1430,7 @@ void LidarOdometry::onWheelOdometryImpl(const CObservation::Ptr & o)
 
   MRPT_LOG_DEBUG_STREAM("onWheelOdometry: odom=" << odo->odometry);
 
-  state_.navstate_fuse.fuse_odometry(*odo);
+  state_.navstate_fuse->fuse_odometry(*odo);
 }
 
 void LidarOdometry::onGPS(const CObservation::Ptr & o)

--- a/mola-cli-launchs/lidar_odometry_from_kitti.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_kitti.yaml
@@ -48,3 +48,10 @@ modules:
     # with the LIDAR-Odometry pipeline configuration:
     params: '${MOLA_ODOMETRY_PIPELINE_YAML|../pipelines/lidar3d-default.yaml}'
 
+  - name: state_estimation
+    type: '${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}'
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}'
+
+    # This includes here a whole block "params: (...)":
+    params: '${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}'
+

--- a/mola-cli-launchs/lidar_odometry_from_kitti.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_kitti.yaml
@@ -10,7 +10,7 @@ modules:
   # =====================
   - name: viz
     type: mola::MolaViz
-    #verbosity_level: DEBUG
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_VIZ|INFO}'
     params: ~ # none
 
 # Offline or online sensory data sources =====================
@@ -42,7 +42,7 @@ modules:
 
   - name: lidar_odom
     type: mola::LidarOdometry
-    #verbosity_level: DEBUG
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_LO|INFO}'
     raw_data_source: 'dataset_input'
     # This includes here a whole block "params: (...)"
     # with the LIDAR-Odometry pipeline configuration:

--- a/mola-cli-launchs/lidar_odometry_from_kitti360.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_kitti360.yaml
@@ -48,3 +48,10 @@ modules:
     # with the LIDAR-Odometry pipeline configuration:
     params: '${MOLA_ODOMETRY_PIPELINE_YAML|../pipelines/lidar3d-default.yaml}'
 
+  - name: state_estimation
+    type: '${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}'
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}'
+
+    # This includes here a whole block "params: (...)":
+    params: '${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}'
+

--- a/mola-cli-launchs/lidar_odometry_from_kitti360.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_kitti360.yaml
@@ -10,7 +10,7 @@ modules:
   # =====================
   - name: viz
     type: mola::MolaViz
-    #verbosity_level: DEBUG
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_VIZ|INFO}'
     params: ~ # none
 
 # Offline or online sensory data sources =====================
@@ -42,7 +42,7 @@ modules:
 
   - name: lidar_odom
     type: mola::LidarOdometry
-    #verbosity_level: DEBUG
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_LO|INFO}'
     raw_data_source: 'dataset_input'
     # This includes here a whole block "params: (...)"
     # with the LIDAR-Odometry pipeline configuration:

--- a/mola-cli-launchs/lidar_odometry_from_kitti_output_ros2.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_kitti_output_ros2.yaml
@@ -48,6 +48,13 @@ modules:
     # with the LIDAR-Odometry pipeline configuration:
     params: '${MOLA_ODOMETRY_PIPELINE_YAML|../pipelines/lidar3d-default.yaml}'
 
+  - name: state_estimation
+    type: '${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}'
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}'
+
+    # This includes here a whole block "params: (...)":
+    params: '${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}'
+
   # MOLA -> ROS 2 bridge  =====================
   - name: ros2_bridge
     type: mola::BridgeROS2

--- a/mola-cli-launchs/lidar_odometry_from_kitti_output_ros2.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_kitti_output_ros2.yaml
@@ -10,7 +10,7 @@ modules:
   # =====================
   - name: viz
     type: mola::MolaViz
-    #verbosity_level: DEBUG
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_VIZ|INFO}'
     params: ~ # none
 
 # Offline or online sensory data sources =====================
@@ -42,7 +42,7 @@ modules:
 
   - name: lidar_odom
     type: mola::LidarOdometry
-    #verbosity_level: DEBUG
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_LO|INFO}'
     raw_data_source: 'dataset_input'
     # This includes here a whole block "params: (...)"
     # with the LIDAR-Odometry pipeline configuration:
@@ -51,6 +51,7 @@ modules:
   # MOLA -> ROS 2 bridge  =====================
   - name: ros2_bridge
     type: mola::BridgeROS2
+    verbosity_level: '${MOLA_VERBOSITY_BRIDGE_ROS2|INFO}'
 
     execution_rate: 20 # Hz
 

--- a/mola-cli-launchs/lidar_odometry_from_mulran.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_mulran.yaml
@@ -10,7 +10,7 @@ modules:
   # =====================
   - name: viz
     type: mola::MolaViz
-    #verbosity_level: DEBUG
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_VIZ|INFO}'
     params: ~ # none
 
 # Offline or online sensory data sources =====================
@@ -38,7 +38,7 @@ modules:
 
   - name: lidar_odom
     type: mola::LidarOdometry
-    #verbosity_level: DEBUG
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_LO|INFO}'
     raw_data_source: 'dataset_input'
     # This includes here a whole block "params: (...)"
     # with the LIDAR-Odometry pipeline configuration:

--- a/mola-cli-launchs/lidar_odometry_from_mulran.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_mulran.yaml
@@ -43,3 +43,11 @@ modules:
     # This includes here a whole block "params: (...)"
     # with the LIDAR-Odometry pipeline configuration:
     params: '${MOLA_ODOMETRY_PIPELINE_YAML|../pipelines/lidar3d-default.yaml}'
+
+  - name: state_estimation
+    type: '${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}'
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}'
+
+    # This includes here a whole block "params: (...)":
+    params: '${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}'
+

--- a/mola-cli-launchs/lidar_odometry_from_paris_luco.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_paris_luco.yaml
@@ -10,7 +10,7 @@ modules:
   # =====================
   - name: viz
     type: mola::MolaViz
-    #verbosity_level: DEBUG
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_VIZ|INFO}'
     params: ~ # none
 
 # Offline or online sensory data sources =====================
@@ -36,7 +36,7 @@ modules:
 
   - name: lidar_odom
     type: mola::LidarOdometry
-    #verbosity_level: DEBUG
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_LO|INFO}'
     raw_data_source: 'dataset_input'
     # This includes here a whole block "params: (...)"
     # with the LIDAR-Odometry pipeline configuration:

--- a/mola-cli-launchs/lidar_odometry_from_paris_luco.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_paris_luco.yaml
@@ -42,3 +42,10 @@ modules:
     # with the LIDAR-Odometry pipeline configuration:
     params: '${MOLA_ODOMETRY_PIPELINE_YAML|../pipelines/lidar3d-default.yaml}'
 
+  - name: state_estimation
+    type: '${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}'
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}'
+
+    # This includes here a whole block "params: (...)":
+    params: '${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}'
+

--- a/mola-cli-launchs/lidar_odometry_from_rawlog.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_rawlog.yaml
@@ -10,7 +10,7 @@ modules:
   # =====================
   - name: viz
     type: mola::MolaViz
-    #verbosity_level: DEBUG
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_VIZ|INFO}'
     params: ~ # none
 
 # Offline or online sensory data sources =====================
@@ -38,7 +38,7 @@ modules:
 
   - name: lidar_odom
     type: mola::LidarOdometry
-    #verbosity_level: DEBUG
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_LO|INFO}'
     raw_data_source: 'dataset_input'
     # This includes here a whole block "params: (...)"
     # with the LIDAR-Odometry pipeline configuration:

--- a/mola-cli-launchs/lidar_odometry_from_rawlog.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_rawlog.yaml
@@ -44,3 +44,10 @@ modules:
     # with the LIDAR-Odometry pipeline configuration:
     params: '${MOLA_ODOMETRY_PIPELINE_YAML|../pipelines/lidar3d-default.yaml}'
 
+  - name: state_estimation
+    type: '${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}'
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}'
+
+    # This includes here a whole block "params: (...)":
+    params: '${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}'
+

--- a/mola-cli-launchs/lidar_odometry_from_rosbag2.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_rosbag2.yaml
@@ -24,6 +24,17 @@ modules:
     # with the LIDAR-Odometry pipeline configuration:
     params: '${MOLA_ODOMETRY_PIPELINE_YAML|../pipelines/lidar3d-default.yaml}'
 
+  # =====================
+  # State Estimation
+  # =====================
+  - name: state_estimation
+    type: '${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}'
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}'
+
+    # This includes here a whole block "params: (...)":
+    params: '${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}'
+
+
   # =========================
   # Offline dataset source
   # =========================

--- a/mola-cli-launchs/lidar_odometry_from_rosbag2.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_rosbag2.yaml
@@ -10,7 +10,7 @@ modules:
   # =====================
   - name: viz
     type: mola::MolaViz
-    #verbosity_level: DEBUG
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_VIZ|INFO}'
     params: ~ # none
 
   # =====================
@@ -18,7 +18,7 @@ modules:
   # =====================
   - name: lidar_odom
     type: mola::LidarOdometry
-    #verbosity_level: DEBUG
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_LO|INFO}'
     raw_data_source: 'dataset_input'
     # This includes here a whole block "params: (...)"
     # with the LIDAR-Odometry pipeline configuration:

--- a/mola-cli-launchs/lidar_odometry_ros2.yaml
+++ b/mola-cli-launchs/lidar_odometry_ros2.yaml
@@ -27,11 +27,22 @@ modules:
     params: '${MOLA_ODOMETRY_PIPELINE_YAML|../pipelines/lidar3d-default.yaml}'
 
   # =====================
+  # State Estimation
+  # =====================
+  - name: state_estimation
+    type: '${MOLA_STATE_ESTIMATOR|mola::NavStateFuse}'
+    verbosity_level: '${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}'
+
+    # This includes here a whole block "params: (...)":
+    params: '${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/basic-estimator.yaml}'
+
+  # =====================
   # ROS2 <-> MOLA
   # =====================
   - type: mola::BridgeROS2
     name: ros2_bridge
     verbosity_level: '${MOLA_VERBOSITY_BRIDGE_ROS2|INFO}'
+
     # In BridgeROS2, this execution rate (Hz) determines the
     # rate of publishing odometry observations, if enabled.
     # All other subscribed sensors are forwarded to the MOLA

--- a/mola-cli-launchs/lidar_odometry_ros2.yaml
+++ b/mola-cli-launchs/lidar_odometry_ros2.yaml
@@ -30,11 +30,11 @@ modules:
   # State Estimation
   # =====================
   - name: state_estimation
-    type: '${MOLA_STATE_ESTIMATOR|mola::NavStateFuse}'
+    type: '${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}'
     verbosity_level: '${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}'
 
     # This includes here a whole block "params: (...)":
-    params: '${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/basic-estimator.yaml}'
+    params: '${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}'
 
   # =====================
   # ROS2 <-> MOLA

--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,6 @@
   <depend>mola_common</depend>
   <depend>mola_kernel</depend>
   <depend>mp2p_icp</depend>
-  <depend>mola_navstate_fuse</depend>
   <depend>mola_pose_list</depend>
 
   <depend>mrpt_libtclap</depend>
@@ -47,6 +46,9 @@
   <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>ament_lint_cmake</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  
+  <!-- for C++ unit tests -->
+  <test_depend>mola_state_estimation_simple</test_depend>
 
   <!-- Needed by the mola-lo-* scripts: -->
   <exec_depend>mola_launcher</exec_depend>

--- a/pipelines/extras/lidar3d-dual-map.yaml
+++ b/pipelines/extras/lidar3d-dual-map.yaml
@@ -62,16 +62,6 @@ params:
   initial_twist: ['${MOLA_INITIAL_VX|0.0}', 0.0, 0.0,  0.0, 0.0, 0.0]
 
 
-
-# Parameter block for the "navstate_fuse" module in charge of merging and 
-# extrapolating pose estimations, odometry, IMU, etc.
-navstate_fuse_params:
-  # Maximum time since last observation to consider the validity of the velocity model:
-  max_time_to_use_velocity_model: 2.0 # [seconds]
-  sigma_random_walk_acceleration_linear: 10.0 # [m/s²]
-  sigma_random_walk_acceleration_angular: 10.0 # [rad/s²]
-
-
 # If "icp_settings_without_vel" is not defined here, defaults to be the same than 'icp_settings_with_vel'
 # ICP settings can be included from an external YAML file if desired, or defined
 # in this same YAML for self-completeness:

--- a/pipelines/extras/lidar3d-edges.yaml
+++ b/pipelines/extras/lidar3d-edges.yaml
@@ -67,16 +67,6 @@ params:
   initial_twist: ['${MOLA_INITIAL_VX|0.0}', 0.0, 0.0,  0.0, 0.0, 0.0]
 
 
-
-# Parameter block for the "navstate_fuse" module in charge of merging and 
-# extrapolating pose estimations, odometry, IMU, etc.
-navstate_fuse_params:
-  # Maximum time since last observation to consider the validity of the velocity model:
-  max_time_to_use_velocity_model: 2.0 # [seconds]
-  sigma_random_walk_acceleration_linear: 10.0 # [m/s²]
-  sigma_random_walk_acceleration_angular: 10.0 # [rad/s²]
-
-
 # If "icp_settings_without_vel" is not defined here, defaults to be the same than 'icp_settings_with_vel'
 # ICP settings can be included from an external YAML file if desired, or defined
 # in this same YAML for self-completeness:

--- a/pipelines/extras/lidar3d-intensity.yaml
+++ b/pipelines/extras/lidar3d-intensity.yaml
@@ -76,17 +76,6 @@ params:
   # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s):
   initial_twist: ['${MOLA_INITIAL_VX|0.0}', 0.0, 0.0,  0.0, 0.0, 0.0]
 
-
-
-# Parameter block for the "navstate_fuse" module in charge of merging and 
-# extrapolating pose estimations, odometry, IMU, etc.
-navstate_fuse_params:
-  # Maximum time since last observation to consider the validity of the velocity model:
-  max_time_to_use_velocity_model: 2.0 # [seconds]
-  sigma_random_walk_acceleration_linear: 10.0 # [m/s²]
-  sigma_random_walk_acceleration_angular: 10.0 # [rad/s²]
-
-
 # If "icp_settings_without_vel" is not defined here, defaults to be the same than 'icp_settings_with_vel'
 # ICP settings can be included from an external YAML file if desired, or defined
 # in this same YAML for self-completeness:

--- a/pipelines/extras/lidar3d-kissicp-like.yaml
+++ b/pipelines/extras/lidar3d-kissicp-like.yaml
@@ -54,15 +54,6 @@ params:
   # Profile the internal steps of the ICP implementation:
   icp_profiler_enabled: true
 
-# Parameter block for the "navstate_fuse" module in charge of merging and 
-# extrapolating pose estimations, odometry, IMU, etc.
-navstate_fuse_params:
-  # Maximum time since last observation to consider the validity of the velocity model:
-  max_time_to_use_velocity_model: 2.0 # [seconds]
-  sigma_random_walk_acceleration_linear: 10.0 # [m/s²]
-  sigma_random_walk_acceleration_angular: 10.0 # [rad/s²]
-
-
 # If "icp_settings_without_vel" is not defined here, defaults to be the same than 'icp_settings_with_vel'
 # ICP settings can be included from an external YAML file if desired, or defined
 # in this same YAML for self-completeness:

--- a/pipelines/extras/lidar3d-near-far.yaml
+++ b/pipelines/extras/lidar3d-near-far.yaml
@@ -109,28 +109,6 @@ params:
   # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s):
   initial_twist: ['${MOLA_INITIAL_VX|0.0}', 0.0, 0.0,  0.0, 0.0, 0.0]
 
-# Parameter block for the "navstate_fuse" module in charge of merging and 
-# extrapolating pose estimations, odometry, IMU, etc.
-navstate_fuse_params:
-  # Maximum time since last observation to consider the validity of the velocity model:
-  # (KITTI360 test_3 has some blackouts >=1.0 seconds while angular acceleration is high, so 
-  #  this threshold must be < 1.0 s for that dataset)
-  max_time_to_use_velocity_model: 0.75 # [s]
-  sliding_window_length: 0.50 # [s]
-  sigma_random_walk_acceleration_linear: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC|1.0} # [m/s²]
-  sigma_random_walk_acceleration_angular: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_ANGACC|10.0} # [rad/s²]
-  
-  sigma_integrator_position: 1.0 # [m]
-  sigma_integrator_orientation:  1.0 # [rad]
-
-  # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s):
-  initial_twist: ['${MOLA_INITIAL_VX|0.0}', 0.0, 0.0,  0.0, 0.0, 0.0]
-  initial_twist_sigma_lin: 20.0 # [m/s]
-  initial_twist_sigma_ang: 3.0  # [rad/s]
-
-  robust_param: 0  # 0=no robust disabled
-  max_rmse: 2 # max inconsistencies to discard solution
-
 
 # If "icp_settings_without_vel" is not defined here, defaults to be the same than 'icp_settings_with_vel'
 # ICP settings can be included from an external YAML file if desired, or defined

--- a/pipelines/lidar2d.yaml
+++ b/pipelines/lidar2d.yaml
@@ -89,25 +89,6 @@ params:
   # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s):
   initial_twist: ['${MOLA_INITIAL_VX|0.0}', 0.0, 0.0,  0.0, 0.0, 0.0]
 
-# Parameter block for the "navstate_fuse" module in charge of merging and 
-# extrapolating pose estimations, odometry, IMU, etc.
-navstate_fuse_params:
-  max_time_to_use_velocity_model: 2.0 # [s]
-  sliding_window_length: 0.8 # [s]
-  sigma_random_walk_acceleration_linear: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC|2.0} # [m/s²]
-  sigma_random_walk_acceleration_angular: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_ANGACC|5.0} # [rad/s²]
-  
-  sigma_integrator_position: 0.10 # [m]
-  sigma_integrator_orientation:  0.10 # [rad]
-
-  # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s):
-  initial_twist: ['${MOLA_INITIAL_VX|0.0}', 0.0, 0.0,  0.0, 0.0, 0.0]
-  initial_twist_sigma_lin: 20.0 # [m/s]
-  initial_twist_sigma_ang: 3.0  # [rad/s]
-
-  robust_param: 0  # 0=no robust disabled
-
-
 # If "icp_settings_without_vel" is not defined here, defaults to be the same than 'icp_settings_with_vel'
 # ICP settings can be included from an external YAML file if desired, or defined
 # in this same YAML for self-completeness:

--- a/pipelines/lidar3d-default.yaml
+++ b/pipelines/lidar3d-default.yaml
@@ -80,7 +80,7 @@ params:
     save_to_file: ${MOLA_SAVE_TRAJECTORY|false}
     output_file: ${MOLA_TUM_TRAJECTORY_OUTPUT|'estimated_trajectory.tum'}
 
-  # If run within a mola-cli container, and mola_viz is present, use these options 
+  # If run within a mola-cli container, and mola_viz is present, use these options
   # to show live progress:
   visualization:
     map_update_decimation: 10
@@ -119,29 +119,6 @@ params:
     enabled: '${MOLA_ENABLE_OBS_VALIDITY_FILTER|false}'
     check_layer_name: 'raw'
     minimum_point_count: '${MOLA_OBS_VALIDITY_MIN_POINTS|1000}'
-
-
-# Parameter block for the "navstate_fuse" module in charge of merging and 
-# extrapolating pose estimations, odometry, IMU, etc.
-navstate_fuse_params:
-  # Maximum time since last observation to consider the validity of the velocity model:
-  # (KITTI360 test_3 has some blackouts >=1.0 seconds while angular acceleration is high, so 
-  #  this threshold must be < 1.0 s for that dataset)
-  max_time_to_use_velocity_model: ${MOLA_MAX_TIME_TO_USE_VELOCITY_MODEL|0.75} # [s]
-  sliding_window_length: 0.50 # [s]
-  sigma_random_walk_acceleration_linear: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC|1.0} # [m/s²]
-  sigma_random_walk_acceleration_angular: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_ANGACC|10.0} # [rad/s²]
-  
-  sigma_integrator_position: 1.0 # [m]
-  sigma_integrator_orientation:  1.0 # [rad]
-
-  # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s):
-  initial_twist: ['${MOLA_INITIAL_VX|0.0}', 0.0, 0.0,  0.0, 0.0, 0.0]
-  initial_twist_sigma_lin: 20.0 # [m/s]
-  initial_twist_sigma_ang: 3.0  # [rad/s]
-
-  robust_param: 0  # 0=no robust disabled
-  max_rmse: 2 # max inconsistencies to discard solution
 
 
 # Whether to use a re-localization method at start up:

--- a/pipelines/lidar3d-ndt.yaml
+++ b/pipelines/lidar3d-ndt.yaml
@@ -120,30 +120,6 @@ params:
     check_layer_name: 'raw'
     minimum_point_count: '${MOLA_OBS_VALIDITY_MIN_POINTS|1000}'
 
-
-# Parameter block for the "navstate_fuse" module in charge of merging and 
-# extrapolating pose estimations, odometry, IMU, etc.
-navstate_fuse_params:
-  # Maximum time since last observation to consider the validity of the velocity model:
-  # (KITTI360 test_3 has some blackouts >=1.0 seconds while angular acceleration is high, so 
-  #  this threshold must be < 1.0 s for that dataset)
-  max_time_to_use_velocity_model: ${MOLA_MAX_TIME_TO_USE_VELOCITY_MODEL|0.75} # [s]
-  sliding_window_length: 0.50 # [s]
-  sigma_random_walk_acceleration_linear: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC|1.0} # [m/s²]
-  sigma_random_walk_acceleration_angular: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_ANGACC|10.0} # [rad/s²]
-  
-  sigma_integrator_position: 1.0 # [m]
-  sigma_integrator_orientation:  1.0 # [rad]
-
-  # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s):
-  initial_twist: ['${MOLA_INITIAL_VX|0.0}', 0.0, 0.0,  0.0, 0.0, 0.0]
-  initial_twist_sigma_lin: 20.0 # [m/s]
-  initial_twist_sigma_ang: 3.0  # [rad/s]
-
-  robust_param: 0  # 0=no robust disabled
-  max_rmse: 2 # max inconsistencies to discard solution
-
-
 # Whether to use a re-localization method at start up:
 initial_localization:
   enabled: ${MOLA_INITIAL_LOCALIZATION_ENABLED|false}

--- a/pipelines/rgbd.yaml
+++ b/pipelines/rgbd.yaml
@@ -80,16 +80,6 @@ params:
   initial_twist: ['${MOLA_INITIAL_VX|0.0}', 0.0, 0.0,  0.0, 0.0, 0.0]
 
 
-
-# Parameter block for the "navstate_fuse" module in charge of merging and 
-# extrapolating pose estimations, odometry, IMU, etc.
-navstate_fuse_params:
-  # Maximum time since last observation to consider the validity of the velocity model:
-  max_time_to_use_velocity_model: 2.0 # [seconds]
-  sigma_random_walk_acceleration_linear: 10.0 # [m/s²]
-  sigma_random_walk_acceleration_angular: 10.0 # [rad/s²]
-
-
 # If "icp_settings_without_vel" is not defined here, defaults to be the same than 'icp_settings_with_vel'
 # ICP settings can be included from an external YAML file if desired, or defined
 # in this same YAML for self-completeness:

--- a/state-estimator-params/basic-estimator.yaml
+++ b/state-estimator-params/basic-estimator.yaml
@@ -1,0 +1,27 @@
+# This file holds parameters for the "simple" state estimator mola::NavStateFuse
+# module in charge of merging and extrapolating pose estimations, odometry, IMU, etc.
+#
+# Refer to:
+# https://github.com/MOLAorg/mola_lidar_odometry/
+
+params:
+  # Maximum time since last observation to consider the validity of the velocity model:
+  # (KITTI360 test_3 has some blackouts >=1.0 seconds while angular acceleration is high, so 
+  #  this threshold must be < 1.0 s for that dataset)
+  max_time_to_use_velocity_model: ${MOLA_MAX_TIME_TO_USE_VELOCITY_MODEL|0.75} # [s]
+
+  sliding_window_length: 0.50 # [s]
+
+  sigma_random_walk_acceleration_linear: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC|1.0} # [m/s²]
+  sigma_random_walk_acceleration_angular: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_ANGACC|10.0} # [rad/s²]
+
+  sigma_integrator_position: 1.0 # [m]
+  sigma_integrator_orientation:  1.0 # [rad]
+
+  # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s):
+  initial_twist: ['${MOLA_INITIAL_VX|0.0}', 0.0, 0.0,  0.0, 0.0, 0.0]
+  initial_twist_sigma_lin: 20.0 # [m/s]
+  initial_twist_sigma_ang: 3.0  # [rad/s]
+
+  robust_param: 0  # 0=no robust disabled
+  max_rmse: 2 # max inconsistencies to discard solution

--- a/state-estimator-params/state-estimation-simple.yaml
+++ b/state-estimator-params/state-estimation-simple.yaml
@@ -1,5 +1,4 @@
-# This file holds parameters for the "simple" state estimator mola::NavStateFuse
-# module in charge of merging and extrapolating pose estimations, odometry, IMU, etc.
+# This file holds parameters for mola::state_estimation_simple::StateEstimationSimple
 #
 # Refer to:
 # https://github.com/MOLAorg/mola_lidar_odometry/

--- a/state-estimator-params/state-estimation-smoother.yaml
+++ b/state-estimator-params/state-estimation-smoother.yaml
@@ -1,4 +1,4 @@
-# This file holds parameters for mola::state_estimation_simple::StateEstimationSimple
+# This file holds parameters for mola::state_estimation_smoother::StateEstimationSmoother
 #
 # Refer to:
 # https://docs.mola-slam.org/latest/mola_state_estimators.html
@@ -9,8 +9,23 @@ params:
   #  this threshold must be < 1.0 s for that dataset)
   max_time_to_use_velocity_model: ${MOLA_MAX_TIME_TO_USE_VELOCITY_MODEL|0.75} # [s]
 
+  # Time to keep past observations in the filter
+  sliding_window_length: 0.50 # [s]
+
+  # If the time between two keyframes is larger than this, a warning will be
+  # emitted; but the algorithm will keep trying its best.
+  time_between_frames_to_warning: 3.0 # [s]
+
   sigma_random_walk_acceleration_linear: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC|1.0} # [m/s²]
   sigma_random_walk_acceleration_angular: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_ANGACC|10.0} # [rad/s²]
 
+  sigma_integrator_position: 1.0 # [m]
+  sigma_integrator_orientation:  1.0 # [rad]
+
   # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s):
   initial_twist: ['${MOLA_INITIAL_VX|0.0}', 0.0, 0.0,  0.0, 0.0, 0.0]
+  initial_twist_sigma_lin: 20.0 # [m/s]
+  initial_twist_sigma_ang: 3.0  # [rad/s]
+
+  robust_param: 0  # 0=no robust disabled
+  max_rmse: 2 # max inconsistencies to discard solution

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 #message(STATUS "mola_metric_maps   : ${mola_metric_maps_DIR}")
 
 set(DEFAULT_PIPELINE_YAML ${mola_lidar_odometry_SOURCE_DIR}/pipelines/lidar3d-default.yaml)
+set(DEFAULT_STATE_ESTIMATOR_YAML ${mola_lidar_odometry_SOURCE_DIR}/state-estimator-params/state-estimation-simple.yaml)
 
 # Test: from rawlog file, using KITTI fragment
 # ---------------------------------------------------
@@ -32,6 +33,7 @@ set(KITTI00_GT_TUM ${mola_lidar_odometry_SOURCE_DIR}/test/kitti_00_fragment_gt.t
 
 ament_add_gtest(test_lidar_odometry_kitti test_lidar_odometry_rawlog.cpp
   ENV LO_PIPELINE_YAML=${DEFAULT_PIPELINE_YAML}
+  ENV LO_STATE_ESTIM_YAML=${DEFAULT_STATE_ESTIMATOR_YAML}
   ENV LO_TEST_RAWLOG=${KITTI00_DATASET_FILE}
   ENV LO_TEST_GT_TUM=${KITTI00_GT_TUM}
   ENV MOLA_PROFILER=false
@@ -62,6 +64,7 @@ endif()
 if(EXISTS "${RSLIDAR_DATASET_FILE}")
   ament_add_gtest(test_lidar_odometry_rslidar test_lidar_odometry_rosbag2.cpp
     ENV LO_PIPELINE_YAML=${DEFAULT_PIPELINE_YAML}
+    ENV LO_STATE_ESTIM_YAML=${DEFAULT_STATE_ESTIMATOR_YAML}
     ENV LO_TEST_ROSBAG2=${RSLIDAR_DATASET_FILE}
     ENV LO_TEST_LIDAR_TOPIC=${RSLIDAR_TOPIC}
     ENV LO_TEST_GT_TUM=${RSLIDAR_GT_TUM}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,8 +36,15 @@ ament_add_gtest(test_lidar_odometry_kitti test_lidar_odometry_rawlog.cpp
   ENV LO_TEST_GT_TUM=${KITTI00_GT_TUM}
   ENV MOLA_PROFILER=false
 )
-ament_target_dependencies(test_lidar_odometry_kitti  mrpt-obs)
-target_link_libraries(test_lidar_odometry_kitti mola::mola_lidar_odometry)
+ament_target_dependencies(test_lidar_odometry_kitti
+  mrpt-obs
+  mola_state_estimation_simple
+)
+target_link_libraries(test_lidar_odometry_kitti
+    mola::mola_lidar_odometry
+    mola::mola_state_estimation_simple
+)
+
 
 
 # Test: from rosbag2 file, RSLIDAR data with XYZIRT channels
@@ -62,10 +69,14 @@ if(EXISTS "${RSLIDAR_DATASET_FILE}")
     MOLA_USE_FIXED_LIDAR_POSE=true  # so we don't need /tf topic in test dataset
     MOLA_IGNORE_NO_POINT_STAMPS=${IGNORE_POINT_STAMPS} # make it fail if no timestamps are found
   )
-  ament_target_dependencies(test_lidar_odometry_rslidar  mrpt-obs)
+  ament_target_dependencies(test_lidar_odometry_rslidar 
+    mrpt-obs
+    mola_state_estimation_simple
+  )
   target_link_libraries(test_lidar_odometry_rslidar
     mola::mola_lidar_odometry
     mola::mola_input_rosbag2
+    mola::mola_state_estimation_simple
   )
 else()
   message(STATUS "Skipping test for missing dataset: ${RSLIDAR_DATASET_FILE}")

--- a/test/test_lidar_odometry_rawlog.cpp
+++ b/test/test_lidar_odometry_rawlog.cpp
@@ -53,7 +53,7 @@ int main_odometry(
   const auto cfg = mola::load_yaml_file(yamlConfigFile);
 
   // quiet for the unit tests:
-  liodom->setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  liodom->setMinLoggingLevel(mrpt::system::LVL_DEBUG);
 
   liodom->initialize(cfg);
 
@@ -63,9 +63,9 @@ int main_odometry(
   liodom->params_.lidar_sensor_labels.assign(1, std::regex("lidar"));
 
   // Initialize estimator (default settings):
-  stateEstimator->setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  stateEstimator->setMinLoggingLevel(mrpt::system::LVL_DEBUG);
   const auto cfgEstimator = mola::load_yaml_file(stateEstimConfigFile);
-  stateEstimator->initialize(cfgEstimator);
+  stateEstimator->initialize(cfgEstimator["params"]);
 
   // dataset input:
   mrpt::obs::CRawlog dataset;

--- a/test/test_lidar_odometry_rawlog.cpp
+++ b/test/test_lidar_odometry_rawlog.cpp
@@ -22,12 +22,15 @@
 // -----------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
+#include <mola_kernel/MinimalModuleContainer.h>
 #include <mola_kernel/interfaces/OfflineDatasetSource.h>
 #include <mola_kernel/pretty_print_exception.h>
 #include <mola_lidar_odometry/LidarOdometry.h>
+#include <mola_navstate_fuse/NavStateFuse.h>
 #include <mola_yaml/yaml_helpers.h>
 #include <mrpt/core/exceptions.h>
 #include <mrpt/core/get_env.h>
+#include <mrpt/obs/CObservationOdometry.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CRawlog.h>
 #include <mrpt/poses/Lie/SE.h>
@@ -36,24 +39,33 @@
 namespace
 {
 
-static int main_odometry(
-  const std::string & yamlConfigFile, const std::string & rawlogFile,
-  const std::string & gtTrajectory)
+int main_odometry(
+  const std::string & yamlConfigFile, const std::string & stateEstimConfigFile,
+  const std::string & rawlogFile, const std::string & gtTrajectory)
 {
-  mola::LidarOdometry liodom;
+  auto liodom = mola::LidarOdometry::Create();
+  auto stateEstimator = mola::NavStateFuse::Create();
+
+  // Put both modules together so LO can find the state estimator:
+  mola::MinimalModuleContainer moduleContainer = {liodom, stateEstimator};
 
   // Initialize LiDAR Odometry:
   const auto cfg = mola::load_yaml_file(yamlConfigFile);
 
   // quiet for the unit tests:
-  liodom.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  liodom->setMinLoggingLevel(mrpt::system::LVL_ERROR);
 
-  liodom.initialize(cfg);
+  liodom->initialize(cfg);
 
-  liodom.params_.simplemap.generate = false;
-  liodom.params_.estimated_trajectory.output_file.clear();
+  liodom->params_.simplemap.generate = false;
+  liodom->params_.estimated_trajectory.output_file.clear();
 
-  liodom.params_.lidar_sensor_labels.assign(1, std::regex("lidar"));
+  liodom->params_.lidar_sensor_labels.assign(1, std::regex("lidar"));
+
+  // Initialize estimator (default settings):
+  stateEstimator->setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  const auto cfgEstimator = mola::load_yaml_file(stateEstimConfigFile);
+  stateEstimator->initialize(cfgEstimator);
 
   // dataset input:
   mrpt::obs::CRawlog dataset;
@@ -75,14 +87,14 @@ static int main_odometry(
     if (!obs) continue;
 
     // Send it to the odometry pipeline:
-    liodom.onNewObservation(obs);
+    liodom->onNewObservation(obs);
 
-    while (liodom.isBusy()) {
+    while (liodom->isBusy()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
   }
 
-  const mrpt::poses::CPose3DInterpolator trajectory = liodom.estimatedTrajectory();
+  const mrpt::poses::CPose3DInterpolator trajectory = liodom->estimatedTrajectory();
 
   mrpt::poses::CPose3DInterpolator gt;
   const bool gtLoadOk = gt.loadFromTextFile_TUM(gtTrajectory);
@@ -113,10 +125,11 @@ static int main_odometry(
 TEST(RunDataset, FromRawlog)
 {
   const std::string yamlConfigFile = mrpt::get_env<std::string>("LO_PIPELINE_YAML");
+  const std::string yamlEstimatorFile = mrpt::get_env<std::string>("LO_STATE_ESTIM_YAML");
   const std::string rawlogFile = mrpt::get_env<std::string>("LO_TEST_RAWLOG");
   const std::string gtTrajectory = mrpt::get_env<std::string>("LO_TEST_GT_TUM");
 
-  main_odometry(yamlConfigFile, rawlogFile, gtTrajectory);
+  main_odometry(yamlConfigFile, yamlEstimatorFile, rawlogFile, gtTrajectory);
 }
 
 // The main function running all the tests

--- a/test/test_lidar_odometry_rawlog.cpp
+++ b/test/test_lidar_odometry_rawlog.cpp
@@ -26,7 +26,7 @@
 #include <mola_kernel/interfaces/OfflineDatasetSource.h>
 #include <mola_kernel/pretty_print_exception.h>
 #include <mola_lidar_odometry/LidarOdometry.h>
-#include <mola_navstate_fuse/NavStateFuse.h>
+#include <mola_state_estimation_simple/StateEstimationSimple.h>
 #include <mola_yaml/yaml_helpers.h>
 #include <mrpt/core/exceptions.h>
 #include <mrpt/core/get_env.h>
@@ -44,10 +44,10 @@ int main_odometry(
   const std::string & rawlogFile, const std::string & gtTrajectory)
 {
   auto liodom = mola::LidarOdometry::Create();
-  auto stateEstimator = mola::NavStateFuse::Create();
+  auto stateEstimator = mola::state_estimation_simple::StateEstimationSimple::Create();
 
   // Put both modules together so LO can find the state estimator:
-  mola::MinimalModuleContainer moduleContainer = {liodom, stateEstimator};
+  mola::MinimalModuleContainer moduleContainer = {{liodom, stateEstimator}};
 
   // Initialize LiDAR Odometry:
   const auto cfg = mola::load_yaml_file(yamlConfigFile);

--- a/test/test_lidar_odometry_rosbag2.cpp
+++ b/test/test_lidar_odometry_rosbag2.cpp
@@ -23,12 +23,15 @@
 
 #include <gtest/gtest.h>
 #include <mola_input_rosbag2/Rosbag2Dataset.h>
+#include <mola_kernel/MinimalModuleContainer.h>
 #include <mola_kernel/interfaces/OfflineDatasetSource.h>
 #include <mola_kernel/pretty_print_exception.h>
 #include <mola_lidar_odometry/LidarOdometry.h>
+#include <mola_navstate_fuse/NavStateFuse.h>
 #include <mola_yaml/yaml_helpers.h>
 #include <mrpt/core/exceptions.h>
 #include <mrpt/core/get_env.h>
+#include <mrpt/obs/CObservationOdometry.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CRawlog.h>
 #include <mrpt/poses/Lie/SE.h>
@@ -67,24 +70,33 @@ std::shared_ptr<mola::OfflineDatasetSource> dataset_from_rosbag2(
   return o;
 }
 
-static int main_odometry(
-  const std::string & yamlConfigFile, const std::string & rosbag2File,
-  const std::string & lidarTopic, const std::string & gtTrajectory)
+int main_odometry(
+  const std::string & yamlConfigFile, const std::string & stateEstimConfigFile,
+  const std::string & rosbag2File, const std::string & lidarTopic, const std::string & gtTrajectory)
 {
-  mola::LidarOdometry liodom;
+  auto liodom = mola::LidarOdometry::Create();
+  auto stateEstimator = mola::NavStateFuse::Create();
+
+  // Put both modules together so LO can find the state estimator:
+  mola::MinimalModuleContainer moduleContainer = {liodom, stateEstimator};
 
   // Initialize LiDAR Odometry:
   const auto cfg = mola::load_yaml_file(yamlConfigFile);
 
   // quiet for the unit tests:
-  liodom.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  liodom->setMinLoggingLevel(mrpt::system::LVL_ERROR);
 
-  liodom.initialize(cfg);
+  liodom->initialize(cfg);
 
-  liodom.params_.simplemap.generate = false;
-  liodom.params_.estimated_trajectory.output_file.clear();
+  liodom->params_.simplemap.generate = false;
+  liodom->params_.estimated_trajectory.output_file.clear();
 
-  liodom.params_.lidar_sensor_labels.assign(1, std::regex(lidarTopic));
+  liodom->params_.lidar_sensor_labels.assign(1, std::regex(lidarTopic));
+
+  // Initialize estimator (default settings):
+  stateEstimator->setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  const auto cfgEstimator = mola::load_yaml_file(stateEstimConfigFile);
+  stateEstimator->initialize(cfgEstimator);
 
   // dataset input:
   std::shared_ptr<mola::OfflineDatasetSource> dataset;
@@ -111,14 +123,14 @@ static int main_odometry(
     if (!obs) continue;
 
     // Send it to the odometry pipeline:
-    liodom.onNewObservation(obs);
+    liodom->onNewObservation(obs);
 
-    while (liodom.isBusy()) {
+    while (liodom->isBusy()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
   }
 
-  const mrpt::poses::CPose3DInterpolator trajectory = liodom.estimatedTrajectory();
+  const mrpt::poses::CPose3DInterpolator trajectory = liodom->estimatedTrajectory();
 
   trajectory.saveToTextFile_TUM("/tmp/gt.tum");
 
@@ -150,11 +162,12 @@ static int main_odometry(
 TEST(RunDataset, FromRosbag2)
 {
   const std::string yamlConfigFile = mrpt::get_env<std::string>("LO_PIPELINE_YAML");
+  const std::string yamlEstimatorFile = mrpt::get_env<std::string>("LO_STATE_ESTIM_YAML");
   const std::string rosbag2File = mrpt::get_env<std::string>("LO_TEST_ROSBAG2");
   const std::string lidarTopic = mrpt::get_env<std::string>("LO_TEST_LIDAR_TOPIC");
   const std::string gtTrajectory = mrpt::get_env<std::string>("LO_TEST_GT_TUM");
 
-  main_odometry(yamlConfigFile, rosbag2File, lidarTopic, gtTrajectory);
+  main_odometry(yamlConfigFile, yamlEstimatorFile, rosbag2File, lidarTopic, gtTrajectory);
 }
 
 // The main function running all the tests

--- a/test/test_lidar_odometry_rosbag2.cpp
+++ b/test/test_lidar_odometry_rosbag2.cpp
@@ -27,7 +27,7 @@
 #include <mola_kernel/interfaces/OfflineDatasetSource.h>
 #include <mola_kernel/pretty_print_exception.h>
 #include <mola_lidar_odometry/LidarOdometry.h>
-#include <mola_navstate_fuse/NavStateFuse.h>
+#include <mola_state_estimation_simple/StateEstimationSimple.h>
 #include <mola_yaml/yaml_helpers.h>
 #include <mrpt/core/exceptions.h>
 #include <mrpt/core/get_env.h>
@@ -75,10 +75,10 @@ int main_odometry(
   const std::string & rosbag2File, const std::string & lidarTopic, const std::string & gtTrajectory)
 {
   auto liodom = mola::LidarOdometry::Create();
-  auto stateEstimator = mola::NavStateFuse::Create();
+  auto stateEstimator = mola::state_estimation_simple::StateEstimationSimple::Create();
 
   // Put both modules together so LO can find the state estimator:
-  mola::MinimalModuleContainer moduleContainer = {liodom, stateEstimator};
+  mola::MinimalModuleContainer moduleContainer = {{liodom, stateEstimator}};
 
   // Initialize LiDAR Odometry:
   const auto cfg = mola::load_yaml_file(yamlConfigFile);

--- a/test/test_lidar_odometry_rosbag2.cpp
+++ b/test/test_lidar_odometry_rosbag2.cpp
@@ -96,7 +96,7 @@ int main_odometry(
   // Initialize estimator (default settings):
   stateEstimator->setMinLoggingLevel(mrpt::system::LVL_ERROR);
   const auto cfgEstimator = mola::load_yaml_file(stateEstimConfigFile);
-  stateEstimator->initialize(cfgEstimator);
+  stateEstimator->initialize(cfgEstimator["params"]);
 
   // dataset input:
   std::shared_ptr<mola::OfflineDatasetSource> dataset;


### PR DESCRIPTION
State estimation is now no longer a built-in module, but a generic module with virtual interface, etc.
Implementations live here: https://github.com/MOLAorg/mola_state_estimation

