### PR TITLE
Implement new mola_kernel diagnostics API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ endif()
 # Install files:
 install(
   DIRECTORY
+    config
     mola-cli-launchs
     pipelines
     ros2-launchs

--- a/config/diagnostics_aggregator.yaml
+++ b/config/diagnostics_aggregator.yaml
@@ -1,0 +1,28 @@
+# Sample diagnostic_aggregator configuration for MOLA-LO.
+#
+# Usage (launched automatically when passing
+#   use_diagnostic_aggregator:=True
+# to ros2-lidar-odometry.launch.py), or manually with:
+#
+#   ros2 run diagnostic_aggregator aggregator_node \
+#     --ros-args --params-file \
+#     $(ros2 pkg prefix mola_lidar_odometry)/share/mola_lidar_odometry/config/diagnostics_aggregator.yaml
+#
+# Then visualize with:
+#   ros2 run rqt_robot_monitor rqt_robot_monitor
+#
+# This groups MOLA-LO's DiagnosticStatus entries under a single "MOLA LO"
+# category so rqt_robot_monitor shows a rolled-up health indicator.
+
+/**:
+  ros__parameters:
+    analyzers:
+      mola_lo:
+        type: diagnostic_aggregator/AnalyzerGroup
+        path: MOLA LO
+        analyzers:
+          odometry:
+            type: diagnostic_aggregator/GenericAnalyzer
+            path: LidarOdometry
+            startswith: ['LidarOdometry']
+            timeout: 5.0

--- a/docs/mola_lidar_odometry.rst
+++ b/docs/mola_lidar_odometry.rst
@@ -102,6 +102,7 @@ Apart of this way to run MOLA-LO, two additional ways are provided for convenien
   It is also great for scripting and automating SLAM pipelines from raw datasets or rosbags.
 * :ref:`ROS 2 integration <mola_lo_ros>`: ROS 2 launch files are also provided for easier integration
   for real-time odometry and mapping.
+* :ref:`ROS 2 diagnostics (REP-107) <mola_lo_diagnostics>`: health monitoring published on ``/diagnostics``.
 
 |
 

--- a/docs/mola_lo_diagnostics.rst
+++ b/docs/mola_lo_diagnostics.rst
@@ -65,9 +65,42 @@ Inspecting diagnostics at runtime
    # Raw array:
    ros2 topic echo /diagnostics
 
-   # Human-readable live view:
+   # Human-readable live view (flat list, no aggregator needed):
    ros2 run rqt_runtime_monitor rqt_runtime_monitor
 
-   # Aggregated view (with a diagnostic_aggregator analyzer):
+   # Aggregated / grouped view (requires a running diagnostic_aggregator,
+   # reads /diagnostics_agg):
    ros2 run rqt_robot_monitor rqt_robot_monitor
+
+Foxglove Studio also ships a native *Diagnostics — Detail* and
+*Diagnostics — Summary* panel that consumes ``/diagnostics`` directly; no
+aggregator required.
+
+Testing with the bundled aggregator
+-----------------------------------
+
+For quick bring-up / demos, the launch file can start a standalone
+``diagnostic_aggregator`` preconfigured for MOLA-LO:
+
+.. code-block:: bash
+
+   ros2 launch mola_lidar_odometry ros2-lidar-odometry.launch.py \
+       lidar_topic_name:=/ouster/points \
+       use_diagnostic_aggregator:=True
+
+   # In another terminal:
+   ros2 run rqt_robot_monitor rqt_robot_monitor
+
+The sample aggregator YAML is installed at
+``$(ros2 pkg prefix mola_lidar_odometry)/share/mola_lidar_odometry/config/diagnostics_aggregator.yaml``
+and groups MOLA-LO statuses under the ``MOLA LO`` category.
+
+.. note::
+
+   Leave ``use_diagnostic_aggregator:=False`` (the default) when MOLA-LO is
+   part of a larger robot stack that already launches its own central
+   aggregator — two aggregators subscribing to the same ``/diagnostics``
+   will produce duplicated/conflicting ``/diagnostics_agg`` trees. In that
+   case, just add a ``startswith: ['LidarOdometry']`` analyzer to your
+   existing aggregator YAML.
 

--- a/docs/mola_lo_diagnostics.rst
+++ b/docs/mola_lo_diagnostics.rst
@@ -1,0 +1,73 @@
+.. _mola_lo_diagnostics:
+
+===========================
+ROS 2 Diagnostics (REP-107)
+===========================
+
+MOLA-LO implements the ``mola::DiagnosticsProvider`` interface so that its
+health status is published, when running in a ROS 2 stack, as
+``diagnostic_msgs/DiagnosticArray`` messages on the ``/diagnostics`` topic,
+following `REP-107 <https://www.ros.org/reps/rep-0107.html>`_.
+
+Publication is handled by :ref:`mola_bridge_ros2 <mola_bridge_ros2>`, which
+discovers all loaded modules implementing ``DiagnosticsProvider`` via
+``findService<>()`` and aggregates their statuses.
+
+.. contents::
+   :depth: 1
+   :local:
+   :backlinks: none
+
+Published statuses
+---------------------
+
+MOLA-LO publishes the following ``DiagnosticStatus`` entries on each tick:
+
+* **LidarOdometry: Input Data** — staleness of incoming LiDAR observations
+  and dropped-frame ratio.
+* **LidarOdometry: ICP Quality** — current ICP quality metric from the last
+  scan matching.
+* **LidarOdometry: Timing** — processing time utilization (fraction of the
+  expected frame period used by the pipeline).
+* **LidarOdometry: Local Map** — local map size and update state
+  (mapping enabled/disabled).
+* **LidarOdometry: Overall Status** — worst-of aggregate of the above.
+
+Each status carries a REP-107 severity (``OK`` / ``WARN`` / ``ERROR`` /
+``STALE``) plus a set of ``key=value`` pairs with the numeric values used
+for the decision.
+
+Configuration
+----------------
+
+Thresholds are exposed as YAML parameters under the ``diagnostics`` block of
+the LO pipeline (see ``pipelines/lidar3d-default.yaml``):
+
+.. code-block:: yaml
+
+   diagnostics:
+     icp_quality_warn:       0.30    # ICP quality below this → WARN
+     icp_quality_error:      0.10    # ICP quality below this → ERROR
+     input_stale_sec:        3.0     # Age of last input beyond this → STALE
+     input_error_sec:        5.0     # Age of last input beyond this → ERROR
+     dropped_ratio_warn:     0.20    # Dropped-frame ratio beyond this → WARN
+     dropped_ratio_error:    0.50    # Dropped-frame ratio beyond this → ERROR
+     timing_utilization_warn: 0.80   # Frame utilization beyond this → WARN
+
+All fields are optional; omitted entries fall back to the defaults shown
+above.
+
+Inspecting diagnostics at runtime
+-----------------------------------
+
+.. code-block:: bash
+
+   # Raw array:
+   ros2 topic echo /diagnostics
+
+   # Human-readable live view:
+   ros2 run rqt_runtime_monitor rqt_runtime_monitor
+
+   # Aggregated view (with a diagnostic_aggregator analyzer):
+   ros2 run rqt_robot_monitor rqt_robot_monitor
+

--- a/docs/mola_lo_ros_node.rst
+++ b/docs/mola_lo_ros_node.rst
@@ -265,6 +265,13 @@ runs **MOLA-LO** live on point clouds received from a ROS 2 topic, **demonstrati
       If ``true``, enables LIO mode (forces ``MotionCompensationMethod::IMU`` for deskew).
       Requires a working ``imu_topic_name``.
 
+    * ``use_diagnostic_aggregator`` (default ``False``):
+      Launch a standalone ``diagnostic_aggregator`` with the bundled MOLA-LO
+      config (publishes ``/diagnostics_agg`` for ``rqt_robot_monitor``).
+      Enable only for isolated bring-up/demos; leave disabled when a central
+      aggregator is launched elsewhere in the robot stack. See
+      :ref:`mola_lo_diagnostics`.
+
     * ``use_mola_gui`` (default ``True``):
       Whether to open the MolaViz GUI for live mapping visualization and control.
 

--- a/docs/mola_lo_ros_node.rst
+++ b/docs/mola_lo_ros_node.rst
@@ -261,16 +261,16 @@ runs **MOLA-LO** live on point clouds received from a ROS 2 topic, **demonstrati
     * ``state_estimator_config_yaml`` (default ``""``):
       Path to estimator YAML. If empty, it is auto-resolved based on ``use_state_estimator``.
 
-    * ``use_imu_for_lio`` (default ``False``):
-      If ``true``, enables LIO mode (forces ``MotionCompensationMethod::IMU`` for deskew).
-      Requires a working ``imu_topic_name``.
-
     * ``use_diagnostic_aggregator`` (default ``False``):
       Launch a standalone ``diagnostic_aggregator`` with the bundled MOLA-LO
       config (publishes ``/diagnostics_agg`` for ``rqt_robot_monitor``).
       Enable only for isolated bring-up/demos; leave disabled when a central
       aggregator is launched elsewhere in the robot stack. See
       :ref:`mola_lo_diagnostics`.
+
+    * ``use_imu_for_lio`` (default ``False``):
+      If ``true``, enables LIO mode (forces ``MotionCompensationMethod::IMU`` for deskew).
+      Requires a working ``imu_topic_name``.
 
     * ``use_mola_gui`` (default ``True``):
       Whether to open the MolaViz GUI for live mapping visualization and control.

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -22,6 +22,10 @@
 
 // MOLA interfaces:
 #include <mola_kernel/id.h>  // INVALID_ID
+#if __has_include(<mola_kernel/interfaces/DiagnosticsProvider.h>)
+#include <mola_kernel/interfaces/DiagnosticsProvider.h>
+#define MOLA_HAS_DIAGNOSTICS_PROVIDER 1
+#endif
 #include <mola_kernel/interfaces/FrontEndBase.h>
 #include <mola_kernel/interfaces/LocalizationSourceBase.h>
 #include <mola_kernel/interfaces/MapServer.h>
@@ -96,6 +100,10 @@ class LidarOdometry : public mola::FrontEndBase,
                       public mola::MapSourceBase,
                       public mola::MapServer,
                       public mola::Relocalization
+#if MOLA_HAS_DIAGNOSTICS_PROVIDER
+,
+                      public mola::DiagnosticsProvider
+#endif
 {
   DEFINE_MRPT_OBJECT(LidarOdometry, mola)
 
@@ -316,6 +324,29 @@ public:
       void initialize(const Yaml & c);
     };
     AdaptiveThreshold adaptive_threshold;
+
+    /** Thresholds for REP-107 diagnostics levels. */
+    struct Diagnostics
+    {
+      double icp_quality_warn = 0.30;
+      double icp_quality_error = 0.10;
+
+      /// Input considered stale if no observation received for this many seconds
+      double input_stale_sec = 3.0;
+
+      /// Fatal-level staleness (no data for this many seconds)
+      double input_error_sec = 5.0;
+
+      /// Warn when dropped-frames ratio exceeds this value
+      double dropped_ratio_warn = 0.20;
+      double dropped_ratio_error = 0.50;
+
+      /// Warn when average process time exceeds this fraction of sensor period
+      double timing_utilization_warn = 0.80;
+
+      void initialize(const Yaml & c);
+    };
+    Diagnostics diagnostics;
 
     /** ICP parameters for the case of having, or not, a good velocity
          * model that works a good prior. Each entry in the vector is an
@@ -937,6 +968,11 @@ private:
   void handleUnloadSinglePastObservation(CObservation::Ptr & o) const;
 
   void onPublishDiagnostics();
+
+#if MOLA_HAS_DIAGNOSTICS_PROVIDER
+  /// REP-107 structured diagnostics, collected by BridgeROS2 at ~1 Hz.
+  void getDiagnostics(std::vector<mola::DiagnosticStatusMsg> & status) override;
+#endif
   void handleInitialLocalization();
   void handleInitialLocalizationStateEstimation();
   void handleInitialLocalizationDoInitFromPose(

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -715,6 +715,7 @@ private:
     std::optional<mrpt::Clock::time_point> first_ever_timestamp;
     std::optional<mrpt::Clock::time_point> last_obs_timestamp;
     std::optional<mrpt::Clock::time_point> last_icp_timestamp;
+    double last_observed_scan_period_sec = 0.0;  //!< seconds between last two processed scans
 
     /// Timestamp when we started waiting for state estimator convergence
     std::optional<mrpt::Clock::time_point> waiting_for_state_estimator_since;

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -715,6 +715,9 @@ private:
     std::optional<mrpt::Clock::time_point> first_ever_timestamp;
     std::optional<mrpt::Clock::time_point> last_obs_timestamp;
     std::optional<mrpt::Clock::time_point> last_icp_timestamp;
+    /// Wall-clock time when the last observation was received (used for
+    /// staleness checks, avoids relying on sensor hardware clocks).
+    std::optional<mrpt::Clock::time_point> last_obs_reception_time;
     double last_observed_scan_period_sec = 0.0;  //!< seconds between last two processed scans
 
     /// Timestamp when we started waiting for state estimator convergence

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -159,6 +159,10 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
     params_.adaptive_threshold.initialize(cfg["adaptive_threshold"]);
   }
 
+  if (cfg.has("diagnostics")) {
+    params_.diagnostics.initialize(cfg["diagnostics"]);
+  }
+
   if (cfg.has("visualization")) {
     params_.visualization.initialize(cfg["visualization"]);
   }

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -31,6 +31,17 @@
 namespace mola
 {
 
+void LidarOdometry::Parameters::Diagnostics::initialize(const Yaml & cfg)
+{
+  YAML_LOAD_OPT(icp_quality_warn, double);
+  YAML_LOAD_OPT(icp_quality_error, double);
+  YAML_LOAD_OPT(input_stale_sec, double);
+  YAML_LOAD_OPT(input_error_sec, double);
+  YAML_LOAD_OPT(dropped_ratio_warn, double);
+  YAML_LOAD_OPT(dropped_ratio_error, double);
+  YAML_LOAD_OPT(timing_utilization_warn, double);
+}
+
 void LidarOdometry::Parameters::AdaptiveThreshold::initialize(const Yaml & cfg)
 {
   YAML_LOAD_REQ(enabled, bool);

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -50,8 +50,8 @@ void LidarOdometry::Parameters::Diagnostics::initialize(const Yaml & cfg)
   ASSERTMSG_(
     icp_quality_error < icp_quality_warn,
     mrpt::format(
-      "diagnostics: icp_quality_error (%.3f) must be < icp_quality_warn (%.3f)",
-      icp_quality_error, icp_quality_warn));
+      "diagnostics: icp_quality_error (%.3f) must be < icp_quality_warn (%.3f)", icp_quality_error,
+      icp_quality_warn));
 
   ASSERTMSG_(
     input_stale_sec >= 0 && input_error_sec >= 0,
@@ -61,8 +61,8 @@ void LidarOdometry::Parameters::Diagnostics::initialize(const Yaml & cfg)
   ASSERTMSG_(
     input_stale_sec < input_error_sec,
     mrpt::format(
-      "diagnostics: input_stale_sec (%.3f) must be < input_error_sec (%.3f)",
-      input_stale_sec, input_error_sec));
+      "diagnostics: input_stale_sec (%.3f) must be < input_error_sec (%.3f)", input_stale_sec,
+      input_error_sec));
 
   ASSERTMSG_(
     dropped_ratio_warn >= 0 && dropped_ratio_warn <= 1 && dropped_ratio_error >= 0 &&

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -40,6 +40,46 @@ void LidarOdometry::Parameters::Diagnostics::initialize(const Yaml & cfg)
   YAML_LOAD_OPT(dropped_ratio_warn, double);
   YAML_LOAD_OPT(dropped_ratio_error, double);
   YAML_LOAD_OPT(timing_utilization_warn, double);
+
+  // Validate thresholds so misconfiguration cannot silently invert severities.
+  ASSERTMSG_(
+    icp_quality_warn >= 0 && icp_quality_error >= 0,
+    mrpt::format(
+      "diagnostics: icp_quality_warn (%.3f) and icp_quality_error (%.3f) must be >= 0",
+      icp_quality_warn, icp_quality_error));
+  ASSERTMSG_(
+    icp_quality_error < icp_quality_warn,
+    mrpt::format(
+      "diagnostics: icp_quality_error (%.3f) must be < icp_quality_warn (%.3f)",
+      icp_quality_error, icp_quality_warn));
+
+  ASSERTMSG_(
+    input_stale_sec >= 0 && input_error_sec >= 0,
+    mrpt::format(
+      "diagnostics: input_stale_sec (%.3f) and input_error_sec (%.3f) must be >= 0",
+      input_stale_sec, input_error_sec));
+  ASSERTMSG_(
+    input_stale_sec < input_error_sec,
+    mrpt::format(
+      "diagnostics: input_stale_sec (%.3f) must be < input_error_sec (%.3f)",
+      input_stale_sec, input_error_sec));
+
+  ASSERTMSG_(
+    dropped_ratio_warn >= 0 && dropped_ratio_warn <= 1 && dropped_ratio_error >= 0 &&
+      dropped_ratio_error <= 1,
+    mrpt::format(
+      "diagnostics: dropped_ratio_warn (%.3f) and dropped_ratio_error (%.3f) must be in [0,1]",
+      dropped_ratio_warn, dropped_ratio_error));
+  ASSERTMSG_(
+    dropped_ratio_warn < dropped_ratio_error,
+    mrpt::format(
+      "diagnostics: dropped_ratio_warn (%.3f) must be < dropped_ratio_error (%.3f)",
+      dropped_ratio_warn, dropped_ratio_error));
+
+  ASSERTMSG_(
+    timing_utilization_warn >= 0 && timing_utilization_warn <= 1,
+    mrpt::format(
+      "diagnostics: timing_utilization_warn (%.3f) must be in [0,1]", timing_utilization_warn));
 }
 
 void LidarOdometry::Parameters::AdaptiveThreshold::initialize(const Yaml & cfg)

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -93,6 +93,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 
   // Keep timestamps for logging purposes:
   state_.last_obs_timestamp = this_obs_tim;
+  state_.last_obs_reception_time = mrpt::Clock::now();
   if (!state_.first_ever_timestamp) {
     state_.first_ever_timestamp = this_obs_tim;
   }

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -380,6 +380,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     if (state_.last_icp_timestamp) {
       in.time_since_last_keyframe =
         mrpt::system::timeDifference(*state_.last_icp_timestamp, this_obs_tim);
+      state_.last_observed_scan_period_sec = in.time_since_last_keyframe;
     }
     state_.last_icp_timestamp = this_obs_tim;
 

--- a/module/src/LidarOdometry_Publish.cpp
+++ b/module/src/LidarOdometry_Publish.cpp
@@ -298,8 +298,10 @@ void LidarOdometry::getDiagnostics(std::vector<mola::DiagnosticStatusMsg> & stat
 
   const auto & th = params_.diagnostics;
   const auto now = mrpt::Clock::now();
-  const double lastObsAgeSec = state_.last_obs_timestamp
-                                 ? mrpt::system::timeDifference(*state_.last_obs_timestamp, now)
+  // Use wall-clock reception time to avoid false positives when sensor
+  // hardware clocks are not synchronized to system time.
+  const double lastObsAgeSec = state_.last_obs_reception_time
+                                 ? mrpt::system::timeDifference(*state_.last_obs_reception_time, now)
                                  : std::numeric_limits<double>::infinity();
 
   const double icpQ = state_.last_icp_quality;
@@ -312,7 +314,7 @@ void LidarOdometry::getDiagnostics(std::vector<mola::DiagnosticStatusMsg> & stat
   {
     mola::DiagnosticStatusMsg s;
     s.name = "LidarOdometry: Input Data";
-    if (!state_.last_obs_timestamp) {
+    if (!state_.last_obs_reception_time) {
       s.level = L::STALE;
       s.message = "No observations received yet";
     } else if (lastObsAgeSec > th.input_error_sec) {

--- a/module/src/LidarOdometry_Publish.cpp
+++ b/module/src/LidarOdometry_Publish.cpp
@@ -300,9 +300,10 @@ void LidarOdometry::getDiagnostics(std::vector<mola::DiagnosticStatusMsg> & stat
   const auto now = mrpt::Clock::now();
   // Use wall-clock reception time to avoid false positives when sensor
   // hardware clocks are not synchronized to system time.
-  const double lastObsAgeSec = state_.last_obs_reception_time
-                                 ? mrpt::system::timeDifference(*state_.last_obs_reception_time, now)
-                                 : std::numeric_limits<double>::infinity();
+  const double lastObsAgeSec =
+    state_.last_obs_reception_time
+      ? mrpt::system::timeDifference(*state_.last_obs_reception_time, now)
+      : std::numeric_limits<double>::infinity();
 
   const double icpQ = state_.last_icp_quality;
   const double dtAvr = profiler_.getMeanTime("onLidar");

--- a/module/src/LidarOdometry_Publish.cpp
+++ b/module/src/LidarOdometry_Publish.cpp
@@ -25,6 +25,11 @@
 // MRPT:
 #include <mrpt/io/CMemoryStream.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/system/datetime.h>
+
+#include <iomanip>
+#include <limits>
+#include <sstream>
 
 // MOLA:
 #include <mola_kernel/version.h>
@@ -250,5 +255,173 @@ void LidarOdometry::onPublishDiagnostics()
 
   module_publish_diagnostics(diag);
 }
+
+#if MOLA_HAS_DIAGNOSTICS_PROVIDER
+namespace
+{
+mola::DiagnosticKeyValue kv_d(const std::string & key, double value, int precision = 3)
+{
+  std::ostringstream ss;
+  ss.precision(precision);
+  ss << std::fixed << value;
+  return {key, ss.str()};
+}
+mola::DiagnosticKeyValue kv_u(const std::string & key, std::size_t value)
+{
+  return {key, std::to_string(value)};
+}
+mola::DiagnosticLevel worst(mola::DiagnosticLevel a, mola::DiagnosticLevel b)
+{
+  using L = mola::DiagnosticLevel;
+  auto rank = [](L x) {
+    switch (x) {
+      case L::OK:
+        return 0;
+      case L::WARN:
+        return 1;
+      case L::STALE:
+        return 2;
+      case L::ERROR:
+        return 3;
+    }
+    return 0;
+  };
+  return rank(a) >= rank(b) ? a : b;
+}
+}  // namespace
+
+void LidarOdometry::getDiagnostics(std::vector<mola::DiagnosticStatusMsg> & status)
+{
+  using L = mola::DiagnosticLevel;
+
+  auto lckState = mrpt::lockHelper(state_mtx_);
+
+  const auto & th = params_.diagnostics;
+  const auto now = mrpt::Clock::now();
+  const double lastObsAgeSec = state_.last_obs_timestamp
+                                 ? mrpt::system::timeDifference(*state_.last_obs_timestamp, now)
+                                 : std::numeric_limits<double>::infinity();
+
+  const double icpQ = state_.last_icp_quality;
+  const double dtAvr = profiler_.getMeanTime("onLidar");
+  const double droppedRatio = getDropStats();
+  const double sensorPeriod = params_.min_time_between_scans;
+
+  // 1) Input Data
+  {
+    mola::DiagnosticStatusMsg s;
+    s.name = "LidarOdometry: Input Data";
+    if (!state_.last_obs_timestamp) {
+      s.level = L::STALE;
+      s.message = "No observations received yet";
+    } else if (lastObsAgeSec > th.input_error_sec) {
+      s.level = L::ERROR;
+      s.message = "No observations for >" + std::to_string(th.input_error_sec) + "s";
+    } else if (lastObsAgeSec > th.input_stale_sec) {
+      s.level = L::STALE;
+      s.message = "Input appears stale";
+    } else if (droppedRatio > th.dropped_ratio_error) {
+      s.level = L::ERROR;
+      s.message = "Very high frame drop rate";
+    } else if (droppedRatio > th.dropped_ratio_warn) {
+      s.level = L::WARN;
+      s.message = "High frame drop rate";
+    } else {
+      s.level = L::OK;
+      s.message = "Nominal";
+    }
+    s.values.push_back(kv_d("last_obs_age_sec", lastObsAgeSec));
+    s.values.push_back(kv_d("dropped_ratio", droppedRatio));
+    status.push_back(std::move(s));
+  }
+
+  // 2) ICP Quality
+  {
+    mola::DiagnosticStatusMsg s;
+    s.name = "LidarOdometry: ICP Quality";
+    if (icpQ < th.icp_quality_error) {
+      s.level = L::ERROR;
+      s.message = "ICP quality critically low";
+    } else if (icpQ < th.icp_quality_warn) {
+      s.level = L::WARN;
+      s.message = "ICP quality degraded";
+    } else {
+      s.level = L::OK;
+      s.message = "Nominal";
+    }
+    s.values.push_back(kv_d("quality", icpQ));
+    s.values.push_back(kv_u("last_icp_iterations", state_.last_icp_iterations));
+    s.values.push_back({"last_icp_was_good", state_.last_icp_was_good ? "true" : "false"});
+    status.push_back(std::move(s));
+  }
+
+  // 3) Timing
+  {
+    mola::DiagnosticStatusMsg s;
+    s.name = "LidarOdometry: Timing";
+    const double util = (sensorPeriod > 0) ? (dtAvr / sensorPeriod) : 0.0;
+    if (sensorPeriod > 0 && util > th.timing_utilization_warn) {
+      s.level = L::WARN;
+      s.message = "Process time close to sensor period";
+    } else {
+      s.level = L::OK;
+      s.message = "Nominal";
+    }
+    s.values.push_back(kv_d("avg_ms", dtAvr * 1000.0));
+    s.values.push_back(kv_d("sensor_period_ms", sensorPeriod * 1000.0));
+    s.values.push_back(kv_d("utilization_pct", util * 100.0));
+    status.push_back(std::move(s));
+  }
+
+  // 4) Local Map (informational)
+  {
+    mola::DiagnosticStatusMsg s;
+    s.name = "LidarOdometry: Local Map";
+    s.level = L::OK;
+    s.message = "Informational";
+    std::size_t numLayers = 0;
+    std::size_t totalPts = 0;
+    if (state_.local_map) {
+      numLayers = state_.local_map->layers.size();
+      for (const auto & [layerName, layerMap] : state_.local_map->layers) {
+        if (!layerMap) continue;
+        if (auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(layerMap); pts)
+          totalPts += pts->size();
+      }
+    }
+    s.values.push_back(kv_u("num_layers", numLayers));
+    s.values.push_back(kv_u("total_points", totalPts));
+    status.push_back(std::move(s));
+  }
+
+  // 5) Overall status: worst-of the above
+  {
+    mola::DiagnosticStatusMsg s;
+    s.name = "LidarOdometry: Overall Status";
+    s.level = L::OK;
+    for (const auto & sub : status) {
+      s.level = worst(s.level, sub.level);
+    }
+    switch (s.level) {
+      case L::OK:
+        s.message = "Nominal";
+        break;
+      case L::WARN:
+        s.message = "Degraded";
+        break;
+      case L::STALE:
+        s.message = "Stale input";
+        break;
+      case L::ERROR:
+        s.message = "Non-functional";
+        break;
+    }
+    s.values.push_back(kv_d("icp_quality", icpQ));
+    s.values.push_back(kv_d("process_time_avg_ms", dtAvr * 1000.0));
+    s.values.push_back(kv_d("dropped_frames_ratio", droppedRatio));
+    status.push_back(std::move(s));
+  }
+}
+#endif  // MOLA_HAS_DIAGNOSTICS_PROVIDER
 
 }  // namespace mola

--- a/module/src/LidarOdometry_Publish.cpp
+++ b/module/src/LidarOdometry_Publish.cpp
@@ -305,7 +305,8 @@ void LidarOdometry::getDiagnostics(std::vector<mola::DiagnosticStatusMsg> & stat
   const double icpQ = state_.last_icp_quality;
   const double dtAvr = profiler_.getMeanTime("onLidar");
   const double droppedRatio = getDropStats();
-  const double sensorPeriod = params_.min_time_between_scans;
+  const std::size_t startIndex = status.size();
+  const double sensorPeriod = state_.last_observed_scan_period_sec;
 
   // 1) Input Data
   {
@@ -339,7 +340,10 @@ void LidarOdometry::getDiagnostics(std::vector<mola::DiagnosticStatusMsg> & stat
   {
     mola::DiagnosticStatusMsg s;
     s.name = "LidarOdometry: ICP Quality";
-    if (icpQ < th.icp_quality_error) {
+    if (!state_.last_icp_timestamp) {
+      s.level = L::STALE;
+      s.message = "No ICP result yet";
+    } else if (icpQ < th.icp_quality_error) {
       s.level = L::ERROR;
       s.message = "ICP quality critically low";
     } else if (icpQ < th.icp_quality_warn) {
@@ -394,13 +398,13 @@ void LidarOdometry::getDiagnostics(std::vector<mola::DiagnosticStatusMsg> & stat
     status.push_back(std::move(s));
   }
 
-  // 5) Overall status: worst-of the above
+  // 5) Overall status: worst-of the entries added by this provider
   {
     mola::DiagnosticStatusMsg s;
     s.name = "LidarOdometry: Overall Status";
     s.level = L::OK;
-    for (const auto & sub : status) {
-      s.level = worst(s.level, sub.level);
+    for (std::size_t i = startIndex; i < status.size(); ++i) {
+      s.level = worst(s.level, status[i].level);
     }
     switch (s.level) {
       case L::OK:

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -88,6 +88,17 @@ params:
     kp: 2.0
     alpha: ${MOLA_ADAPT_THRESHOLD_ALPHA|0.99}
 
+  # REP-107 diagnostics thresholds published on /diagnostics via mola_bridge_ros2.
+  # Any of these can be omitted to keep its built-in default.
+  diagnostics:
+    icp_quality_warn: 0.30         # [0-1] WARN if icp_quality below this
+    icp_quality_error: 0.10        # [0-1] ERROR if icp_quality below this
+    input_stale_sec: 3.0           # [s]   STALE if no observation for this long
+    input_error_sec: 5.0           # [s]   ERROR if no observation for this long
+    dropped_ratio_warn: 0.20       # [0-1] WARN if dropped-frames ratio exceeds
+    dropped_ratio_error: 0.50      # [0-1] ERROR if dropped-frames ratio exceeds
+    timing_utilization_warn: 0.80  # [0-1] WARN if avg process time / sensor period exceeds
+
   # If enabled, a map will be stored in RAM and (if using the CLI) stored
   # to a ".simplemap" file for later use for localization, etc.
   simplemap:

--- a/ros2-launchs/ros2-lidar-odometry.launch.py
+++ b/ros2-launchs/ros2-lidar-odometry.launch.py
@@ -548,7 +548,6 @@ def generate_launch_description():
             package='diagnostic_aggregator',
             executable='aggregator_node',
             name='diagnostic_aggregator',
-            remappings=tf_remaps,
             parameters=[os.path.join(
                 get_package_share_directory('mola_lidar_odometry'),
                 'config', 'diagnostics_aggregator.yaml')],

--- a/ros2-launchs/ros2-lidar-odometry.launch.py
+++ b/ros2-launchs/ros2-lidar-odometry.launch.py
@@ -230,6 +230,34 @@ def generate_launch_description():
     use_rviz_arg = DeclareLaunchArgument(
         "use_rviz", default_value="True", description="Whether to launch RViz2 with default lidar-odometry.rviz configuration")
 
+    # diagnostic_aggregator is OFF by default.
+    #
+    # Rationale: on a real robot there is typically a single, central
+    # diagnostic_aggregator launched by the system integrator that groups
+    # diagnostics from ALL nodes (drivers, controllers, navigation, MOLA-LO,
+    # ...) into one /diagnostics_agg tree. Launching our own aggregator here
+    # would duplicate / conflict with that system-wide one.
+    #
+    # Enable this flag only when:
+    #   - You are running MOLA-LO in isolation (bring-up, demos, debugging).
+    #   - You just want to quickly visualize MOLA-LO's own health in
+    #     rqt_robot_monitor without setting up a central aggregator.
+    #
+    # Leave it False when:
+    #   - MOLA-LO is part of a larger robot stack that already launches
+    #     diagnostic_aggregator (the common production case). In that case
+    #     just include "LidarOdometry" (or the relevant startswith/contains
+    #     pattern) in your central aggregator YAML.
+    use_diagnostic_aggregator = LaunchConfiguration('use_diagnostic_aggregator')
+    use_diagnostic_aggregator_arg = DeclareLaunchArgument(
+        "use_diagnostic_aggregator", default_value="False",
+        description=(
+            "Whether to launch a standalone diagnostic_aggregator with the "
+            "MOLA-LO sample config (publishes /diagnostics_agg for "
+            "rqt_robot_monitor). Enable for isolated bring-up/demos; leave "
+            "disabled when a central aggregator is launched elsewhere in "
+            "the robot stack."))
+
     use_mola_gui_arg = DeclareLaunchArgument(
         "use_mola_gui", default_value="True", description="Whether to open MolaViz GUI interface for watching live mapping and control UI")
     use_mola_gui_env_var = SetEnvironmentVariable(
@@ -512,6 +540,18 @@ def generate_launch_description():
             remappings=tf_remaps,
             arguments=[
                 '-d', [os.path.join(myDir, 'rviz2', 'lidar-odometry.rviz')]]
+        ),
+
+        # Optional standalone diagnostic_aggregator (see flag docs above).
+        Node(
+            condition=IfCondition(use_diagnostic_aggregator),
+            package='diagnostic_aggregator',
+            executable='aggregator_node',
+            name='diagnostic_aggregator',
+            remappings=tf_remaps,
+            parameters=[os.path.join(
+                get_package_share_directory('mola_lidar_odometry'),
+                'config', 'diagnostics_aggregator.yaml')],
         )
     ])
 
@@ -584,6 +624,7 @@ def generate_launch_description():
         use_mola_gui_arg,
         use_mola_gui_env_var,
         use_rviz_arg,
+        use_diagnostic_aggregator_arg,
         use_state_estimator_arg,
         use_state_estimator_env_var,
         # Reject: (a) enabling the /tf pathway and a direct /odom subscription


### PR DESCRIPTION
Diagnostics exported to ROS2 via BridgeROS2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - REP-107-style diagnostics for LiDAR odometry (Input Data, ICP Quality, Timing, Local Map, Overall) published on /diagnostics when diagnostics support is available.
  - Runtime diagnostics API exposed and configurable thresholds via a pipeline `diagnostics` block (defaults apply if omitted).
  - Records input timing/staleness and computes timing utilization; optional launch flag to start a bundled local diagnostic aggregator.

* **Documentation**
  - New docs detailing diagnostics, configuration, aggregator usage, and inspection tools.

* **Chores**
  - Installed sample diagnostics aggregator config and pipeline examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->