### PR TITLE
Use IMU readings to estimate gravity up vector as ICP prior constraint

### DIFF
--- a/docs/mola_lo_pipelines.rst
+++ b/docs/mola_lo_pipelines.rst
@@ -307,6 +307,34 @@ Sensor inputs: IMU (optional)
 - ``MOLA_DESKEW_METHOD`` (Default: ``MotionCompensationMethod::Linear``): **IMPORTANT**: If you do not change this from its default,
   the IMU data will not be used for deskewing. To fully achieve the best accuracy, set this variable to ``MotionCompensationMethod::IMU``.
 
+IMU gravity correction (pitch/roll)
+"""""""""""""""""""""""""""""""""""""
+
+When an IMU is available, MOLA-LO can use the accelerometer readings to
+continuously estimate the gravity direction and inject it as a **pitch/roll
+constraint** into the ICP prior. This prevents vertical drift in the LiDAR
+odometry output without requiring a full factor-graph smoother.
+
+The feature averages recent accelerometer samples in a circular buffer,
+rotates the result to the vehicle frame using the IMU ``sensorPose``
+extrinsics, and derives pitch and roll from the gravity direction.
+
+.. note::
+
+   This feature acts on the ICP prior independently of the
+   ``StateEstimationSmoother`` gravity factor. Both can be active simultaneously.
+
+- ``MOLA_IMU_GRAVITY_CORRECTION`` (Default: ``false``): Set to ``true`` to enable
+  accelerometer-based pitch/roll correction of the ICP prior.
+
+- ``MOLA_IMU_GRAVITY_SIGMA_DEG`` (Default: ``2.0`` [deg]): Standard deviation of the
+  gravity-derived pitch/roll prior. Lower values give more trust to the IMU.
+  Typical range: 1–5 deg.
+
+- ``MOLA_IMU_GRAVITY_AVG_SAMPLES`` (Default: ``20``): Number of recent accelerometer
+  samples to average for the gravity estimate. The correction activates as soon as
+  3 samples are available, even if the full window has not filled yet.
+
 
 Sensor inputs: Wheels odometry (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/mola_lo_pipelines.rst
+++ b/docs/mola_lo_pipelines.rst
@@ -335,6 +335,11 @@ extrinsics, and derives pitch and roll from the gravity direction.
   samples to average for the gravity estimate. The correction activates as soon as
   3 samples are available, even if the full window has not filled yet.
 
+- ``MOLA_IMU_GRAVITY_MAX_AGE`` (Default: ``2.0`` [s]): Maximum age in seconds for
+  accelerometer samples used in the gravity average. Samples older than this are
+  discarded, ensuring the estimate reflects current orientation rather than stale
+  data. Set to ``0`` to disable age filtering.
+
 
 Sensor inputs: Wheels odometry (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/mola_lo_pipelines.rst
+++ b/docs/mola_lo_pipelines.rst
@@ -370,7 +370,7 @@ Scan de-skew options
   will be just processed without doing any de-skew on them. If this variable is set to ``false``, an exception will be triggered
   in such event, which can be used as a fail-safe check against missing stamps, important in high velocity scenarios.
 
-- ``MOLA_DESKEW_METHOD`` (Default: ``false``): If enabled, scan de-skew (motion compensation) will be skipped.
+- ``MOLA_DESKEW_METHOD`` (Default: ``MotionCompensationMethod::Linear``): Selects the scan de-skew (motion compensation) method. Set to ``MotionCompensationMethod::IMU`` to use IMU data for deskewing when an IMU stream is available.
 
 General options
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -384,13 +384,13 @@ General options
 - ``MOLA_LOAD_MM`` (Default: none): An optional path to a metric map (``*.mm``) file with a prebuilt metric map. Useful for
   multisession mapping or localization-only mode.
 
-- ``MOLA_MINIMUM_ICP_QUALITY`` (Default: ``0.25``): Minimum quality (from the ``mpcp_icp`` quality evaluators), in the range [0,1], to
+- ``MOLA_MINIMUM_ICP_QUALITY`` (Default: ``0.50``): Minimum quality (from the ``mpcp_icp`` quality evaluators), in the range [0,1], to
   consider an ICP optimization to be valid.
 
-- ``MOLA_SIGMA_MIN_MOTION`` (Default: ``0.10`` [m]): Absolute minimum adaptive "sigma" threshold (refer to the paper).
+- ``MOLA_SIGMA_MIN_MOTION`` (Default: ``0.04`` [m]): Absolute minimum adaptive "sigma" threshold (refer to the paper).
 
 
-- ``MOLA_ADAPT_THRESHOLD_ALPHA`` (Default: ``0.9``): Alpha parameter of the IIR low-pass filter for adaptive threshold 
+- ``MOLA_ADAPT_THRESHOLD_ALPHA`` (Default: ``0.99``): Alpha parameter of the IIR low-pass filter for adaptive threshold 
   proportional controller (refer to the paper).
 
 - ``MOLA_START_ACTIVE`` (default: ``true``): If set to ``false``, the odometry pipeline will ignore incoming observations
@@ -491,4 +491,3 @@ Trace debug files
 
 - ``MOLA_SAVE_DEBUG_TRACES`` (Default: ``false``): Whether to generate and save this debug information to a file.
 - ``MOLA_DEBUG_TRACES_FILE`` (Default: ``mola-lo-traces.csv``): The name of the file to store trace information, if enabled.
-

--- a/docs/mola_lo_pipelines.rst
+++ b/docs/mola_lo_pipelines.rst
@@ -324,8 +324,10 @@ extrinsics, and derives pitch and roll from the gravity direction.
    This feature acts on the ICP prior independently of the
    ``StateEstimationSmoother`` gravity factor. Both can be active simultaneously.
 
-- ``MOLA_IMU_GRAVITY_CORRECTION`` (Default: ``false``): Set to ``true`` to enable
-  accelerometer-based pitch/roll correction of the ICP prior.
+- ``MOLA_IMU_GRAVITY_CORRECTION`` (Default: ``true``): Set to ``false`` to disable
+  accelerometer-based pitch/roll correction of the ICP prior. Safe to leave
+  enabled even without an IMU — when no IMU data is present the correction is
+  silently skipped.
 
 - ``MOLA_IMU_GRAVITY_SIGMA_DEG`` (Default: ``2.0`` [deg]): Standard deviation of the
   gravity-derived pitch/roll prior. Lower values give more trust to the IMU.

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -466,6 +466,10 @@ public:
       /// Number of recent accelerometer samples to average for gravity estimation.
       uint32_t averaging_samples = 20;
 
+      /// Maximum age [seconds] for accelerometer samples used in averaging.
+      /// Samples older than this are discarded. 0 = no age limit.
+      double max_age_seconds = 2.0;
+
       void initialize(const Yaml & c);
     };
 
@@ -637,14 +641,23 @@ private:
     /// a smoothed pitch/roll estimate from the gravity direction.
     struct GravityEstimator
     {
-      mrpt::containers::circular_buffer<std::array<double, 3>> acc_buffer{200};
+      struct TimestampedAcc
+      {
+        double timestamp = 0;
+        std::array<double, 3> acc = {0, 0, 0};
+      };
+
+      mrpt::containers::circular_buffer<TimestampedAcc> acc_buffer{200};
       mrpt::poses::CPose3D imu_sensor_pose;  ///< last known IMU extrinsics
+      double imu_sensor_pose_timestamp = 0;  ///< timestamp of last sensor pose update
 
       void add(const mrpt::obs::CObservationIMU & imu, uint32_t max_samples);
 
       /// Returns estimated (pitch, roll) in radians from averaged
       /// accelerometer data in the vehicle frame, or nullopt if not enough data.
-      std::optional<std::pair<double, double>> estimatedPitchRoll(uint32_t required_samples) const;
+      /// max_age_seconds <= 0 means no age filtering.
+      std::optional<std::pair<double, double>> estimatedPitchRoll(
+        uint32_t required_samples, double max_age_seconds) const;
     };
 
     GravityEstimator gravity_estimator;

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -457,7 +457,7 @@ public:
     struct IMUGravityCorrection
     {
       /// Enable accelerometer-based pitch/roll correction in ICP prior.
-      bool enabled = false;
+      bool enabled = true;
 
       /// Sigma [degrees] for the gravity-derived pitch/roll prior.
       /// Lower values = more trust in IMU. Typical: 1–5 deg.

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -454,6 +454,23 @@ public:
 
     ObservationValidityChecks observation_validity_checks;
 
+    struct IMUGravityCorrection
+    {
+      /// Enable accelerometer-based pitch/roll correction in ICP prior.
+      bool enabled = false;
+
+      /// Sigma [degrees] for the gravity-derived pitch/roll prior.
+      /// Lower values = more trust in IMU. Typical: 1–5 deg.
+      double sigma_deg = 2.0;
+
+      /// Number of recent accelerometer samples to average for gravity estimation.
+      uint32_t averaging_samples = 20;
+
+      void initialize(const Yaml & c);
+    };
+
+    IMUGravityCorrection imu_gravity_correction;
+
     bool start_active = true;
 
     uint32_t max_lidar_queue_before_drop = 15;
@@ -615,6 +632,22 @@ private:
 
     /// Used for pitch & roll initialization
     std::optional<mola::imu::ImuInitialCalibrator> imu_initializer;
+
+    /// Accumulates recent accelerometer readings and provides
+    /// a smoothed pitch/roll estimate from the gravity direction.
+    struct GravityEstimator
+    {
+      mrpt::containers::circular_buffer<std::array<double, 3>> acc_buffer{200};
+      mrpt::poses::CPose3D imu_sensor_pose;  ///< last known IMU extrinsics
+
+      void add(const mrpt::obs::CObservationIMU & imu, uint32_t max_samples);
+
+      /// Returns estimated (pitch, roll) in radians from averaged
+      /// accelerometer data in the vehicle frame, or nullopt if not enough data.
+      std::optional<std::pair<double, double>> estimatedPitchRoll(uint32_t required_samples) const;
+    };
+
+    GravityEstimator gravity_estimator;
 
     mrpt::poses::CPose3DPDFGaussian last_lidar_pose;  //!< in local map
 

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -183,6 +183,10 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
     params_.observation_validity_checks.initialize(cfg["observation_validity_checks"]);
   }
 
+  if (cfg.has("imu_gravity_correction")) {
+    params_.imu_gravity_correction.initialize(cfg["imu_gravity_correction"]);
+  }
+
   if (c.has("initial_localization")) {
     params_.initial_localization.initialize(c["initial_localization"]);
   }

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -197,6 +197,13 @@ void LidarOdometry::Parameters::ObservationValidityChecks::initialize(const Yaml
   YAML_LOAD_OPT(minimum_point_count, uint32_t);
 }
 
+void LidarOdometry::Parameters::IMUGravityCorrection::initialize(const Yaml & cfg)
+{
+  YAML_LOAD_OPT(enabled, bool);
+  YAML_LOAD_OPT(sigma_deg, double);
+  YAML_LOAD_OPT(averaging_samples, uint32_t);
+}
+
 void LidarOdometry::onParameterUpdate(const mrpt::containers::yaml & names_values)
 {
   if (names_values.isNullNode() || names_values.empty()) {

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -202,6 +202,18 @@ void LidarOdometry::Parameters::IMUGravityCorrection::initialize(const Yaml & cf
   YAML_LOAD_OPT(enabled, bool);
   YAML_LOAD_OPT(sigma_deg, double);
   YAML_LOAD_OPT(averaging_samples, uint32_t);
+  YAML_LOAD_OPT(max_age_seconds, double);
+
+  if (enabled) {
+    ASSERTMSG_(
+      averaging_samples >= 1 && averaging_samples <= 200,
+      mrpt::format(
+        "imu_gravity_correction.averaging_samples=%u is out of valid range [1, 200]",
+        static_cast<unsigned>(averaging_samples)));
+
+    ASSERTMSG_(
+      sigma_deg > 0, mrpt::format("imu_gravity_correction.sigma_deg=%.4f must be > 0", sigma_deg));
+  }
 }
 
 void LidarOdometry::onParameterUpdate(const mrpt::containers::yaml & names_values)

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -334,6 +334,41 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       }
     }
 
+    // Apply IMU gravity correction to ICP prior (pitch/roll):
+    if (params_.imu_gravity_correction.enabled) {
+      const auto gravityPR = state_.gravity_estimator.estimatedPitchRoll(
+        std::min(params_.imu_gravity_correction.averaging_samples, 3u));
+
+      if (gravityPR.has_value()) {
+        const auto [imu_pitch, imu_roll] = *gravityPR;
+
+        if (!in.prior.has_value()) {
+          // Create a prior from current initial guess:
+          in.prior.emplace();
+          in.prior->mean = mrpt::poses::CPose3D(in.init_guess_local_wrt_global);
+          in.prior->cov_inv = mrpt::math::CMatrixDouble66::Zero();
+        }
+
+        // Override pitch & roll in the prior mean:
+        double cur_yaw, cur_pitch, cur_roll;
+        in.prior->mean.getYawPitchRoll(cur_yaw, cur_pitch, cur_roll);
+        in.prior->mean.setYawPitchRoll(cur_yaw, imu_pitch, imu_roll);
+
+        // Increase confidence for roll (idx=3) and pitch (idx=4):
+        const double sigma_rad = mrpt::DEG2RAD(params_.imu_gravity_correction.sigma_deg);
+        const double inv_var = 1.0 / (sigma_rad * sigma_rad);
+
+        in.prior->cov_inv(3, 3) = std::max(in.prior->cov_inv(3, 3), inv_var);
+        in.prior->cov_inv(4, 4) = std::max(in.prior->cov_inv(4, 4), inv_var);
+
+        MRPT_LOG_DEBUG_FMT(
+          "IMU gravity correction: pitch=%.2f deg, roll=%.2f deg "
+          "(sigma=%.1f deg, %zu samples)",
+          mrpt::RAD2DEG(imu_pitch), mrpt::RAD2DEG(imu_roll),
+          params_.imu_gravity_correction.sigma_deg, state_.gravity_estimator.acc_buffer.size());
+      }
+    }
+
     // If we don't have a valid twist estimation, use a larger ICP
     // correspondence threshold:
     in.align_kind = hasMotionModel ? AlignKind::RegularOdometry : AlignKind::NoMotionModel;

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -351,16 +351,16 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
         }
 
         // Override pitch & roll in the prior mean:
