### PR TITLE
feat(launch): expose transform_tolerance and transform_publish_period

### DIFF
--- a/mola-cli-launchs/lidar_odometry_ros2.yaml
+++ b/mola-cli-launchs/lidar_odometry_ros2.yaml
@@ -125,6 +125,13 @@ modules:
       #  - false: the wall-clock time.
       publish_in_sim_time: ${MOLA_ROS2_PUBLISH_IN_SIM_TIME|true}
 
+      # Future-dating offset [s] for the localization /tf stamp.
+      transform_tolerance: ${MOLA_ROS2_TRANSFORM_TOLERANCE|0.1}
+
+      # Period [s] for re-broadcasting the latest localization /tf
+      # (0 disables). Default 20 Hz.
+      transform_publish_period: ${MOLA_ROS2_TRANSFORM_PUBLISH_PERIOD|0.05}
+
       # Period [s] to publish the updated map to ROS2 from the MOLA SLAM solution:
       # Note that no repeated maps are published. This is just the period for checking the need to republish.
       period_publish_new_map: ${MOLA_ROS2_PUBLISH_MAPS_PERIOD|1.0} # [s]


### PR DESCRIPTION
Plumbs the two new `BridgeROS2` params from MOLAorg/mola#132 through the standard `MOLA_ROS2_*` env-var convention so they can be overridden from `ros2 launch` without editing YAML:

- `MOLA_ROS2_TRANSFORM_TOLERANCE` (default `0.1`)
- `MOLA_ROS2_TRANSFORM_PUBLISH_PERIOD` (default `0.05`, i.e. 20 Hz; `0` disables)

Defaults match `BridgeROS2` and the AMCL / slam_toolbox / RTAB-Map convention. Depends on MOLAorg/mola#132.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new ROS2 bridge configuration parameters to enhance transform management. Users can now customize the timestamp offset for localization transforms and configure the re-broadcasting period. These additions enable better control over transform synchronization and publication timing, improving integration with navigation and localization systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->