### PR TITLE
fix(mola_lidar_odometry): anchor ESTIMATED_SENSOR_MAX_RANGE and FilterByRange at the sensor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Changelog for package mola_lidar_odometry
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Rename the family of *_sensor_* pipeline names that actually meant
+  observation-from-``base_link`` to *_observation_radius_* /
+  ``*_OBSERVATION_RADIUS`` to clarify semantics. The legacy names remain as
+  deprecated aliases so existing pipelines keep working unchanged; a
+  one-shot warning is emitted at init when the loaded YAML still references
+  any legacy name. The aliases will be removed in a future release.
+
+  - Dynamic variables: ``ESTIMATED_SENSOR_MAX_RANGE`` →
+    ``ESTIMATED_OBSERVATION_RADIUS``, ``INSTANTANEOUS_SENSOR_MAX_RANGE`` →
+    ``INSTANTANEOUS_OBSERVATION_RADIUS``.
+  - YAML param keys: ``max_sensor_range_filter_coefficient`` →
+    ``observation_radius_filter_coefficient``, ``absolute_minimum_sensor_range``
+    → ``absolute_minimum_observation_radius``.
+
 2.0.0 (2026-04-02)
 ------------------
 * Merge pull request `#53 <https://github.com/MOLAorg/mola_lidar_odometry/issues/53>`_ from MOLAorg/feat/use-imu-grav-align

--- a/docs/mola_lo_pipelines.rst
+++ b/docs/mola_lo_pipelines.rst
@@ -281,11 +281,12 @@ Sensor inputs: LiDAR
 - ``MOLA_LIDAR_MAX_TIME_OFFSET`` (Default: ``0.1`` [s]): Maximum delay between different LiDAR observations to handle them together.
   Note that deskewing takes into account the exact delays between clouds from different LiDARs.
 
-- ``MOLA_ABS_MIN_SENSOR_RANGE`` (Default: ``5.0`` [m]): Absolute minimum for the otherwise automatically 
-  detected maximum sensor range.
+- ``MOLA_ABS_MIN_SENSOR_RANGE`` (Default: ``5.0`` [m]): Absolute minimum for the otherwise
+  automatically detected observation radius (see ``ESTIMATED_OBSERVATION_RADIUS``).
 
-- ``MOLA_MINIMUM_RANGE_FILTER`` (Default: 3% of max sensor range). Minimum range for 3D points. This removes points from 
-  the robot/vehicle itself.
+- ``MOLA_MINIMUM_RANGE_FILTER`` (Default: 3% of the estimated observation radius). Minimum range
+  (L∞ cube around ``base_link``) for 3D points used by ICP; intended to cut out points coming from
+  the robot/vehicle body itself or a person standing right next to it.
 
 Sensor inputs: IMU (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -158,8 +158,11 @@ public:
          */
     double min_time_between_scans = 0.05;
 
-    double max_sensor_range_filter_coefficient = 0.999;
-    double absolute_minimum_sensor_range = 5.0;  // [m]
+    // Low-pass filter alpha for the EMA of ESTIMATED_OBSERVATION_RADIUS, and
+    // the absolute floor for that estimate. Both used to be named *_sensor_*
+    // before the observation-radius rename; the old YAML keys still parse.
+    double observation_radius_filter_coefficient = 0.999;
+    double absolute_minimum_observation_radius = 5.0;  // [m]
 
     /** If enabled (slower), vehicle twist will be optimized during ICP
          *  enabling better and more robust odometry in high dynamics motion.
@@ -740,9 +743,10 @@ private:
     // KISS-ICP-like adaptive threshold method:
     double adapt_thres_sigma = 0;  // 0: initial
 
-    // Automatic estimation of max range:
-    std::optional<double> estimated_sensor_max_range;
-    std::optional<double> instantaneous_sensor_max_range;
+    // Automatic estimation of the observation bounding-radius (measured from
+    // base_link, not from the sensor — see ESTIMATED_OBSERVATION_RADIUS docs):
+    std::optional<double> estimated_observation_radius;
+    std::optional<double> instantaneous_observation_radius;
 
     mp2p_icp_filters::GeneratorSet obs_generators;
     mp2p_icp_filters::FilterPipeline pc_filterAdjustTimes;
@@ -925,8 +929,8 @@ private:
   // KISS-ICP adaptive threshold method:
   void doUpdateAdaptiveThreshold(const mrpt::poses::CPose3D & lastMotionModelError);
 
-  void doInitializeEstimatedMaxSensorRange(const mrpt::obs::CObservation & o);
-  void doUpdateEstimatedMaxSensorRange(const mp2p_icp::metric_map_t & m);
+  void doInitializeEstimatedObservationRadius(const mrpt::obs::CObservation & o);
+  void doUpdateEstimatedObservationRadius(const mp2p_icp::metric_map_t & m);
 
   /// Returns false if the scan/observation is not valid:
   bool doCheckIsValidObservation(const mp2p_icp::metric_map_t & m);

--- a/module/src/LidarOdometry_AdaptiveVariables.cpp
+++ b/module/src/LidarOdometry_AdaptiveVariables.cpp
@@ -108,15 +108,23 @@ void LidarOdometry::updatePipelineDynamicVariables(const mrpt::Clock::time_point
   ensureVarIsDefined("twistCorrectionCount");
   ensureVarIsDefined("icp_quality");
 
-  if (state_.estimated_sensor_max_range) {
+  if (state_.estimated_observation_radius) {
     state_.parameter_source.updateVariable(
-      "ESTIMATED_SENSOR_MAX_RANGE", *state_.estimated_sensor_max_range);
+      "ESTIMATED_OBSERVATION_RADIUS", *state_.estimated_observation_radius);
+    // Deprecated alias kept for one release cycle so user pipelines that
+    // still reference the old name keep working unchanged. A one-shot
+    // warning is emitted at init (see initialize()) when the loaded YAML
+    // still uses the legacy name.
+    state_.parameter_source.updateVariable(
+      "ESTIMATED_SENSOR_MAX_RANGE", *state_.estimated_observation_radius);
   }
 
-  state_.parameter_source.updateVariable(
-    "INSTANTANEOUS_SENSOR_MAX_RANGE", state_.instantaneous_sensor_max_range
-                                        ? *state_.instantaneous_sensor_max_range
-                                        : 20.0 /*default, only used once*/);
+  const double instRadius = state_.instantaneous_observation_radius
+                              ? *state_.instantaneous_observation_radius
+                              : 20.0 /*default, only used once*/;
+  state_.parameter_source.updateVariable("INSTANTANEOUS_OBSERVATION_RADIUS", instRadius);
+  // Deprecated alias, see comment above.
+  state_.parameter_source.updateVariable("INSTANTANEOUS_SENSOR_MAX_RANGE", instRadius);
 
   if (state_.last_obs_timestamp && state_.first_ever_timestamp) {
     state_.parameter_source.updateVariable(
@@ -142,11 +150,11 @@ double computeModelError(const mrpt::poses::CPose3D & model_deviation, double ma
 
 void LidarOdometry::doUpdateAdaptiveThreshold(const mrpt::poses::CPose3D & lastMotionModelError)
 {
-  if (!state_.estimated_sensor_max_range.has_value()) {
+  if (!state_.estimated_observation_radius.has_value()) {
     return;
   }
 
-  const double max_range = state_.estimated_sensor_max_range.value();
+  const double max_range = state_.estimated_observation_radius.value();
 
   const double ALPHA = params_.adaptive_threshold.alpha;
 
@@ -182,9 +190,9 @@ void LidarOdometry::doUpdateAdaptiveThreshold(const mrpt::poses::CPose3D & lastM
     state_.last_icp_quality, state_.adapt_thres_sigma);
 }
 
-void LidarOdometry::doInitializeEstimatedMaxSensorRange(const mrpt::obs::CObservation & o)
+void LidarOdometry::doInitializeEstimatedObservationRadius(const mrpt::obs::CObservation & o)
 {
-  auto & maxRange = state_.estimated_sensor_max_range;
+  auto & maxRange = state_.estimated_observation_radius;
   ASSERT_(!maxRange.has_value());  // this method is for 1st call only
 
   mp2p_icp_filters::Generator gen;
@@ -206,24 +214,25 @@ void LidarOdometry::doInitializeEstimatedMaxSensorRange(const mrpt::obs::CObserv
 
   // check for NaN, Infinities, etc.: See: https://github.com/MOLAorg/mola_lidar_odometry/issues/10
   if (!std::isnormal(radius)) {
-    MRPT_LOG_WARN_STREAM("NaN bounding box for sensor point cloud. Using default sensor range.");
-    radius = params_.absolute_minimum_sensor_range;
+    MRPT_LOG_WARN_STREAM(
+      "NaN bounding box for observation point cloud. Using default observation radius.");
+    radius = params_.absolute_minimum_observation_radius;
   } else {
-    mrpt::keep_max(radius, params_.absolute_minimum_sensor_range);
+    mrpt::keep_max(radius, params_.absolute_minimum_observation_radius);
   }
 
   maxRange = radius;
 
   MRPT_LOG_DEBUG_STREAM(
-    "Estimated sensor max range=" << *state_.estimated_sensor_max_range
-                                  << " (instantaneous=" << radius << ")");
+    "Estimated observation radius=" << *state_.estimated_observation_radius
+                                    << " (instantaneous=" << radius << ")");
 }
 
-void LidarOdometry::doUpdateEstimatedMaxSensorRange(const mp2p_icp::metric_map_t & m)
+void LidarOdometry::doUpdateEstimatedObservationRadius(const mp2p_icp::metric_map_t & m)
 {
-  const double ALPHA = params_.max_sensor_range_filter_coefficient;
+  const double ALPHA = params_.observation_radius_filter_coefficient;
 
-  auto & maxRange = state_.estimated_sensor_max_range;
+  auto & maxRange = state_.estimated_observation_radius;
   ASSERT_(maxRange.has_value());  // this method is for subsequent calls only
 
   for (const auto & [layerName, layer] : m.layers) {
@@ -239,22 +248,22 @@ void LidarOdometry::doUpdateEstimatedMaxSensorRange(const mp2p_icp::metric_map_t
 
     double radius = std::max(bb.max.norm(), bb.min.norm());
 
-    mrpt::keep_max(radius, params_.absolute_minimum_sensor_range);
+    mrpt::keep_max(radius, params_.absolute_minimum_observation_radius);
 
-    state_.instantaneous_sensor_max_range = radius;
+    state_.instantaneous_observation_radius = radius;
 
     // low-pass filter update:
     maxRange = (maxRange.value() * ALPHA) + (radius * (1.0 - ALPHA));
 
     MRPT_LOG_DEBUG_STREAM(
-      "Estimated sensor max range=" << *state_.estimated_sensor_max_range
-                                    << " (instantaneous=" << radius << ")");
+      "Estimated observation radius=" << *state_.estimated_observation_radius
+                                      << " (instantaneous=" << radius << ")");
 
     // one layer is enough:
     return;
   }
   MRPT_LOG_DEBUG(
-    "Estimated sensor max range could NOT be updated, no points layer "
+    "Estimated observation radius could NOT be updated, no points layer "
     "found in observation metric_map_t");
 }
 

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -833,12 +833,12 @@ void LidarOdometry::updateVisualizationTextLabels()
       "LiDAR=%6.02f Hz | IMU=%6.02f Hz | GNSS=%5.02f Hz", rate_lidar, rate_imu, rate_gnss));
   }
 
-  if (state_.estimated_sensor_max_range) {
+  if (state_.estimated_observation_radius) {
     gui_.lbSensorRange->set(mrpt::format(
-      "Est. max range: %.02f m (inst: %.02f m)", *state_.estimated_sensor_max_range,
-      state_.instantaneous_sensor_max_range ? *state_.instantaneous_sensor_max_range : .0));
+      "Est. obs. radius: %.02f m (inst: %.02f m)", *state_.estimated_observation_radius,
+      state_.instantaneous_observation_radius ? *state_.instantaneous_observation_radius : .0));
   } else {
-    gui_.lbSensorRange->set("Est. max range: (Not available)");
+    gui_.lbSensorRange->set("Est. obs. radius: (Not available)");
   }
 
   {
@@ -879,12 +879,12 @@ void LidarOdometry::updateVisualizationTextLabels()
       "LiDAR=%6.02f Hz | IMU=%6.02f Hz | GNSS=%5.02f Hz", rate_lidar, rate_imu, rate_gnss));
   }
 