-        double cur_yaw, cur_pitch, cur_roll;
-        in.prior->mean.getYawPitchRoll(cur_yaw, cur_pitch, cur_roll);
+        const double cur_yaw = in.prior->mean.yaw();
         in.prior->mean.setYawPitchRoll(cur_yaw, imu_pitch, imu_roll);
 
         // Increase confidence for roll (idx=3) and pitch (idx=4):
         const double sigma_rad = mrpt::DEG2RAD(params_.imu_gravity_correction.sigma_deg);
         const double inv_var = 1.0 / (sigma_rad * sigma_rad);
 
-        in.prior->cov_inv(3, 3) = std::max(in.prior->cov_inv(3, 3), inv_var);
-        in.prior->cov_inv(4, 4) = std::max(in.prior->cov_inv(4, 4), inv_var);
+        // MRPT cov order: x y z yaw pitch[4] roll[5]
+        mrpt::keep_max(in.prior->cov_inv(4, 4), inv_var);
+        mrpt::keep_max(in.prior->cov_inv(5, 5), inv_var);
 
         MRPT_LOG_DEBUG_FMT(
           "IMU gravity correction: pitch=%.2f deg, roll=%.2f deg "

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -337,7 +337,8 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     // Apply IMU gravity correction to ICP prior (pitch/roll):
     if (params_.imu_gravity_correction.enabled) {
       const auto gravityPR = state_.gravity_estimator.estimatedPitchRoll(
-        std::min(params_.imu_gravity_correction.averaging_samples, 3u));
+        std::min(params_.imu_gravity_correction.averaging_samples, 3u),
+        params_.imu_gravity_correction.max_age_seconds);
 
       if (gravityPR.has_value()) {
         const auto [imu_pitch, imu_roll] = *gravityPR;

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -241,6 +241,12 @@ void LidarOdometry::onIMUImpl(const CObservation::ConstPtr & o)
     mp2p_icp_filters::apply_generators(state_.obs_generators, *imu, dummy_map);
   }
 
+  // 3) Gravity estimation for ICP verticality correction:
+  if (params_.imu_gravity_correction.enabled) {
+    auto lckState2 = mrpt::lockHelper(state_mtx_);
+    state_.gravity_estimator.add(*imu, params_.imu_gravity_correction.averaging_samples);
+  }
+
   // Finally, schedule to run those LiDAR scans that were waiting for IMU data:
   if (isPipelineUsingIMU()) {
     const auto imuTim = mrpt::Clock::toDouble(imu->timestamp);
@@ -448,6 +454,81 @@ void LidarOdometry::MethodState::append_gnss_stamp(
   const mrpt::Clock::time_point & stamp, const mrpt::system::COutputLogger & logger)
 {
   append_stamp_to_buffer(recent_gnss_stamps, mrpt::Clock::toDouble(stamp), "GNSS", logger);
+}
+
+void LidarOdometry::MethodState::GravityEstimator::add(
+  const mrpt::obs::CObservationIMU & imu, uint32_t max_samples)
+{
+  if (
+    !imu.has(mrpt::obs::IMU_X_ACC) || !imu.has(mrpt::obs::IMU_Y_ACC) ||
+    !imu.has(mrpt::obs::IMU_Z_ACC)) {
+    return;
+  }
+
+  const std::array<double, 3> acc = {
+    imu.get(mrpt::obs::IMU_X_ACC), imu.get(mrpt::obs::IMU_Y_ACC), imu.get(mrpt::obs::IMU_Z_ACC)};
+
+  // Basic sanity: reject readings that are clearly not gravity-like
+  const double norm = std::sqrt(acc[0] * acc[0] + acc[1] * acc[1] + acc[2] * acc[2]);
+  if (std::abs(norm - 9.8) > 3.0 && std::abs(norm - 1.0) > 0.5) {
+    return;  // not a plausible gravity reading
+  }
+
+  // Trim buffer to the desired averaging window:
+  while (acc_buffer.size() >= max_samples) {
+    acc_buffer.pop();
+  }
+  acc_buffer.push(acc);
+
+  // Remember the sensor pose for vehicle-frame transform:
+  imu_sensor_pose = imu.sensorPose;
+}
+
+std::optional<std::pair<double, double>>
+LidarOdometry::MethodState::GravityEstimator::estimatedPitchRoll(uint32_t required_samples) const
+{
+  if (acc_buffer.size() < required_samples) {
+    return std::nullopt;
+  }
+
+  // Average the accelerometer readings (in sensor frame):
+  double sx = 0, sy = 0, sz = 0;
+  const auto n = acc_buffer.size();
+  for (std::size_t i = 0; i < n; i++) {
+    const auto & a = acc_buffer.peek(i);
+    sx += a[0];
+    sy += a[1];
+    sz += a[2];
+  }
+  const double inv_n = 1.0 / static_cast<double>(n);
+  const double ax = sx * inv_n;
+  const double ay = sy * inv_n;
+  const double az = sz * inv_n;
+
+  // Transform averaged gravity from IMU sensor frame to vehicle frame:
+  const auto rotMat = imu_sensor_pose.getRotationMatrix();
+
+  const double gx_veh = rotMat(0, 0) * ax + rotMat(0, 1) * ay + rotMat(0, 2) * az;
+  const double gy_veh = rotMat(1, 0) * ax + rotMat(1, 1) * ay + rotMat(1, 2) * az;
+  const double gz_veh = rotMat(2, 0) * ax + rotMat(2, 1) * ay + rotMat(2, 2) * az;
+
+  // From gravity direction in vehicle frame, estimate pitch and roll.
+  // Convention: if vehicle is level, gravity = [0, 0, +g] (z-up).
+  //   pitch = rotation about Y that tilts gravity into X
+  //   roll  = rotation about X that tilts gravity into Y
+  const double g_norm = std::sqrt(gx_veh * gx_veh + gy_veh * gy_veh + gz_veh * gz_veh);
+  if (g_norm < 1e-3) {
+    return std::nullopt;
+  }
+
+  const double nx = gx_veh / g_norm;
+  const double ny = gy_veh / g_norm;
+  const double nz = gz_veh / g_norm;
+
+  const double pitch = std::asin(-nx);
+  const double roll = std::atan2(ny, nz);
+
+  return std::make_pair(pitch, roll);
 }
 
 }  // namespace mola

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -468,39 +468,59 @@ void LidarOdometry::MethodState::GravityEstimator::add(
   const std::array<double, 3> acc = {
     imu.get(mrpt::obs::IMU_X_ACC), imu.get(mrpt::obs::IMU_Y_ACC), imu.get(mrpt::obs::IMU_Z_ACC)};
 
-  // Basic sanity: reject readings that are clearly not gravity-like
+  // Reject readings whose specific-force deviates from gravity by >2 m/s²
+  // (tighter than original threshold to avoid bias during dynamic motion):
   const double norm = std::sqrt(acc[0] * acc[0] + acc[1] * acc[1] + acc[2] * acc[2]);
-  if (std::abs(norm - 9.8) > 3.0 && std::abs(norm - 1.0) > 0.5) {
-    return;  // not a plausible gravity reading
+  if (std::abs(norm - 9.81) > 2.0) {
+    return;
   }
+
+  const double stamp = mrpt::Clock::toDouble(imu.timestamp);
 
   // Trim buffer to the desired averaging window:
   while (acc_buffer.size() >= max_samples) {
     acc_buffer.pop();
   }
-  acc_buffer.push(acc);
+  acc_buffer.push({stamp, acc});
 
   // Remember the sensor pose for vehicle-frame transform:
   imu_sensor_pose = imu.sensorPose;
+  imu_sensor_pose_timestamp = stamp;
 }
 
 std::optional<std::pair<double, double>>
-LidarOdometry::MethodState::GravityEstimator::estimatedPitchRoll(uint32_t required_samples) const
+LidarOdometry::MethodState::GravityEstimator::estimatedPitchRoll(
+  uint32_t required_samples, double max_age_seconds) const
 {
   if (acc_buffer.size() < required_samples) {
     return std::nullopt;
   }
 
-  // Average the accelerometer readings (in sensor frame):
+  // Determine the newest timestamp in the buffer for age filtering:
+  const double newest_stamp = acc_buffer.peek(acc_buffer.size() - 1).timestamp;
+  const bool use_age_filter = max_age_seconds > 0;
+
+  // Average the accelerometer readings (in sensor frame),
+  // considering only samples within the age limit:
   double sx = 0, sy = 0, sz = 0;
+  std::size_t count = 0;
   const auto n = acc_buffer.size();
   for (std::size_t i = 0; i < n; i++) {
-    const auto & a = acc_buffer.peek(i);
-    sx += a[0];
-    sy += a[1];
-    sz += a[2];
+    const auto & entry = acc_buffer.peek(i);
+    if (use_age_filter && (newest_stamp - entry.timestamp) > max_age_seconds) {
+      continue;  // too old
+    }
+    sx += entry.acc[0];
+    sy += entry.acc[1];
+    sz += entry.acc[2];
+    ++count;
   }
-  const double inv_n = 1.0 / static_cast<double>(n);
+
+  if (count < required_samples) {
+    return std::nullopt;
+  }
+
+  const double inv_n = 1.0 / static_cast<double>(count);
   const double ax = sx * inv_n;
   const double ay = sy * inv_n;
   const double az = sz * inv_n;

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -41,7 +41,7 @@ params:
   # IMU accelerometer-based verticality correction:
   # Uses averaged accelerometer readings to constrain ICP pitch/roll.
   imu_gravity_correction:
-    enabled: ${MOLA_IMU_GRAVITY_CORRECTION|false}
+    enabled: ${MOLA_IMU_GRAVITY_CORRECTION|true}
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
     max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -44,6 +44,7 @@ params:
     enabled: ${MOLA_IMU_GRAVITY_CORRECTION|false}
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
+    max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}
 
   # When publishing pose updates, the reference frame for both, estimated robot poses, and the local map.
   publish_reference_frame: "${MOLA_LO_PUBLISH_REF_FRAME|odom}"

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -38,6 +38,13 @@ params:
   # If using LO without IMU, try lidar3d-gicp-optimize-twist.yaml to enable optimize_twist if needed.
   optimize_twist: false
 
+  # IMU accelerometer-based verticality correction:
+  # Uses averaged accelerometer readings to constrain ICP pitch/roll.
+  imu_gravity_correction:
+    enabled: ${MOLA_IMU_GRAVITY_CORRECTION|false}
+    sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
+    averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
+
   # When publishing pose updates, the reference frame for both, estimated robot poses, and the local map.
   publish_reference_frame: "${MOLA_LO_PUBLISH_REF_FRAME|odom}"
 

--- a/ros2-launchs/ros2-lidar-odometry.launch.py
+++ b/ros2-launchs/ros2-lidar-odometry.launch.py
@@ -184,6 +184,11 @@ def generate_launch_description():
     imu_gravity_correction_env_var = SetEnvironmentVariable(
         name='MOLA_IMU_GRAVITY_CORRECTION', value=LaunchConfiguration('imu_gravity_correction'))
     # ~~~~~~~~~~~~
+    imu_gravity_sigma_deg_arg = DeclareLaunchArgument(
+        "imu_gravity_sigma_deg", default_value="2.0", description="Sigma [degrees] for the gravity-derived pitch/roll prior. Lower values = more trust in IMU.")
+    imu_gravity_sigma_deg_env_var = SetEnvironmentVariable(
+        name='MOLA_IMU_GRAVITY_SIGMA_DEG', value=LaunchConfiguration('imu_gravity_sigma_deg'))
+    # ~~~~~~~~~~~~
     mola_tf_base_link_arg = DeclareLaunchArgument(
         "mola_tf_base_link", default_value="base_link", description="The /tf frame name for the robot base link.")
     mola_tf_base_link_env_var = SetEnvironmentVariable(
@@ -278,6 +283,8 @@ def generate_launch_description():
         lidar_topic_type_env_var,
         imu_gravity_correction_arg,
         imu_gravity_correction_env_var,
+        imu_gravity_sigma_deg_arg,
+        imu_gravity_sigma_deg_env_var,
         mola_deskew_method_arg,
         mola_deskew_method_env_var,
         mola_footprint_to_base_link_tf_arg,

--- a/ros2-launchs/ros2-lidar-odometry.launch.py
+++ b/ros2-launchs/ros2-lidar-odometry.launch.py
@@ -179,6 +179,11 @@ def generate_launch_description():
     mola_deskew_method_env_var = SetEnvironmentVariable(
         name='MOLA_DESKEW_METHOD', value=LaunchConfiguration('mola_deskew_method'))
     # ~~~~~~~~~~~~
+    imu_gravity_correction_arg = DeclareLaunchArgument(
+        "imu_gravity_correction", default_value="true", description="Whether to use IMU accelerometer readings to constrain ICP pitch/roll (prevents vertical drift; safe to leave enabled even without an IMU)")
+    imu_gravity_correction_env_var = SetEnvironmentVariable(
+        name='MOLA_IMU_GRAVITY_CORRECTION', value=LaunchConfiguration('imu_gravity_correction'))
+    # ~~~~~~~~~~~~
     mola_tf_base_link_arg = DeclareLaunchArgument(
         "mola_tf_base_link", default_value="base_link", description="The /tf frame name for the robot base link.")
     mola_tf_base_link_env_var = SetEnvironmentVariable(
@@ -271,6 +276,8 @@ def generate_launch_description():
         lidar_topic_name_arg,
         lidar_topic_type_arg,
         lidar_topic_type_env_var,
+        imu_gravity_correction_arg,
+        imu_gravity_correction_env_var,
         mola_deskew_method_arg,
         mola_deskew_method_env_var,
         mola_footprint_to_base_link_tf_arg,

--- a/ros2-launchs/ros2-lidar-odometry.launch.py
+++ b/ros2-launchs/ros2-lidar-odometry.launch.py
@@ -1,4 +1,3 @@
-
 # ROS 2 launch file
 
 from launch import LaunchDescription
@@ -189,6 +188,16 @@ def generate_launch_description():
     imu_gravity_sigma_deg_env_var = SetEnvironmentVariable(
         name='MOLA_IMU_GRAVITY_SIGMA_DEG', value=LaunchConfiguration('imu_gravity_sigma_deg'))
     # ~~~~~~~~~~~~
+    imu_gravity_avg_samples_arg = DeclareLaunchArgument(
+        "imu_gravity_avg_samples", default_value="20", description="Number of IMU samples to average when estimating the gravity direction for pitch/roll correction.")
+    imu_gravity_avg_samples_env_var = SetEnvironmentVariable(
+        name='MOLA_IMU_GRAVITY_AVG_SAMPLES', value=LaunchConfiguration('imu_gravity_avg_samples'))
+    # ~~~~~~~~~~~~
+    imu_gravity_max_age_arg = DeclareLaunchArgument(
+        "imu_gravity_max_age", default_value="2.0", description="Maximum age [seconds] of IMU samples used for gravity alignment. Samples older than this are discarded.")
+    imu_gravity_max_age_env_var = SetEnvironmentVariable(
+        name='MOLA_IMU_GRAVITY_MAX_AGE', value=LaunchConfiguration('imu_gravity_max_age'))
+    # ~~~~~~~~~~~~
     mola_tf_base_link_arg = DeclareLaunchArgument(
         "mola_tf_base_link", default_value="base_link", description="The /tf frame name for the robot base link.")
     mola_tf_base_link_env_var = SetEnvironmentVariable(
@@ -285,6 +294,10 @@ def generate_launch_description():
         imu_gravity_correction_env_var,
         imu_gravity_sigma_deg_arg,
         imu_gravity_sigma_deg_env_var,
+        imu_gravity_avg_samples_arg,
+        imu_gravity_avg_samples_env_var,
+        imu_gravity_max_age_arg,
+        imu_gravity_max_age_env_var,
         mola_deskew_method_arg,
         mola_deskew_method_env_var,
         mola_footprint_to_base_link_tf_arg,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IMU-based gravity correction: uses accelerometer-derived pitch/roll to add a prior to ICP alignment, improving pose estimation when IMU is present. Configurable confidence, averaging window and sample-age filtering; can operate alongside existing gravity factors.
  * Added launch-time controls to enable/disable and tune the feature.

* **Documentation**
  * Added docs and environment variables for configuring behavior and defaults: MOLA_IMU_GRAVITY_CORRECTION, MOLA_IMU_GRAVITY_SIGMA_DEG, MOLA_IMU_GRAVITY_AVG_SAMPLES, MOLA_IMU_GRAVITY_MAX_AGE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->