### PR TITLE
Fix: provide a mechanism to read 2D lidar from ROS

### DIFF
--- a/docs/mola_lo_ros_node.rst
+++ b/docs/mola_lo_ros_node.rst
@@ -166,6 +166,10 @@ runs **MOLA-LO** live on point clouds received from a ROS 2 topic, **demonstrati
           'lidar_topic_name':
              Topic name to listen for PointCloud2 input from the LiDAR (for example '/ouster/points')
 
+          'lidar_topic_type':
+             The type of LiDAR topic to subscribe to. Options: 'PointCloud2' (default) or 'LaserScan'
+             (default: 'PointCloud2')
+
           'mola_deskew_method':
              Which motion-compensation method to use to align LiDAR scans more precisely
              (default: 'MotionCompensationMethod::Linear')

--- a/docs/mola_lo_ros_node.rst
+++ b/docs/mola_lo_ros_node.rst
@@ -44,7 +44,6 @@ runs **MOLA-LO** live on point clouds received from a ROS 2 topic, **demonstrati
            mola_tf_base_link:=os_sensor
 
    .. tab-item:: LIO usage (No /tf)
-      :selected:
 
       This is how to use LiDAR-Inertial Odometry (LIO) by using LiDAR clouds plus an IMU,
       when no /tf is available for the sensor poses so you must manually specify them:
@@ -64,7 +63,6 @@ runs **MOLA-LO** live on point clouds received from a ROS 2 topic, **demonstrati
 
 
    .. tab-item:: Robot with NS
-      :selected:
 
       If your robot uses a ROS 2 namespace ``ROBOT_NS`` for all its sensor and tf topics, use:
 
@@ -76,8 +74,21 @@ runs **MOLA-LO** live on point clouds received from a ROS 2 topic, **demonstrati
             use_namespace:=True \
             namespace:=ROBOT_NS
 
-|
+   .. tab-item:: 2D LiDAR
 
+      To use with a 2D LiDAR, define the argument `lidar_topic_type:=LaserScan`, e.g.:
+
+      .. code-block:: bash
+
+         # Minimal use case:
+         ros2 launch mola_lidar_odometry ros2-lidar-odometry.launch.py \
+            lidar_topic_name:=/scan \
+            lidar_topic_type:=LaserScan \
+            mola_lo_pipeline:=../pipelines/lidar2d.yaml \
+            ignore_lidar_pose_from_tf:=False \
+            publish_localization_following_rep105:=True
+
+|
 
 .. dropdown:: How to invoke for a rosbag (``.mcap``, ``.db3``)
     :icon: list-unordered

--- a/mola-cli-launchs/lidar_odometry_ros2.yaml
+++ b/mola-cli-launchs/lidar_odometry_ros2.yaml
@@ -140,7 +140,7 @@ modules:
       # ROS2 topics to be forwarded to the MOLA system:
       subscribe:
         - topic: ${MOLA_LIDAR_TOPIC|/ouster/points}
-          msg_type: PointCloud2
+          msg_type: ${MOLA_LIDAR_TOPIC_TYPE|PointCloud2} # Can be PointCloud2 or LaserScan
           output_sensor_label: ${MOLA_LIDAR_NAME|lidar}
           # If present, this will override whatever /tf tells about the sensor pose:
           fixed_sensor_pose: "${LIDAR_POSE_X|0} ${LIDAR_POSE_Y|0} ${LIDAR_POSE_Z|0} ${LIDAR_POSE_YAW|0} ${LIDAR_POSE_PITCH|0} ${LIDAR_POSE_ROLL|0}" # 'x y z yaw_deg pitch_deg roll_deg''

--- a/ros2-launchs/ros2-lidar-odometry.launch.py
+++ b/ros2-launchs/ros2-lidar-odometry.launch.py
@@ -26,6 +26,11 @@ def generate_launch_description():
     lidar_topic_env_var = SetEnvironmentVariable(
         name='MOLA_LIDAR_TOPIC', value=LaunchConfiguration('lidar_topic_name'))
     # ~~~~~~~~~~~~
+    lidar_topic_type_arg = DeclareLaunchArgument(
+        "lidar_topic_type", default_value="PointCloud2", description="The type of LiDAR topic to subscribe to. Options: 'PointCloud2' (default) or 'LaserScan'")
+    lidar_topic_type_env_var = SetEnvironmentVariable(
+        name='MOLA_LIDAR_TOPIC_TYPE', value=LaunchConfiguration('lidar_topic_type'))
+    # ~~~~~~~~~~~~
     ignore_lidar_pose_from_tf_arg = DeclareLaunchArgument(
         "ignore_lidar_pose_from_tf", default_value="false", description="If true, the LiDAR pose will be assumed to be at the origin (base_link). Set to false (default) if you want to read the actual sensor pose from /tf")
     ignore_lidar_pose_from_tf_env_var = SetEnvironmentVariable(
@@ -257,6 +262,8 @@ def generate_launch_description():
         lidar_scan_validity_minimum_point_env_var,
         lidar_topic_env_var,
         lidar_topic_name_arg,
+        lidar_topic_type_arg,
+        lidar_topic_type_env_var,
         mola_deskew_method_arg,
         mola_deskew_method_env_var,
         mola_footprint_to_base_link_tf_arg,

--- a/ros2-launchs/ros2-lidar-odometry.launch.py
+++ b/ros2-launchs/ros2-lidar-odometry.launch.py
@@ -22,7 +22,7 @@ def generate_launch_description():
     # -------------------
     # Mandatory
     lidar_topic_name_arg = DeclareLaunchArgument(
-        "lidar_topic_name", description="Topic name to listen for PointCloud2 input from the LiDAR (for example '/ouster/points')")
+        "lidar_topic_name", description="Topic name to listen for LiDAR input, for example '/ouster/points' for PointCloud2 or '/scan' for LaserScan; see lidar_topic_type")
     lidar_topic_env_var = SetEnvironmentVariable(
         name='MOLA_LIDAR_TOPIC', value=LaunchConfiguration('lidar_topic_name'))
     # ~~~~~~~~~~~~


### PR DESCRIPTION
Addresses #42 .


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for 2D LiDAR (LaserScan) alongside existing 3D (PointCloud2).
  * New configurable launch parameter to select LiDAR topic type, defaulting to PointCloud2.

* **Changes**
  * LiDAR message type is now configurable while remaining backward compatible.

* **Documentation**
  * Added a 2D LiDAR tab with examples and parameters; adjusted default tab focus behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->