### PR TITLE
Ensure no detached threads

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -731,6 +731,10 @@ private:
   mrpt::WorkerThreadsPool worker_others_{
     1 /*num threads*/, mrpt::WorkerThreadsPool::POLICY_FIFO, "worker_imu"};
 
+  /** The worker thread pool with 1 thread for processing saving lazy-load observations to disk */
+  mutable mrpt::WorkerThreadsPool worker_disk_io_{
+    1 /*num threads*/, mrpt::WorkerThreadsPool::POLICY_FIFO, "worker_disk"};
+
   MethodState state_;
   const MethodState & state() const { return state_; }
   MethodState stateCopy() const { return state_; }

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -103,6 +103,15 @@ LidarOdometry::~LidarOdometry()
     if (!params_.local_map_updates.save_final_local_map.empty()) {
       saveLocalMapToFile();
     }
+
+    // This must come after save map calls above:
+    while (worker_disk_io_.pendingTasks() > 0) {
+      MRPT_LOG_THROTTLE_WARN(
+        2.0, "Destructor: waiting for pending tasks on the lazy-load write thread...");
+      std::this_thread::sleep_for(100ms);
+    }
+    worker_disk_io_.clear();
+
   } catch (const std::exception & e) {
     std::cerr << "[~LidarOdometry] Exception: " << e.what();
   }
@@ -345,15 +354,16 @@ void LidarOdometry::handleUnloadSinglePastObservation(mrpt::obs::CObservation::P
     filename, CObservationPointCloud::ExternalStorageFormat::MRPT_Serialization);
 
   // Since unload() does the actual saving to disk and it might take some time, let's run it in its own detached thread:
-  std::thread([oPts]() {
+  const auto fut = this->worker_disk_io_.enqueue([oPts]() {
     try {
       oPts->unload();
     } catch (const std::exception & e) {
-      std::cerr
-        << "[LidarOdometry] handleUnloadSinglePastObservation(): Error saving observation to disk: "
-        << e.what() << "\n";
+      std::cerr << "[LidarOdometry] handleUnloadSinglePastObservation(): Error saving "
+                   "observation to disk: "
+                << e.what() << "\n";
     }
-  }).detach();
+  });
+  (void)fut;
 }
 
 void LidarOdometry::enqueue_request(const std::function<void()> & userRequest)

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -278,9 +278,9 @@ void LidarOdometry::saveLocalMapToFile() const
   const bool saved_ok = state_.local_map->save_to_file(fil);
   if (!saved_ok) {
     MRPT_LOG_ERROR_STREAM("Error saving map to: " << fil);
+  } else {
+    MRPT_LOG_INFO("Final local metric map saved.");
   }
-
-  MRPT_LOG_INFO("Final local metric map saved.");
 }
 
 void LidarOdometry::unloadPastSimplemapObservations(const size_t maxSizeUnloadQueue) const
@@ -353,7 +353,7 @@ void LidarOdometry::handleUnloadSinglePastObservation(mrpt::obs::CObservation::P
   oPts->setAsExternalStorage(
     filename, CObservationPointCloud::ExternalStorageFormat::MRPT_Serialization);
 
-  // Since unload() does the actual saving to disk and it might take some time, let's run it in its own detached thread:
+  // Since unload() does the actual saving to disk and it might take some time, let's run it in its own thread.
   const auto fut = this->worker_disk_io_.enqueue([oPts]() {
     try {
       oPts->unload();

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -266,7 +266,10 @@ void LidarOdometry::saveLocalMapToFile() const
   MRPT_LOG_INFO_STREAM("Saving final metric map to file '" << fil << "'...");
   std::cout.flush();
 
-  state_.local_map->save_to_file(fil);
+  const bool saved_ok = state_.local_map->save_to_file(fil);
+  if (!saved_ok) {
+    MRPT_LOG_ERROR_STREAM("Error saving map to: " << fil);
+  }
 
   MRPT_LOG_INFO("Final local metric map saved.");
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added explicit error logging when saving local maps fails.
  * Improved and consolidated error messaging for unload operations.

* **Improvements**
  * Shutdown now waits for pending disk I/O to finish for more reliable termination.
  * Unload operations moved to managed disk I/O task handling to improve stability and avoid detached-thread behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->