### PR TITLE
Add optional prefilter pipeline for all ICP methods

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -640,6 +640,7 @@ private:
 
     mp2p_icp_filters::GeneratorSet obs_generators;
     mp2p_icp_filters::FilterPipeline pc_filterAdjustTimes;
+    mp2p_icp_filters::FilterPipeline pc_prefilter;
     mp2p_icp_filters::FilterPipeline pc_filter1, pc_filter2, pc_filter3;
     mp2p_icp_filters::GeneratorSet local_map_generators;
     mp2p_icp::metric_map_t::Ptr local_map = mp2p_icp::metric_map_t::Create();

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -27,6 +27,7 @@
 
 // MP2P_ICP:
 #include <mp2p_icp/icp_pipeline_from_yaml.h>
+#include <mrpt/system/filesystem.h>
 
 namespace mola
 {
@@ -248,6 +249,22 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
       MRPT_LOG_WARN(
         "No YAML entry 'observations_filter_adjust_timestamps', this "
         "filter stage will have no effect.");
+    }
+
+    if (c.has("observations_prefilter_file")) {
+      if (const auto prefilterFile = c["observations_prefilter_file"].as<std::string>();
+          !prefilterFile.empty()) {
+        ASSERT_FILE_EXISTS_(prefilterFile);
+
+        const auto prefilterYaml = mrpt::containers::yaml::FromFile(prefilterFile);
+
+        // Create, and copy my own verbosity level:
+        state_.pc_prefilter =
+          mp2p_icp_filters::filter_pipeline_from_yaml(prefilterYaml, this->getMinLoggingLevel());
+
+        // Attach to the parameter source for dynamic parameters:
+        mp2p_icp::AttachToParameterSource(state_.pc_prefilter, state_.parameter_source);
+      }
     }
 
     if (c.has("observations_filter_1st_pass")) {

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -143,18 +143,22 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)
     observationRawForViz.layers["raw"] = observation->layers.at("raw");
   }
 
-  // Filter/segment the point cloud (optional, but normally will be
-  // present):
-  ProfilerEntry tle1(profiler_, "onLidar.1.filter_1st");
+  // Filter/segment the point cloud (optional, but normally will be present):
 
-  mp2p_icp_filters::apply_filter_pipeline(state_.pc_filter1, *observation, profiler_);
-  tle1.stop();
+  if (!state_.pc_prefilter.empty()) {  // optional pre-filter stage
+    ProfilerEntry tle1(profiler_, "onLidar.1.filter_pre");
+    mp2p_icp_filters::apply_filter_pipeline(state_.pc_prefilter, *observation, profiler_);
+  }
 
-  ProfilerEntry tle1b(profiler_, "onLidar.1.filter_2nd");
+  {
+    ProfilerEntry tle1(profiler_, "onLidar.1.filter_1st");
+    mp2p_icp_filters::apply_filter_pipeline(state_.pc_filter1, *observation, profiler_);
+  }
 
-  mp2p_icp_filters::apply_filter_pipeline(state_.pc_filter2, *observation, profiler_);
-
-  tle1b.stop();
+  {
+    ProfilerEntry tle1(profiler_, "onLidar.1.filter_2nd");
+    mp2p_icp_filters::apply_filter_pipeline(state_.pc_filter2, *observation, profiler_);
+  }
 
   // Update sensor max range from the obs map layers:
   doUpdateEstimatedMaxSensorRange(*observation);

--- a/pipelines/lidar2d.yaml
+++ b/pipelines/lidar2d.yaml
@@ -9,7 +9,7 @@
 # =====================================================================================
 
 params:
-  pipeline_name: 'point-to-gridmap 2D ICP' # For display/debug only
+  pipeline_name: "point-to-gridmap 2D ICP" # For display/debug only
 
   # These sensor labels will be handled as LIDAR observations:
   # Can be overridden with cli flag --lidar-sensor-label
@@ -205,6 +205,9 @@ observations_generator:
       throw_on_unhandled_observation_class: true
       process_class_names_regex: ".*"
       process_sensor_labels_regex: ".*"
+
+# Path to an (optional) user-customizable pipeline definition file. Default: empty = none.
+observations_prefilter_file: ${MOLA_LO_OBS_PREFILTER_PIPELINE_FILE|""}
 
 observations_filter_1st_pass:
   # Filters:

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -318,6 +318,9 @@ observations_filter_adjust_timestamps:
       time_offset: "SENSOR_TIME_OFFSET"
       method: "${MOLA_SCAN_POINT_STAMPS_ADJUST_METHOD|TimestampAdjustMethod::MiddleIsZero}"
 
+# Path to an (optional) user-customizable pipeline definition file. Default: empty = none.
+observations_prefilter_file: ${MOLA_LO_OBS_PREFILTER_PIPELINE_FILE|""}
+
 observations_filter_1st_pass:
   # Filters:
   #

--- a/pipelines/lidar3d-icp.yaml
+++ b/pipelines/lidar3d-icp.yaml
@@ -295,6 +295,9 @@ observations_filter_adjust_timestamps:
       time_offset: "SENSOR_TIME_OFFSET"
       method: "${MOLA_SCAN_POINT_STAMPS_ADJUST_METHOD|TimestampAdjustMethod::MiddleIsZero}"
 
+# Path to an (optional) user-customizable pipeline definition file. Default: empty = none.
+observations_prefilter_file: ${MOLA_LO_OBS_PREFILTER_PIPELINE_FILE|""}
+
 observations_filter_1st_pass:
   # Filters:
   #

--- a/pipelines/lidar3d-ndt.yaml
+++ b/pipelines/lidar3d-ndt.yaml
@@ -277,6 +277,9 @@ observations_filter_adjust_timestamps:
       method: "TimestampAdjustMethod::MiddleIsZero"
       #method: 'TimestampAdjustMethod::EarliestIsZero'
 
+# Path to an (optional) user-customizable pipeline definition file. Default: empty = none.
+observations_prefilter_file: ${MOLA_LO_OBS_PREFILTER_PIPELINE_FILE|""}
+
 observations_filter_1st_pass:
   # Filters:
   #


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional custom prefilter pipelines in LiDAR odometry processing. Users can now configure a separate prefilter pipeline file via the `observations_prefilter_file` parameter to apply preprocessing before standard observation filtering stages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->