### PR TITLE
New env var to debug bad ICP cases: MOLA_WRITE_DEBUG_ICP_LOG_IF_QUALITY_UNDER

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -230,6 +230,9 @@ public:
          * accepted during regular lidar odometry & mapping */
     double min_icp_goodness = 0.4;
 
+    /** If defined, .icplog files will be saved if ICP quality drops below the given threshold */
+    std::optional<double> write_debug_icp_log_if_quality_under;
+
     bool pipeline_profiler_enabled = false;
     bool icp_profiler_enabled = false;
     bool icp_profiler_full_history = false;

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -128,6 +128,14 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
     params_.multiple_lidars.initialize(cfg["multiple_lidars"], params_);
   }
 
+  // this one is std::optional
+  {
+    const std::string key = "write_debug_icp_log_if_quality_under";
+    if (cfg.has(key) && !cfg[key].isNullNode() && !cfg[key].as<std::string>().empty()) {
+      params_.write_debug_icp_log_if_quality_under.emplace(cfg[key].as<double>());
+    }
+  }
+
   YAML_LOAD_OPT(params_, min_time_between_scans, double);
   YAML_LOAD_REQ(params_, min_icp_goodness, double);
   YAML_LOAD_OPT(params_, max_sensor_range_filter_coefficient, double);

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -398,6 +398,15 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     auto icp_params = in.icp_params;
     size_t remainingIcpIters = icp_params.maxIterations;
 
+#if MP2P_ICP_VERSION >= 0x020501
+    if (params_.write_debug_icp_log_if_quality_under.has_value()) {
+      icp_params.functor_should_generate_debug_file =
+        [this](const mp2p_icp::LogRecord & log) -> bool {
+        return log.icpResult.quality < params_.write_debug_icp_log_if_quality_under.value();
+      };
+    }
+#endif
+
     do {
       icp_params.maxIterations = remainingIcpIters;
 

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -66,6 +66,10 @@ params:
   # Minimum ICP quality to insert it into the map:
   min_icp_goodness: ${MOLA_MINIMUM_ICP_QUALITY|0.50}
 
+  # If defined, ".icplog" files will be saved if ICP quality drops below the given threshold.
+  # Useful to debug mapping issues. If empty, only the env var MP2P_ICP_GENERATE_DEBUG_FILES and the icp.params setting will define when to save logs.
+  write_debug_icp_log_if_quality_under: ${MOLA_WRITE_DEBUG_ICP_LOG_IF_QUALITY_UNDER|""}
+
   # Adaptive threshold, as in the KISS-ICP paper:
   adaptive_threshold:
     enabled: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration to auto-save ICP debug logs when lidar odometry quality falls below a user-defined threshold, enabling targeted diagnostic file generation.
  * Configuration is optional and preserves existing logging behavior unless a threshold is specified.

* **Documentation**
  * Pipeline configuration updated with descriptive comments explaining the new option and its fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->