-  if (state_.estimated_sensor_max_range) {
+  if (state_.estimated_observation_radius) {
     gui_.lbSensorRange->setCaption(mrpt::format(
-      "Est. max range: %.02f m (inst: %.02f m)", *state_.estimated_sensor_max_range,
-      state_.instantaneous_sensor_max_range ? *state_.instantaneous_sensor_max_range : .0));
+      "Est. obs. radius: %.02f m (inst: %.02f m)", *state_.estimated_observation_radius,
+      state_.instantaneous_observation_radius ? *state_.instantaneous_observation_radius : .0));
   } else {
-    gui_.lbSensorRange->setCaption("Est. max range: (Not available)");
+    gui_.lbSensorRange->setCaption("Est. obs. radius: (Not available)");
   }
 
   {

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -30,6 +30,9 @@
 #include <mp2p_icp/icp_pipeline_from_yaml.h>
 #include <mrpt/system/filesystem.h>
 
+// Std:
+#include <sstream>
+
 namespace mola
 {
 
@@ -55,6 +58,35 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
 
   // make a copy of the initialization, for use in reset()
   lastInitConfig_ = c;
+
+  // One-shot deprecation warning for the legacy *_sensor_* names. Aliases
+  // are still honored (dynamic variables are double-published; the *_sensor_*
+  // YAML param keys fall back via cfg.getOrDefault below), so old pipelines
+  // keep working, but we nudge users to migrate. Scope-limited substring scan
+  // over the serialized config covers embedded pipeline blocks
+  // (observations_deskew_pass, localmap_generator, etc.) without parsing
+  // them again.
+  {
+    std::stringstream ss;
+    ss << c;
+    const std::string serialized = ss.str();
+    const auto found = [&](const char * needle) {
+      return serialized.find(needle) != std::string::npos;
+    };
+    if (
+      found("ESTIMATED_SENSOR_MAX_RANGE") || found("INSTANTANEOUS_SENSOR_MAX_RANGE") ||
+      found("max_sensor_range_filter_coefficient") || found("absolute_minimum_sensor_range")) {
+      MRPT_LOG_WARN(
+        "Your YAML pipeline references one or more deprecated *_sensor_* "
+        "names (ESTIMATED_SENSOR_MAX_RANGE, INSTANTANEOUS_SENSOR_MAX_RANGE, "
+        "max_sensor_range_filter_coefficient, absolute_minimum_sensor_range). "
+        "They are aliases of ESTIMATED_OBSERVATION_RADIUS, "
+        "INSTANTANEOUS_OBSERVATION_RADIUS, observation_radius_filter_coefficient, "
+        "absolute_minimum_observation_radius respectively (all measured from "
+        "base_link, not from the sensor) and will be removed in a future "
+        "release. Please rename references in your pipeline files.");
+    }
+  }
 
   // Load params:
   const auto cfg = c["params"];
@@ -139,8 +171,15 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
 
   YAML_LOAD_OPT(params_, min_time_between_scans, double);
   YAML_LOAD_REQ(params_, min_icp_goodness, double);
-  YAML_LOAD_OPT(params_, max_sensor_range_filter_coefficient, double);
-  YAML_LOAD_OPT(params_, absolute_minimum_sensor_range, double);
+  // Accept the deprecated *_sensor_* keys as fallbacks before reading the new
+  // canonical names, so a YAML that only sets the old key keeps working and a
+  // YAML that sets both lets the new key win.
+  params_.observation_radius_filter_coefficient = cfg.getOrDefault<double>(
+    "max_sensor_range_filter_coefficient", params_.observation_radius_filter_coefficient);
+  params_.absolute_minimum_observation_radius = cfg.getOrDefault<double>(
+    "absolute_minimum_sensor_range", params_.absolute_minimum_observation_radius);
+  YAML_LOAD_OPT(params_, observation_radius_filter_coefficient, double);
+  YAML_LOAD_OPT(params_, absolute_minimum_observation_radius, double);
   YAML_LOAD_OPT(params_, start_active, bool);
 
   YAML_LOAD_OPT(params_, max_lidar_queue_before_drop, uint32_t);

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -120,8 +120,8 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
   state_.last_obs_tim_by_label[obs->sensorLabel] = this_obs_tim;
 
   // Use the observation to update the estimated sensor range:
-  if (!state_.estimated_sensor_max_range.has_value()) {
-    doInitializeEstimatedMaxSensorRange(*obs);
+  if (!state_.estimated_observation_radius.has_value()) {
+    doInitializeEstimatedObservationRadius(*obs);
   }
 
   // Handle multiple simultaneous LIDARs:
@@ -185,7 +185,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
   }
 
   // Update sensor max range from the obs map layers:
-  doUpdateEstimatedMaxSensorRange(*observation);
+  doUpdateEstimatedObservationRadius(*observation);
 
   profiler_.enter("onLidar.2.copy_vars");
 

--- a/pipelines/extras/lidar3d-dual-map.yaml
+++ b/pipelines/extras/lidar3d-dual-map.yaml
@@ -16,7 +16,7 @@ params:
   # How often to update the local map model:
   local_map_updates:
     enabled: "${MOLA_MAPPING_ENABLED|true}"
-    min_translation_between_keyframes: "0.5e-2*ESTIMATED_SENSOR_MAX_RANGE" # [m]
+    min_translation_between_keyframes: "0.5e-2*ESTIMATED_OBSERVATION_RADIUS" # [m]
     min_rotation_between_keyframes: 15.0 # [deg]
 
   # Minimum ICP quality to insert it into the map:
@@ -146,12 +146,12 @@ localmap_generator:
         class: mola::HashedVoxelPointCloud
         plugin: "libmola_metric_maps.so" # Import additional custom user-defined map classes (search in LD_LIBRARY_PATH)
         creationOpts:
-          voxel_size: "$f{max(0.5, 0.01*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+          voxel_size: "$f{max(0.5, 0.01*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
         insertOpts:
           max_points_per_voxel: 20
           min_distance_between_points: 0 # [m]
           # if !=0, remove voxels farther (L1) than the current observation insert point
-          remove_voxels_farther_than: "$f{max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+          remove_voxels_farther_than: "$f{max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
         likelihoodOpts:
           sigma_dist: 1.0 # [m]
           max_corr_distance: 2.0 #[m]
@@ -170,12 +170,12 @@ localmap_generator:
         class: mola::HashedVoxelPointCloud
         plugin: "libmola_metric_maps.so" # Import additional custom user-defined map classes (search in LD_LIBRARY_PATH)
         creationOpts:
-          voxel_size: "$f{max(0.5, 0.01*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+          voxel_size: "$f{max(0.5, 0.01*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
         insertOpts:
           max_points_per_voxel: 10
           min_distance_between_points: 0 # [m]
           # if !=0, remove voxels farther (L1) than the current observation insert point
-          remove_voxels_farther_than: "$f{max(100.0, 1.10*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+          remove_voxels_farther_than: "$f{max(100.0, 1.10*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
         likelihoodOpts:
           sigma_dist: 1.0 # [m]
           max_corr_distance: 2.0 #[m]
@@ -228,8 +228,8 @@ observations_filter_1st_pass:
     params:
       input_pointcloud_layer: "deskewed"
       output_layer_between: "range_filtered"
-      range_min: max(1.0, 0.05*ESTIMATED_SENSOR_MAX_RANGE)
-      range_max: 1.2*ESTIMATED_SENSOR_MAX_RANGE
+      range_min: max(1.0, 0.05*ESTIMATED_OBSERVATION_RADIUS)
+      range_max: 1.2*ESTIMATED_OBSERVATION_RADIUS
 
   # Remove close ceilings (problematic in most cases!)
   - class_name: mp2p_icp_filters::FilterBoundingBox
@@ -238,15 +238,15 @@ observations_filter_1st_pass:
       outside_pointcloud_layer: "filtered"
       bounding_box_min:
         [
-          -0.30*ESTIMATED_SENSOR_MAX_RANGE,
-          -0.30*ESTIMATED_SENSOR_MAX_RANGE,
-          0.05*ESTIMATED_SENSOR_MAX_RANGE,
+          -0.30*ESTIMATED_OBSERVATION_RADIUS,
+          -0.30*ESTIMATED_OBSERVATION_RADIUS,
+          0.05*ESTIMATED_OBSERVATION_RADIUS,
         ]
       bounding_box_max:
         [
-          0.30*ESTIMATED_SENSOR_MAX_RANGE,
-          0.30*ESTIMATED_SENSOR_MAX_RANGE,
-          0.40*ESTIMATED_SENSOR_MAX_RANGE,
+          0.30*ESTIMATED_OBSERVATION_RADIUS,
+          0.30*ESTIMATED_OBSERVATION_RADIUS,
+          0.40*ESTIMATED_OBSERVATION_RADIUS,
         ]
 
   - class_name: mp2p_icp_filters::FilterBoundingBox
@@ -256,39 +256,39 @@ observations_filter_1st_pass:
       outside_pointcloud_layer: "far"
       bounding_box_min:
         [
-          -0.30*ESTIMATED_SENSOR_MAX_RANGE,
-          -0.30*ESTIMATED_SENSOR_MAX_RANGE,
+          -0.30*ESTIMATED_OBSERVATION_RADIUS,
+          -0.30*ESTIMATED_OBSERVATION_RADIUS,
           -1000.0,
         ]
       bounding_box_max:
-        [0.30*ESTIMATED_SENSOR_MAX_RANGE, 0.30*ESTIMATED_SENSOR_MAX_RANGE, -1.0]
+        [0.30*ESTIMATED_OBSERVATION_RADIUS, 0.30*ESTIMATED_OBSERVATION_RADIUS, -1.0]
 
   - class_name: mp2p_icp_filters::FilterDecimateVoxels
     params:
       input_pointcloud_layer: "near"
       output_pointcloud_layer: "decimated_for_icp_near"
-      voxel_filter_resolution: 2.00*1e-2*ESTIMATED_SENSOR_MAX_RANGE # [m]
+      voxel_filter_resolution: 2.00*1e-2*ESTIMATED_OBSERVATION_RADIUS # [m]
       decimate_method: DecimateMethod::FirstPoint
 
   - class_name: mp2p_icp_filters::FilterDecimateVoxels
     params:
       input_pointcloud_layer: "far"
       output_pointcloud_layer: "decimated_for_map_far"
-      voxel_filter_resolution: 1.00*1e-2*ESTIMATED_SENSOR_MAX_RANGE # [m]
+      voxel_filter_resolution: 1.00*1e-2*ESTIMATED_OBSERVATION_RADIUS # [m]
       decimate_method: DecimateMethod::FirstPoint
 
   - class_name: mp2p_icp_filters::FilterDecimateVoxels
     params:
       input_pointcloud_layer: "filtered"
       output_pointcloud_layer: "decimated_for_icp"
-      voxel_filter_resolution: 1.50*1e-2*ESTIMATED_SENSOR_MAX_RANGE # [m]
+      voxel_filter_resolution: 1.50*1e-2*ESTIMATED_OBSERVATION_RADIUS # [m]
       decimate_method: DecimateMethod::FirstPoint
 
   - class_name: mp2p_icp_filters::FilterDecimateVoxels
     params:
       input_pointcloud_layer: "range_filtered"
       output_pointcloud_layer: "decimated_for_map"
-      voxel_filter_resolution: 0.5*1e-2*ESTIMATED_SENSOR_MAX_RANGE # [m]
+      voxel_filter_resolution: 0.5*1e-2*ESTIMATED_OBSERVATION_RADIUS # [m]
       decimate_method: DecimateMethod::FirstPoint
 
   # Remove layers to save memory and log file storage

--- a/pipelines/extras/lidar3d-edges.yaml
+++ b/pipelines/extras/lidar3d-edges.yaml
@@ -16,10 +16,10 @@ params:
   # How often to update the local map model:
   local_map_updates:
     enabled: "${MOLA_MAPPING_ENABLED|true}"
-    min_translation_between_keyframes: "(0.5e-2 + sqrt(WX^2+WY^2+WZ^2)*0.2 )*ESTIMATED_SENSOR_MAX_RANGE" # [m]
+    min_translation_between_keyframes: "(0.5e-2 + sqrt(WX^2+WY^2+WZ^2)*0.2 )*ESTIMATED_OBSERVATION_RADIUS" # [m]
     min_rotation_between_keyframes: 15.0 # [deg]
     # Should match the "remove farther than" option of the local metric map. "0" means deletion of distant key-frames is disabled
-    max_distance_to_keep_keyframes: "max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)" # [m]
+    max_distance_to_keep_keyframes: "max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)" # [m]
     check_for_removal_every_n: 100
 
   # Minimum ICP quality to insert it into the map:
@@ -145,12 +145,12 @@ localmap_generator:
         class: mola::HashedVoxelPointCloud
         plugin: "libmola_metric_maps.so" # Import additional custom user-defined map classes (search in LD_LIBRARY_PATH)
         creationOpts:
-          voxel_size: "$f{max(0.5, 0.01*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+          voxel_size: "$f{max(0.5, 0.01*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
         insertOpts:
           max_points_per_voxel: 20
           min_distance_between_points: 0 # [m]
           # if !=0, remove voxels farther (L1) than the current observation insert point
-          remove_voxels_farther_than: "$f{max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+          remove_voxels_farther_than: "$f{max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
         likelihoodOpts:
           sigma_dist: 1.0 # [m]
           max_corr_distance: 2.0 #[m]
@@ -169,12 +169,12 @@ localmap_generator:
         class: mola::HashedVoxelPointCloud
         plugin: "libmola_metric_maps.so" # Import additional custom user-defined map classes (search in LD_LIBRARY_PATH)
         creationOpts:
-          voxel_size: "$f{max(0.5, 0.01*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+          voxel_size: "$f{max(0.5, 0.01*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
         insertOpts:
           max_points_per_voxel: 10
           min_distance_between_points: 0 # [m]
           # if !=0, remove voxels farther (L1) than the current observation insert point
-          remove_voxels_farther_than: "$f{max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+          remove_voxels_farther_than: "$f{max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
         likelihoodOpts:
           sigma_dist: 1.0 # [m]
           max_corr_distance: 2.0 #[m]
@@ -227,8 +227,8 @@ observations_filter_1st_pass:
     params:
       input_pointcloud_layer: "deskewed"
       output_layer_between: "range_filtered"
-      range_min: max(1.0, 0.05*ESTIMATED_SENSOR_MAX_RANGE)
-      range_max: 1.2*ESTIMATED_SENSOR_MAX_RANGE
+      range_min: max(1.0, 0.05*ESTIMATED_OBSERVATION_RADIUS)
+      range_max: 1.2*ESTIMATED_OBSERVATION_RADIUS
 
   # Remove close ceilings (problematic in most cases!)
   - class_name: mp2p_icp_filters::FilterBoundingBox
@@ -237,15 +237,15 @@ observations_filter_1st_pass:
       outside_pointcloud_layer: "filtered"
       bounding_box_min:
         [
-          -0.30*ESTIMATED_SENSOR_MAX_RANGE,
-          -0.30*ESTIMATED_SENSOR_MAX_RANGE,
-          0.05*ESTIMATED_SENSOR_MAX_RANGE,
+          -0.30*ESTIMATED_OBSERVATION_RADIUS,
+          -0.30*ESTIMATED_OBSERVATION_RADIUS,
+          0.05*ESTIMATED_OBSERVATION_RADIUS,
         ]
       bounding_box_max:
         [
-          0.30*ESTIMATED_SENSOR_MAX_RANGE,
-          0.30*ESTIMATED_SENSOR_MAX_RANGE,
-          0.40*ESTIMATED_SENSOR_MAX_RANGE,
+          0.30*ESTIMATED_OBSERVATION_RADIUS,
+          0.30*ESTIMATED_OBSERVATION_RADIUS,
+          0.40*ESTIMATED_OBSERVATION_RADIUS,
         ]
 
   - class_name: mp2p_icp_filters::FilterCurvature
@@ -262,28 +262,28 @@ observations_filter_1st_pass:
     params:
       input_pointcloud_layer: "large_curvature"
       output_pointcloud_layer: "decimated_for_map_large_curvature"
-      voxel_filter_resolution: 1.0*1e-2*ESTIMATED_SENSOR_MAX_RANGE # [m]
+      voxel_filter_resolution: 1.0*1e-2*ESTIMATED_OBSERVATION_RADIUS # [m]
       decimate_method: DecimateMethod::FirstPoint
 
   - class_name: mp2p_icp_filters::FilterDecimateVoxels
     params:
       input_pointcloud_layer: "decimated_for_map_large_curvature"
       output_pointcloud_layer: "decimated_for_icp_large_curvature"
-      voxel_filter_resolution: 1.5*1e-2*ESTIMATED_SENSOR_MAX_RANGE # [m]
+      voxel_filter_resolution: 1.5*1e-2*ESTIMATED_OBSERVATION_RADIUS # [m]
       decimate_method: DecimateMethod::FirstPoint
 
   - class_name: mp2p_icp_filters::FilterDecimateVoxels
     params:
       input_pointcloud_layer: "smaller_curvature"
       output_pointcloud_layer: "decimated_for_map_smaller_curvature"
-      voxel_filter_resolution: 0.5*1e-2*ESTIMATED_SENSOR_MAX_RANGE # [m]
+      voxel_filter_resolution: 0.5*1e-2*ESTIMATED_OBSERVATION_RADIUS # [m]
       decimate_method: DecimateMethod::FirstPoint
 
   - class_name: mp2p_icp_filters::FilterDecimateVoxels
     params:
       input_pointcloud_layer: "decimated_for_map_smaller_curvature"
       output_pointcloud_layer: "decimated_for_icp_smaller_curvature"
-      voxel_filter_resolution: 2.0*1e-2*ESTIMATED_SENSOR_MAX_RANGE # [m]
+      voxel_filter_resolution: 2.0*1e-2*ESTIMATED_OBSERVATION_RADIUS # [m]
       decimate_method: DecimateMethod::FirstPoint
 
   # Remove layers to save memory and log file storage

--- a/pipelines/extras/rgbd.yaml
+++ b/pipelines/extras/rgbd.yaml
@@ -22,8 +22,8 @@ params:
   min_time_between_scans: 1e-3 # [seconds]
 
   # Parameters for max sensor range automatic estimation:
-  max_sensor_range_filter_coefficient: 0.999
-  absolute_minimum_sensor_range: 10.0
+  observation_radius_filter_coefficient: 0.999
+  absolute_minimum_observation_radius: 10.0
 
   # When publishing pose updates, the reference frame for both, estimated robot poses, and the local map.
   publish_reference_frame: "${MOLA_LO_PUBLISH_REF_FRAME|odom}"
@@ -34,10 +34,10 @@ params:
   # How often to update the local map model:
   local_map_updates:
     enabled: "${MOLA_MAPPING_ENABLED|true}"
-    min_translation_between_keyframes: "${MOLA_MIN_XYZ_BETWEEN_MAP_UPDATES|(0.03 + sqrt(WX^2+WY^2+WZ^2)*0.1)*ESTIMATED_SENSOR_MAX_RANGE}" # [m]
+    min_translation_between_keyframes: "${MOLA_MIN_XYZ_BETWEEN_MAP_UPDATES|(0.03 + sqrt(WX^2+WY^2+WZ^2)*0.1)*ESTIMATED_OBSERVATION_RADIUS}" # [m]
     min_rotation_between_keyframes: 15.0 # [deg]
     # Should match the "remove farther than" option of the local metric map. "0" means deletion of distant key-frames is disabled
-    max_distance_to_keep_keyframes: "max(50.0, 2.50*ESTIMATED_SENSOR_MAX_RANGE)" # [m]
+    max_distance_to_keep_keyframes: "max(50.0, 2.50*ESTIMATED_OBSERVATION_RADIUS)" # [m]
     check_for_removal_every_n: 100
 
   # Minimum ICP quality to insert it into the map:
@@ -167,12 +167,12 @@ localmap_generator:
         class: mola::HashedVoxelPointCloud
         plugin: "libmola_metric_maps.so" # Import additional custom user-defined map classes (search in LD_LIBRARY_PATH)
         creationOpts:
-          voxel_size: "$f{max(0.05, min(0.5, 0.10*ESTIMATED_SENSOR_MAX_RANGE))}" # [m]
+          voxel_size: "$f{max(0.05, min(0.5, 0.10*ESTIMATED_OBSERVATION_RADIUS))}" # [m]
         insertOpts:
           max_points_per_voxel: 20
           min_distance_between_points: 0 # [m]
           # if !=0, remove voxels farther (L1) than the current observation insert point
-          remove_voxels_farther_than: "$f{max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+          remove_voxels_farther_than: "$f{max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
         likelihoodOpts:
           sigma_dist: 1.0 # [m]
           max_corr_distance: 2.0 #[m]
@@ -191,11 +191,11 @@ localmap_generator:
         class: mola::SparseTreesPointCloud
         plugin: "libmola_metric_maps.so" # Import additional custom user-defined map classes (search in LD_LIBRARY_PATH)
         creationOpts:
-          grid_size: "$f{max(1.0, min(5.0, 0.10*ESTIMATED_SENSOR_MAX_RANGE))}" # [m]
+          grid_size: "$f{max(1.0, min(5.0, 0.10*ESTIMATED_OBSERVATION_RADIUS))}" # [m]
         insertOpts:
           minimum_points_clearance: 0 # [m]
           # if !=0, remove voxels farther (L1) than the current observation insert point
-          remove_submaps_farther_than: "$f{max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+          remove_submaps_farther_than: "$f{max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
         likelihoodOpts:
           sigma_dist: 1.0 # [m]
           max_corr_distance: 2.0 #[m]

--- a/pipelines/lidar2d.yaml
+++ b/pipelines/lidar2d.yaml
@@ -29,8 +29,8 @@ params:
   min_time_between_scans: 1e-3 # [seconds]
 
   # Parameters for max sensor range automatic estimation:
-  max_sensor_range_filter_coefficient: 0.999
-  absolute_minimum_sensor_range: 20.0
+  observation_radius_filter_coefficient: 0.999
+  absolute_minimum_observation_radius: 20.0
 
   # When publishing pose updates, the reference frame for both, estimated robot poses, and the local map.
   publish_reference_frame: "${MOLA_LO_PUBLISH_REF_FRAME|odom}"
@@ -42,10 +42,10 @@ params:
   local_map_updates:
     enabled: "${MOLA_MAPPING_ENABLED|true}"
     load_existing_local_map: ${MOLA_LOAD_MM|""}
-    min_translation_between_keyframes: "${MOLA_MIN_XYZ_BETWEEN_MAP_UPDATES|0.02*ESTIMATED_SENSOR_MAX_RANGE}" # [m]
+    min_translation_between_keyframes: "${MOLA_MIN_XYZ_BETWEEN_MAP_UPDATES|0.02*ESTIMATED_OBSERVATION_RADIUS}" # [m]
     min_rotation_between_keyframes: 15.0 # [deg]
     # Should match the "remove farther than" option of the local metric map. "0" means deletion of distant key-frames is disabled
-    max_distance_to_keep_keyframes: "max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)" # [m]
+    max_distance_to_keep_keyframes: "max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)" # [m]
     check_for_removal_every_n: 100
 
   # Minimum ICP quality to insert it into the map:
@@ -174,7 +174,7 @@ localmap_generator:
         class: mrpt::maps::CVoxelMap
         #plugin: 'libmola_metric_maps.so' # Import additional custom user-defined map classes (search in LD_LIBRARY_PATH)
         creationOpts:
-          resolution: 0.05 # '$f{max(0.05, min(1.0, 0.005*ESTIMATED_SENSOR_MAX_RANGE))}' # [m]
+          resolution: 0.05 # '$f{max(0.05, min(1.0, 0.005*ESTIMATED_OBSERVATION_RADIUS))}' # [m]
         insertOpts:
           prob_miss: 0.30
           prob_hit: 0.70
@@ -242,8 +242,8 @@ observations_filter_1st_pass:
     params:
       input_pointcloud_layer: "decimated_pre"
       output_layer_between: "decimated"
-      range_min: max(0.10, 0.03*ESTIMATED_SENSOR_MAX_RANGE)
-      range_max: 1.25*ESTIMATED_SENSOR_MAX_RANGE
+      range_min: max(0.10, 0.03*ESTIMATED_OBSERVATION_RADIUS)
+      range_max: 1.25*ESTIMATED_OBSERVATION_RADIUS
 
   # Remove layers to save memory and log file storage
   - class_name: mp2p_icp_filters::FilterDeleteLayer

--- a/pipelines/lidar3d-gicp-optimize-twist.yaml
+++ b/pipelines/lidar3d-gicp-optimize-twist.yaml
@@ -30,8 +30,8 @@ params:
   min_time_between_scans: 1e-3 # [seconds]
 
   # Parameters for max sensor range automatic estimation:
-  max_sensor_range_filter_coefficient: 0.95
-  absolute_minimum_sensor_range: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  observation_radius_filter_coefficient: 0.95
+  absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion without an IMU.
@@ -57,11 +57,11 @@ params:
     save_final_local_map: ${MOLA_SAVE_MM|""} # If not empty, saves the final local metric map to a ".mm" file
 
     # Idea: don't integrate scans with a high rotational speed since they are probably not correctly deskewed:
-    min_translation_between_keyframes: "${MOLA_MIN_XYZ_BETWEEN_MAP_UPDATES|(0.1e-2 + sqrt(wx^2+wy^2+wz^2)*0.1)*ESTIMATED_SENSOR_MAX_RANGE}" # [m]
+    min_translation_between_keyframes: "${MOLA_MIN_XYZ_BETWEEN_MAP_UPDATES|(0.1e-2 + sqrt(wx^2+wy^2+wz^2)*0.1)*ESTIMATED_OBSERVATION_RADIUS}" # [m]
     min_rotation_between_keyframes: "${MOLA_MIN_ROT_BETWEEN_MAP_UPDATES|(15 + sqrt(wx^2+wy^2+wz^2)*500 )}" # [deg]
 
     # Should match the "remove farther than" option of the local metric map. "0" means deletion of distant key-frames is disabled
-    max_distance_to_keep_keyframes: "${MOLA_LOCAL_MAP_MAX_SIZE|max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+    max_distance_to_keep_keyframes: "${MOLA_LOCAL_MAP_MAX_SIZE|max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
     check_for_removal_every_n: 100
     publish_map_updates_every_n: ${MOLA_PUBLISH_LOCAL_MAP_UPDATES_EVERY_N|40}
 
@@ -86,7 +86,7 @@ params:
 
     save_final_map_to_file: ${MOLA_SIMPLEMAP_OUTPUT|'final_map.simplemap'}
 
-    min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*1.0)*ESTIMATED_SENSOR_MAX_RANGE} # m
+    min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*1.0)*ESTIMATED_OBSERVATION_RADIUS} # m
     min_rotation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_ROT|15 + sqrt(wx^2+wy^2+wz^2)*500} # deg
 
     generate_lazy_load_scan_files: ${MOLA_SIMPLEMAP_GENERATE_LAZY_LOAD|false} # If enabled, a directory will be create alongside the .simplemap and pointclouds will be externally serialized there.
@@ -257,7 +257,7 @@ localmap_generator:
           max_search_keyframes: 3
           k_correspondences_for_cov: 20
         insertOpts:
-          remove_frames_farther_than: "${MOLA_LOCAL_MAP_MAX_SIZE|$f{max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)}}" # [m]
+          remove_frames_farther_than: "${MOLA_LOCAL_MAP_MAX_SIZE|$f{max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}}" # [m]
         likelihoodOpts: ~ # none required
         renderOpts:
           color.A: 0.25 # [0,1] Use this alpha value for points, RGB from colormap
@@ -344,8 +344,8 @@ observations_filter_1st_pass:
     params:
       input_pointcloud_layer: "decimated_unfiltered"
       output_layer_between: "decimated_skewed_for_map"
-      range_min: "${MOLA_MINIMUM_RANGE_FILTER|max(1.0, 0.03*ESTIMATED_SENSOR_MAX_RANGE)}"
-      range_max: 1.2*ESTIMATED_SENSOR_MAX_RANGE
+      range_min: "${MOLA_MINIMUM_RANGE_FILTER|max(1.0, 0.03*ESTIMATED_OBSERVATION_RADIUS)}"
+      range_max: 1.2*ESTIMATED_OBSERVATION_RADIUS
       metric_l_infinity: true
 
   - class_name: mp2p_icp_filters::FilterDecimateAdaptive
@@ -432,8 +432,8 @@ observations_filter_deskew_for_visualization:
     params:
       input_pointcloud_layer: "raw"
       output_layer_between: "raw_filtered"
-      range_min: "${MOLA_MINIMUM_RANGE_FILTER|max(1.0, 0.03*ESTIMATED_SENSOR_MAX_RANGE)}"
-      range_max: 1.2*ESTIMATED_SENSOR_MAX_RANGE
+      range_min: "${MOLA_MINIMUM_RANGE_FILTER|max(1.0, 0.03*ESTIMATED_OBSERVATION_RADIUS)}"
+      range_max: 1.2*ESTIMATED_OBSERVATION_RADIUS
       metric_l_infinity: true
 
   - class_name: mp2p_icp_filters::FilterDeskew

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -29,8 +29,8 @@ params:
   min_time_between_scans: 1e-3 # [seconds]
 
   # Parameters for max sensor range automatic estimation:
-  max_sensor_range_filter_coefficient: 0.95
-  absolute_minimum_sensor_range: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  observation_radius_filter_coefficient: 0.95
+  absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion without an IMU.
@@ -63,11 +63,11 @@ params:
     save_final_local_map: ${MOLA_SAVE_MM|""} # If not empty, saves the final local metric map to a ".mm" file
 
     # Idea: don't integrate scans with a high rotational speed since they are probably not correctly deskewed:
-    min_translation_between_keyframes: "${MOLA_MIN_XYZ_BETWEEN_MAP_UPDATES|(0.1e-2 + sqrt(wx^2+wy^2+wz^2)*0.1)*ESTIMATED_SENSOR_MAX_RANGE}" # [m]
+    min_translation_between_keyframes: "${MOLA_MIN_XYZ_BETWEEN_MAP_UPDATES|(0.1e-2 + sqrt(wx^2+wy^2+wz^2)*0.1)*ESTIMATED_OBSERVATION_RADIUS}" # [m]
     min_rotation_between_keyframes: "${MOLA_MIN_ROT_BETWEEN_MAP_UPDATES|(15 + sqrt(wx^2+wy^2+wz^2)*500 )}" # [deg]
 
     # Should match the "remove farther than" option of the local metric map. "0" means deletion of distant key-frames is disabled
-    max_distance_to_keep_keyframes: "${MOLA_LOCAL_MAP_MAX_SIZE|max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+    max_distance_to_keep_keyframes: "${MOLA_LOCAL_MAP_MAX_SIZE|max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
     check_for_removal_every_n: 100
     publish_map_updates_every_n: ${MOLA_PUBLISH_LOCAL_MAP_UPDATES_EVERY_N|40}
 
@@ -107,7 +107,7 @@ params:
 
     save_final_map_to_file: ${MOLA_SIMPLEMAP_OUTPUT|'final_map.simplemap'}
 
-    min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*1.0)*ESTIMATED_SENSOR_MAX_RANGE} # m
+    min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*1.0)*ESTIMATED_OBSERVATION_RADIUS} # m
     min_rotation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_ROT|15 + sqrt(wx^2+wy^2+wz^2)*500} # deg
 
     generate_lazy_load_scan_files: ${MOLA_SIMPLEMAP_GENERATE_LAZY_LOAD|false} # If enabled, a directory will be create alongside the .simplemap and pointclouds will be externally serialized there.
@@ -287,7 +287,7 @@ localmap_generator:
           rotation_distance_weight: 2.0
           num_diverse_keyframes: ${MOLA_LOCALMAP_DIVERSE_KEYFRAMES|1} # Must be < max_search_keyframes
         insertOpts:
-          remove_frames_farther_than: "${MOLA_LOCAL_MAP_MAX_SIZE|$f{max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)}}" # [m]
+          remove_frames_farther_than: "${MOLA_LOCAL_MAP_MAX_SIZE|$f{max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}}" # [m]
         likelihoodOpts: ~ # none required
         renderOpts:
           color.A: 0.25 # [0,1] Use this alpha value for points, RGB from colormap
@@ -356,14 +356,22 @@ observations_prefilter_file: ${MOLA_LO_OBS_PREFILTER_PIPELINE_FILE|""}
 # Runs once; result is reused for decimation, viz, publish, simplemap.
 # Skipped at runtime when !hasIMU && optimize_twist (fallback to 2nd-pass deskew).
 observations_deskew_pass:
-  # Remove points too close, to prevent "noise" from the vehicle,
-  # the person next to the robot, etc.
+  # Drop near returns to remove "noise" from the vehicle body, a person
+  # standing next to the robot (e.g. with a joystick), etc., and clamp
+  # very far returns where small angular errors blow up into large
+  # translational errors. metric_l_infinity → axis-aligned cube; center
+  # is unset → anchored at base_link (the vehicle origin), *not* at the
+  # sensor — this is intentional so the deadzone covers the whole
+  # vehicle footprint regardless of where the sensor is mounted on it.
+  # If you also need a sensor-anchored cut (e.g. the sensor's blind
+  # sphere when it is mounted significantly off base_link), add an
+  # extra filter via observations_prefilter_file.
   - class_name: mp2p_icp_filters::FilterByRange
     params:
       input_pointcloud_layer: "raw"
       output_layer_between: "raw_range_filtered"
-      range_min: "${MOLA_MINIMUM_RANGE_FILTER|max(1.0, 0.03*ESTIMATED_SENSOR_MAX_RANGE)}"
-      range_max: 1.2*ESTIMATED_SENSOR_MAX_RANGE
+      range_min: "${MOLA_MINIMUM_RANGE_FILTER|max(1.0, 0.03*ESTIMATED_OBSERVATION_RADIUS)}"
+      range_max: 1.2*ESTIMATED_OBSERVATION_RADIUS
       metric_l_infinity: true
 
   - class_name: mp2p_icp_filters::FilterDeskew
@@ -444,8 +452,8 @@ observations_filter_deskew_for_visualization:
     params:
       input_pointcloud_layer: "raw"
       output_layer_between: "raw_filtered"
-      range_min: "${MOLA_MINIMUM_RANGE_FILTER|max(1.0, 0.03*ESTIMATED_SENSOR_MAX_RANGE)}"
-      range_max: 1.2*ESTIMATED_SENSOR_MAX_RANGE
+      range_min: "${MOLA_MINIMUM_RANGE_FILTER|max(1.0, 0.03*ESTIMATED_OBSERVATION_RADIUS)}"
+      range_max: 1.2*ESTIMATED_OBSERVATION_RADIUS
       metric_l_infinity: true
 
   - class_name: mp2p_icp_filters::FilterDeskew

--- a/pipelines/lidar3d-icp.yaml
+++ b/pipelines/lidar3d-icp.yaml
@@ -29,8 +29,8 @@ params:
   min_time_between_scans: 1e-3 # [seconds]
 
   # Parameters for max sensor range automatic estimation:
-  max_sensor_range_filter_coefficient: 0.95
-  absolute_minimum_sensor_range: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  observation_radius_filter_coefficient: 0.95
+  absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion.
@@ -56,11 +56,11 @@ params:
     save_final_local_map: ${MOLA_SAVE_MM|""} # If not empty, saves the final local metric map to a ".mm" file
 
     # Idea: don't integrate scans with a high rotational speed since they are probably not correctly deskewed:
-    min_translation_between_keyframes: "${MOLA_MIN_XYZ_BETWEEN_MAP_UPDATES|(0.1e-2 + sqrt(wx^2+wy^2+wz^2)*0.1)*ESTIMATED_SENSOR_MAX_RANGE}" # [m]
+    min_translation_between_keyframes: "${MOLA_MIN_XYZ_BETWEEN_MAP_UPDATES|(0.1e-2 + sqrt(wx^2+wy^2+wz^2)*0.1)*ESTIMATED_OBSERVATION_RADIUS}" # [m]
     min_rotation_between_keyframes: "${MOLA_MIN_ROT_BETWEEN_MAP_UPDATES|(15 + sqrt(wx^2+wy^2+wz^2)*500 )}" # [deg]
 
     # Should match the "remove farther than" option of the local metric map. "0" means deletion of distant key-frames is disabled
-    max_distance_to_keep_keyframes: "${MOLA_LOCAL_MAP_MAX_SIZE|max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+    max_distance_to_keep_keyframes: "${MOLA_LOCAL_MAP_MAX_SIZE|max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
     check_for_removal_every_n: 100
     publish_map_updates_every_n: ${MOLA_PUBLISH_LOCAL_MAP_UPDATES_EVERY_N|5}
 
@@ -84,7 +84,7 @@ params:
 
     save_final_map_to_file: ${MOLA_SIMPLEMAP_OUTPUT|'final_map.simplemap'}
 
-    min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*1.0)*ESTIMATED_SENSOR_MAX_RANGE} # m
+    min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*1.0)*ESTIMATED_OBSERVATION_RADIUS} # m
     min_rotation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_ROT|15 + sqrt(wx^2+wy^2+wz^2)*500} # deg
 
     generate_lazy_load_scan_files: ${MOLA_SIMPLEMAP_GENERATE_LAZY_LOAD|false} # If enabled, a directory will be create alongside the .simplemap and pointclouds will be externally serialized there.
@@ -248,12 +248,12 @@ localmap_generator:
         class: mola::HashedVoxelPointCloud
         plugin: "libmola_metric_maps.so" # Import additional custom user-defined map classes (search in LD_LIBRARY_PATH)
         creationOpts:
-          voxel_size: "${MOLA_LOCAL_VOXELMAP_RESOLUTION|$f{max(0.5, min(1.0, 0.015*ESTIMATED_SENSOR_MAX_RANGE))}}" # [m]
+          voxel_size: "${MOLA_LOCAL_VOXELMAP_RESOLUTION|$f{max(0.5, min(1.0, 0.015*ESTIMATED_OBSERVATION_RADIUS))}}" # [m]
         insertOpts:
           max_points_per_voxel: ${MOLA_LOCALMAP_MAX_POINTS_PER_VOXEL|20}
           min_distance_between_points: 0 # [m]
           # if !=0, remove voxels farther (L1) than the current observation insert point
-          remove_voxels_farther_than: "${MOLA_LOCAL_MAP_MAX_SIZE|$f{max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)}}" # [m]
+          remove_voxels_farther_than: "${MOLA_LOCAL_MAP_MAX_SIZE|$f{max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}}" # [m]
         likelihoodOpts:
           sigma_dist: 1.0 # [m]
           max_corr_distance: 2.0 #[m]
@@ -309,7 +309,7 @@ observations_filter_1st_pass:
     params:
       input_pointcloud_layer: "raw"
       output_pointcloud_layer: "decimated_for_map_raw"
-      voxel_filter_resolution: "${MOLA_MAP_CLOUD_DECIMATION|max(0.20, 0.55*1e-2*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+      voxel_filter_resolution: "${MOLA_MAP_CLOUD_DECIMATION|max(0.20, 0.55*1e-2*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
       minimum_input_points_to_filter: 2000 # don't decimate if smaller than this size
       decimate_method: DecimateMethod::FirstPoint
       #decimate_method: DecimateMethod::ClosestToAverage
@@ -321,8 +321,8 @@ observations_filter_1st_pass:
     params:
       input_pointcloud_layer: "decimated_for_map_raw"
       output_layer_between: "decimated_for_map_by_range"
-      range_min: "${MOLA_MINIMUM_RANGE_FILTER|max(1.0, 0.03*ESTIMATED_SENSOR_MAX_RANGE)}"
-      range_max: 1.2*ESTIMATED_SENSOR_MAX_RANGE
+      range_min: "${MOLA_MINIMUM_RANGE_FILTER|max(1.0, 0.03*ESTIMATED_OBSERVATION_RADIUS)}"
+      range_max: 1.2*ESTIMATED_OBSERVATION_RADIUS
       metric_l_infinity: true
 
   # Remove close ceilings (problematic in most cases!)
@@ -332,22 +332,22 @@ observations_filter_1st_pass:
       outside_pointcloud_layer: "decimated_for_map_skewed"
       bounding_box_min:
         [
-          -0.20*INSTANTANEOUS_SENSOR_MAX_RANGE,
-          -0.20*INSTANTANEOUS_SENSOR_MAX_RANGE,
-          0.01*INSTANTANEOUS_SENSOR_MAX_RANGE,
+          -0.20*INSTANTANEOUS_OBSERVATION_RADIUS,
+          -0.20*INSTANTANEOUS_OBSERVATION_RADIUS,
+          0.01*INSTANTANEOUS_OBSERVATION_RADIUS,
         ]
       bounding_box_max:
         [
-          0.20*INSTANTANEOUS_SENSOR_MAX_RANGE,
-          0.20*INSTANTANEOUS_SENSOR_MAX_RANGE,
-          0.10*INSTANTANEOUS_SENSOR_MAX_RANGE,
+          0.20*INSTANTANEOUS_OBSERVATION_RADIUS,
+          0.20*INSTANTANEOUS_OBSERVATION_RADIUS,
+          0.10*INSTANTANEOUS_OBSERVATION_RADIUS,
         ]
 
   - class_name: mp2p_icp_filters::FilterDecimateVoxels
     params:
       input_pointcloud_layer: "decimated_for_map_skewed"
       output_pointcloud_layer: "decimated_for_icp_skewed"
-      voxel_filter_resolution: "${MOLA_ICP_CLOUD_DECIMATION|max(0.60, 1.6*1e-2*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+      voxel_filter_resolution: "${MOLA_ICP_CLOUD_DECIMATION|max(0.60, 1.6*1e-2*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
       minimum_input_points_to_filter: 2000 # don't decimate if smaller than this size
       decimate_method: DecimateMethod::FirstPoint
       #decimate_method: DecimateMethod::ClosestToAverage
@@ -417,8 +417,8 @@ observations_filter_deskew_for_visualization:
     params:
       input_pointcloud_layer: "raw"
       output_layer_between: "raw_filtered"
-      range_min: "${MOLA_MINIMUM_RANGE_FILTER|max(1.0, 0.03*ESTIMATED_SENSOR_MAX_RANGE)}"
-      range_max: 1.2*ESTIMATED_SENSOR_MAX_RANGE
+      range_min: "${MOLA_MINIMUM_RANGE_FILTER|max(1.0, 0.03*ESTIMATED_OBSERVATION_RADIUS)}"
+      range_max: 1.2*ESTIMATED_OBSERVATION_RADIUS
       metric_l_infinity: true
 
   - class_name: mp2p_icp_filters::FilterDeskew

--- a/pipelines/lidar3d-ndt.yaml
+++ b/pipelines/lidar3d-ndt.yaml
@@ -29,8 +29,8 @@ params:
   min_time_between_scans: 1e-3 # [seconds]
 
   # Parameters for max sensor range automatic estimation:
-  max_sensor_range_filter_coefficient: 0.95
-  absolute_minimum_sensor_range: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  observation_radius_filter_coefficient: 0.95
+  absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion.
@@ -51,11 +51,11 @@ params:
     load_existing_local_map: ${MOLA_LOAD_MM|""}
 
     # Idea: don't integrate scans with a high rotational speed since they are probably not correctly deskewed:
-    min_translation_between_keyframes: "${MOLA_MIN_XYZ_BETWEEN_MAP_UPDATES|(0.1e-2 + sqrt(wx^2+wy^2+wz^2)*0.1)*ESTIMATED_SENSOR_MAX_RANGE}" # [m]
+    min_translation_between_keyframes: "${MOLA_MIN_XYZ_BETWEEN_MAP_UPDATES|(0.1e-2 + sqrt(wx^2+wy^2+wz^2)*0.1)*ESTIMATED_OBSERVATION_RADIUS}" # [m]
     min_rotation_between_keyframes: "${MOLA_MIN_ROT_BETWEEN_MAP_UPDATES|(15 + sqrt(wx^2+wy^2+wz^2)*500 )}" # [deg]
 
     # Should match the "remove farther than" option of the local metric map. "0" means deletion of distant key-frames is disabled
-    max_distance_to_keep_keyframes: "${MOLA_LOCAL_MAP_MAX_SIZE|max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)}" # [m]
+    max_distance_to_keep_keyframes: "${MOLA_LOCAL_MAP_MAX_SIZE|max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
     check_for_removal_every_n: 100
 
   # Minimum ICP quality to insert it into the map:
@@ -78,7 +78,7 @@ params:
 
     save_final_map_to_file: ${MOLA_SIMPLEMAP_OUTPUT|'final_map.simplemap'}
 
-    min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*1.0)*ESTIMATED_SENSOR_MAX_RANGE} # m
+    min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*1.0)*ESTIMATED_OBSERVATION_RADIUS} # m
     min_rotation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_ROT|15 + sqrt(wx^2+wy^2+wz^2)*500} # deg
 
     generate_lazy_load_scan_files: ${MOLA_SIMPLEMAP_GENERATE_LAZY_LOAD|false} # If enabled, a directory will be create alongside the .simplemap and pointclouds will be externally serialized there.
@@ -227,12 +227,12 @@ localmap_generator:
         plugin: "libmola_metric_maps.so" # Import additional custom user-defined map classes (search in LD_LIBRARY_PATH)
         creationOpts:
           #voxel_size: '${MOLA_LOCAL_VOXELMAP_RESOLUTION|2.0}' # [m]
-          voxel_size: "${MOLA_LOCAL_VOXELMAP_RESOLUTION|$f{max(0.5, min(2.5, 0.75*ESTIMATED_SENSOR_MAX_RANGE))}}" # [m]
+          voxel_size: "${MOLA_LOCAL_VOXELMAP_RESOLUTION|$f{max(0.5, min(2.5, 0.75*ESTIMATED_OBSERVATION_RADIUS))}}" # [m]
         insertOpts:
           max_points_per_voxel: ${MOLA_LOCALMAP_MAX_POINTS_PER_VOXEL|0}
           min_distance_between_points: "$f{${MOLA_LOCAL_VOXELMAP_RESOLUTION|2.0}*0.1}" # [m]
           # if !=0, remove voxels farther (L1) than the current observation insert point
-          remove_voxels_farther_than: "${MOLA_LOCAL_MAP_MAX_SIZE|$f{max(100.0, 1.50*ESTIMATED_SENSOR_MAX_RANGE)}}" # [m]
+          remove_voxels_farther_than: "${MOLA_LOCAL_MAP_MAX_SIZE|$f{max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}}" # [m]
           # Max ratio between eigenvalues for considering an NDT a plane:
           max_eigen_ratio_for_planes: 0.05
         likelihoodOpts:
@@ -291,7 +291,7 @@ observations_filter_1st_pass:
     params:
       input_pointcloud_layer: "raw"
       output_pointcloud_layer: "decimated_for_map_raw"
-      voxel_filter_resolution: max(0.10, 0.10*1e-2*ESTIMATED_SENSOR_MAX_RANGE) # [m]
+      voxel_filter_resolution: max(0.10, 0.10*1e-2*ESTIMATED_OBSERVATION_RADIUS) # [m]
       minimum_input_points_to_filter: 2000 # don't decimate if smaller than this size
       decimate_method: DecimateMethod::FirstPoint
       #decimate_method: DecimateMethod::ClosestToAverage
@@ -303,8 +303,8 @@ observations_filter_1st_pass:
     params:
       input_pointcloud_layer: "decimated_for_map_raw"
       output_layer_between: "decimated_for_map_by_range"
-      range_min: "${MOLA_MINIMUM_RANGE_FILTER|max(1.0, 0.03*ESTIMATED_SENSOR_MAX_RANGE)}"
-      range_max: 1.2*ESTIMATED_SENSOR_MAX_RANGE
+      range_min: "${MOLA_MINIMUM_RANGE_FILTER|max(1.0, 0.03*ESTIMATED_OBSERVATION_RADIUS)}"
+      range_max: 1.2*ESTIMATED_OBSERVATION_RADIUS
 
   # Remove close ceilings (problematic in most cases!)
   - class_name: mp2p_icp_filters::FilterBoundingBox
@@ -313,22 +313,22 @@ observations_filter_1st_pass:
       outside_pointcloud_layer: "decimated_for_map_skewed"
       bounding_box_min:
         [
-          -0.20*INSTANTANEOUS_SENSOR_MAX_RANGE,
-          -0.20*INSTANTANEOUS_SENSOR_MAX_RANGE,
-          0.01*INSTANTANEOUS_SENSOR_MAX_RANGE,
+          -0.20*INSTANTANEOUS_OBSERVATION_RADIUS,
+          -0.20*INSTANTANEOUS_OBSERVATION_RADIUS,
+          0.01*INSTANTANEOUS_OBSERVATION_RADIUS,
         ]
       bounding_box_max:
         [
-          0.20*INSTANTANEOUS_SENSOR_MAX_RANGE,
-          0.20*INSTANTANEOUS_SENSOR_MAX_RANGE,
-          0.10*INSTANTANEOUS_SENSOR_MAX_RANGE,
+          0.20*INSTANTANEOUS_OBSERVATION_RADIUS,
+          0.20*INSTANTANEOUS_OBSERVATION_RADIUS,
+          0.10*INSTANTANEOUS_OBSERVATION_RADIUS,
         ]
 
   - class_name: mp2p_icp_filters::FilterDecimateVoxels
     params:
       input_pointcloud_layer: "decimated_for_map_skewed"
       output_pointcloud_layer: "decimated_for_icp_skewed"
-      voxel_filter_resolution: max(0.60, 0.20*1e-2*ESTIMATED_SENSOR_MAX_RANGE) # [m]
+      voxel_filter_resolution: max(0.60, 0.20*1e-2*ESTIMATED_OBSERVATION_RADIUS) # [m]
       minimum_input_points_to_filter: 2000 # don't decimate if smaller than this size
       decimate_method: DecimateMethod::FirstPoint
       #decimate_method: DecimateMethod::ClosestToAverage


### PR DESCRIPTION
## Summary

After the per-observation `mp2p_icp_filters::Generator` runs, the `raw` layer is in **base_link** frame, because `apply_generators` is called without a `robotPose` so points get transformed by `sensorPose`. Two sensor-named quantities are then computed/used in vehicle frame as a side effect:

- `ESTIMATED_SENSOR_MAX_RANGE` is the bbox radius of that vehicle-frame cloud (`module/src/LidarOdometry_AdaptiveVariables.cpp`). For any sensor mounted off `base_link`, this overstates the sensor's true reach.
- `FilterByRange` in the canonical pipelines leaves `center` at the default `(0,0,0)` — i.e. `base_link`. Combined with `metric_l_infinity: true` this is an L∞ cube around the vehicle origin, not a sphere/cube around the sensor: the lidar's true blind sphere is not cut, and depending on geometry, real returns close to the sensor can be kept while real returns close to `base_link` get dropped.

This PR makes both quantities mean what their name says:

1. `doInitializeEstimatedMaxSensorRange` and `doUpdateEstimatedMaxSensorRange` route through a small helper that runs a throwaway `Generator` with `robotPose = -CPose3D(o.sensorPose())`, so the bbox radius is computed in the sensor's own frame. The update path now takes the raw `CObservation` directly instead of inferring from the post-Generator `metric_map_t` (the metric-map-only path can't recover sensor frame after the fact).
2. New per-observation dynamic variables `sensor_x`, `sensor_y`, `sensor_z`, `sensor_yaw`, `sensor_pitch`, `sensor_roll` are exposed in `observationFromRawSensor()`, mirroring the existing `SENSOR_TIME_OFFSET` / `robot_*` patterns. Defaults are seeded via `ensureVarIsDefined` so YAML pipelines that reference them work even before the first observation arrives.
3. Every `FilterByRange` block in the canonical pipelines (`lidar3d-default` / `lidar3d-gicp`, `lidar3d-icp`, `lidar3d-ndt`, `lidar3d-gicp-optimize-twist`, `lidar2d`, `extras/lidar3d-edges`, `extras/lidar3d-dual-map`, `extras/lidar3d-kissicp-like`) gains `center: [sensor_x, sensor_y, sensor_z]`. Inline comments are rewritten to reflect that the deadzone now cuts the sensor's blind sphere; vehicle-anchored noise (vehicle body, person-next-to-the-robot, etc.) should be a separate filter anchored on `robot_x/y/z`.
4. CHANGELOG entry. No behavior change for setups whose `sensorPose` is identity (KITTI, MulRan).

Note that `mp2p_icp_filters::FilterBoundingBox` already supports parameterized `bounding_box_min/max` via `parseAndDeclareParameter`, so users can write e.g. `[\"sensor_x\", \"sensor_y\", \"sensor_z\"]`-style coords if they want a sensor-anchored half-space cut. No code change needed there.

## Known limitation, out of scope here

For multi-LiDAR configurations with non-identical `sensorPose`, the post-merge filters can only see one sensor's pose at a time. Doing this properly requires running the deadzone per-sensor before the merge — flagged here, not addressed.

## Please push back if our reading is wrong

We may have misread the original intent. Specifically: if the existing vehicle-anchored `FilterByRange` deadzone was deliberate ("noise from the vehicle, the person next to the robot") and `ESTIMATED_SENSOR_MAX_RANGE`'s name is purely historical, happy to drop or split this PR — let us know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration parameter names from "sensor max-range" terminology to "observation radius" terminology across all YAML pipeline configurations and documentation.
  * Legacy parameter names retained as deprecated aliases with runtime warning when loaded.

* **Refactor**
  * Renamed internal configuration parameters and GUI labels to reflect observation-radius concept.
  * Updated pipeline expressions to use new naming convention while maintaining backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->