### PR TITLE
FIX: More rational use of mutexes and shared opengl objects

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -818,7 +818,16 @@ private:
     std::map<mrpt::Clock::time_point, std::shared_ptr<const mrpt::obs::CObservationGPS>> last_gnss_;
 
     // Visualization:
-    mrpt::opengl::CSetOfObjects::Ptr glVehicleFrame, glPathGrp;
+    // Cache only the *expensive*, read-only-after-load vehicle model
+    // children (typically CAssimpModel). Each update builds a fresh
+    // CSetOfObjects around them and hands it to MolaViz, so we never
+    // share a long-lived, mutable object pointer with the GUI thread.
+    // glVehicleCachedBuilt tracks whether loading has already happened.
+    std::vector<mrpt::opengl::CRenderizable::Ptr> glVehicleModels;
+    bool glVehicleModelsLoaded = false;
+    // Worker-private growing buffer for the estimated path. Never handed
+    // to the GUI thread directly: each update clones it into a fresh
+    // CSetOfObjects wrapper before dispatch.
     mrpt::opengl::CSetOfLines::Ptr glEstimatedPath;
     int mapUpdateCnt = std::numeric_limits<int>::max();
 

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -502,15 +502,29 @@ void LidarOdometry::updateVisualization(
 
   // Vehicle pose:
   // ---------------------------
-  if (!state_.glVehicleFrame) {
+  if (!state_.glVehicleModelsLoaded) {
     updateVisualizationInitVehFrame();
   }
 
   // Update vehicle pose
   // -------------------------
-  state_.glVehicleFrame->setPose(state_.last_lidar_pose.mean);
-  updateTasks.emplace_back(
-    [this]() { visualizer_->update_3d_object("liodom/vehicle", state_.glVehicleFrame); });
+  // Build a *fresh* CSetOfObjects each update. The vehicle model children
+  // are read-only after load, so sharing their Ptrs between the cached
+  // slot and this fresh parent is safe. We never hand out the cached
+  // list itself to the GUI thread, so there is no writer/reader race on
+  // the parent (MolaViz::update_3d_object deep-reads it on the GUI
+  // thread while the lidar worker may keep producing new frames).
+  auto glVehicle = mrpt::opengl::CSetOfObjects::Create();
+  if (const auto l = params_.visualization.current_pose_corner_size; l > 0) {
+    glVehicle->insert(mrpt::opengl::stock_objects::CornerXYZ(l));
+  }
+  for (const auto & m : state_.glVehicleModels) {
+    glVehicle->insert(m);
+  }
+  glVehicle->setPose(state_.last_lidar_pose.mean);
+  updateTasks.emplace_back([visualizer = visualizer_, glVehicle]() {
+    visualizer->update_3d_object("liodom/vehicle", glVehicle);
+  });
 
   // Update current observation
   // ----------------------------
@@ -523,21 +537,21 @@ void LidarOdometry::updateVisualization(
   // GUI follow vehicle:
   // ---------------------------
   if (params_.visualization.camera_follows_vehicle) {
-    updateTasks.emplace_back([this]() {
-      visualizer_->update_viewport_look_at(state_.last_lidar_pose.mean.translation());
-    });
+    const auto t = state_.last_lidar_pose.mean.translation();
+    updateTasks.emplace_back(
+      [visualizer = visualizer_, t]() { visualizer->update_viewport_look_at(t); });
   }
 
   if (params_.visualization.camera_rotates_with_vehicle) {
-    updateTasks.emplace_back([this]() {
-      const double yaw = state_.last_lidar_pose.mean.yaw();
-      double yawIncr = 0;
-      if (state_.last_yaw_for_viz_camera) {
-        yawIncr = mrpt::math::wrapToPi(yaw - *state_.last_yaw_for_viz_camera);
-      }
-      state_.last_yaw_for_viz_camera = yaw;
+    const double yaw = state_.last_lidar_pose.mean.yaw();
+    double yawIncr = 0;
+    if (state_.last_yaw_for_viz_camera) {
+      yawIncr = mrpt::math::wrapToPi(yaw - *state_.last_yaw_for_viz_camera);
+    }
+    state_.last_yaw_for_viz_camera = yaw;
 
-      visualizer_->update_viewport_camera_azimuth(yawIncr, false /*incremental*/);
+    updateTasks.emplace_back([visualizer = visualizer_, yawIncr]() {
+      visualizer->update_viewport_camera_azimuth(yawIncr, false /*incremental*/);
     });
   }
 
@@ -565,8 +579,9 @@ void LidarOdometry::updateVisualization(
 
       glGroundGrid->insert(glGrid);
     }
-    updateTasks.emplace_back(
-      [this, glGroundGrid]() { visualizer_->update_3d_object("liodom/groundgrid", glGroundGrid); });
+    updateTasks.emplace_back([visualizer = visualizer_, glGroundGrid]() {
+      visualizer->update_3d_object("liodom/groundgrid", glGroundGrid);
+    });
   }
 
   // now, update all visual elements at once:
@@ -614,14 +629,11 @@ void LidarOdometry::updateVisualization(
 
 void LidarOdometry::updateVisualizationInitVehFrame()
 {
-  state_.glVehicleFrame = mrpt::opengl::CSetOfObjects::Create();
+  // Load the vehicle 3D model(s) exactly once and cache them as read-only
+  // children. The corner is cheap and rebuilt on every update so its color
+  // / size can track runtime parameter changes if ever needed.
+  state_.glVehicleModels.clear();
 
-  if (const auto l = params_.visualization.current_pose_corner_size; l > 0) {
-    auto glCorner = mrpt::opengl::stock_objects::CornerXYZ(l);
-    state_.glVehicleFrame->insert(glCorner);
-  }
-
-  // 3D model:
   if (!params_.visualization.model.empty()) {
     const auto & _ = params_.visualization;
 
@@ -640,9 +652,11 @@ void LidarOdometry::updateVisualizationInitVehFrame()
       m->setScale(static_cast<float>(model.scale));
       m->setPose(model.tf);
 
-      state_.glVehicleFrame->insert(m);
+      state_.glVehicleModels.push_back(m);
     }
   }
+
+  state_.glVehicleModelsLoaded = true;
 }
 
 void LidarOdometry::updateVisualizationCurrentObservation(
@@ -770,15 +784,17 @@ void LidarOdometry::updateVisualizationLocalMap(std::vector<std::function<void()
     // local map:
     auto glMap = state_.local_map->get_visualization(rp);
 
-    updateTasks.emplace_back(
-      [this, glMap]() { visualizer_->update_3d_object("liodom/localmap", glMap); });
+    updateTasks.emplace_back([visualizer = visualizer_, glMap]() {
+      visualizer->update_3d_object("liodom/localmap", glMap);
+    });
   }
 
   // Clear the local map if the user clicks on "hide it" at runtime:
   if (!params_.visualization.show_localmap) {
     auto glMap = mrpt::opengl::CSetOfObjects::Create();
-    updateTasks.emplace_back(
-      [this, glMap]() { visualizer_->update_3d_object("liodom/localmap", glMap); });
+    updateTasks.emplace_back([visualizer = visualizer_, glMap]() {
+      visualizer->update_3d_object("liodom/localmap", glMap);
+    });
   }
 }
 
@@ -791,7 +807,6 @@ void LidarOdometry::updateVisualizationPath(std::vector<std::function<void()>> &
       state_.glEstimatedPath = mrpt::opengl::CSetOfLines::Create();
       const auto & rgba = params_.visualization.trajectory_rgba;
       state_.glEstimatedPath->setColor(rgba.at(0), rgba.at(1), rgba.at(2), rgba.at(3));
-      state_.glPathGrp = mrpt::opengl::CSetOfObjects::Create();
     }
     // Update path viz:
     for (size_t i = state_.glEstimatedPath->size(); i < state_.estimated_trajectory.size(); i++) {
@@ -806,11 +821,16 @@ void LidarOdometry::updateVisualizationPath(std::vector<std::function<void()>> &
         state_.glEstimatedPath->appendLineStrip(t);
       }
     }
-    state_.glPathGrp->clear();
-    state_.glPathGrp->insert(mrpt::opengl::CSetOfLines::Create(*state_.glEstimatedPath));
+    // Hand a *fresh* wrapper containing a deep clone of the lines to the
+    // GUI thread, so the worker-private glEstimatedPath buffer can keep
+    // growing on subsequent ticks without racing with MolaViz's deep
+    // read on the GUI thread.
+    auto pathGrp = mrpt::opengl::CSetOfObjects::Create();
+    pathGrp->insert(mrpt::opengl::CSetOfLines::Create(*state_.glEstimatedPath));
 
-    updateTasks.emplace_back(
-      [this]() { visualizer_->update_3d_object("liodom/path", state_.glPathGrp); });
+    updateTasks.emplace_back([visualizer = visualizer_, pathGrp]() {
+      visualizer->update_3d_object("liodom/path", pathGrp);
+    });
   }
 }
 

--- a/module/src/LidarOdometry_InitialLocalization.cpp
+++ b/module/src/LidarOdometry_InitialLocalization.cpp
@@ -115,7 +115,10 @@ void LidarOdometry::handleInitialLocalization()
 
         state_.local_map->clear();
         ASSERT_(state_.local_map->empty());
-        state_.reconstructed_simplemap.clear();
+        {
+          auto lckSM = mrpt::lockHelper(state_simplemap_mtx_);
+          state_.reconstructed_simplemap.clear();
+        }
 
         state_.initial_localization_done = true;
         state_.imu_initializer.reset();  // no longer needed


### PR DESCRIPTION
Follow-up to #63 (map_save/map_load deadlock). Cleans up two adjacent
threading issues that were visible during the same analysis and removes a
small, real data race against the MolaViz GUI thread.

## What changed

### 1. `state_.reconstructed_simplemap`: single owning mutex

After #63, the simplemap is protected by `state_simplemap_mtx_` (not
`state_mtx_`). One remaining writer missed the switch:
`handleInitialLocalization()` in the `PitchAndRollFromIMU` branch was
calling `state_.reconstructed_simplemap.clear()` while holding only
`state_mtx_`. That raced with `reconstructedMap()` /
`saveReconstructedMapToFile()` / the new `map_save_impl()`, which all take
`state_simplemap_mtx_`.

Fixed by adding a short critical section on `state_simplemap_mtx_` around
the `clear()`. The other write site (`initialize_frontend()`) runs during
single-threaded module init and does not need a lock.

### 2. Stop sharing long-lived `state_.gl*` objects with MolaViz

The lidar worker kept two long-lived, mutable OpenGL objects around and
handed the same `shared_ptr` to `MolaViz::update_3d_object`:

- `state_.glVehicleFrame`: `setPose()` + (rare) `insert()` every scan.
- `state_.glPathGrp`: `clear()` + `insert()` every scan.

`MolaViz::update_3d_object` deep-reads that object on the GUI thread
(`*glContainer = *obj;`), so the GUI thread was doing `operator=` on an
object that the lidar worker kept writing. That is a real data race on
plain C++ containers (child list, cached model matrix, ...) and is
exactly the kind of thing that later surfaces as the misaligned member
access / weird render-queue crash under UBSan.

Fixed on the producer side:

- `state_.glVehicleFrame` is gone. We now cache only the
  read-only-after-load vehicle model children
  (`std::vector<CRenderizable::Ptr> glVehicleModels`, typically
  `CAssimpModel`). Each update builds a fresh `CSetOfObjects` around
  them, sets the pose, and hands *that* fresh object to MolaViz. The
  cached model children are read-only, so sharing their `Ptr`s between
  successive fresh parents is safe.
- `state_.glPathGrp` is gone. `state_.glEstimatedPath` remains as a
  worker-private growing `CSetOfLines` buffer, but we no longer share it.
  Each update builds a fresh `CSetOfObjects` containing a *deep clone*
  of the lines, and hands that out.

After this change, no long-lived, mutable renderable owned by the lidar
worker is visible to the GUI thread. The belt-and-suspenders fix on the
MolaViz side (clone inside `update_3d_object` so it works for every
caller) is tracked as a follow-up PR in `mola_viz`.

### 3. Tighten `updateTasks` lambda captures (`LidarOdometry_GUI.cpp`)

Replaced `[this]`/`[this, obj]` captures with the minimum needed
(`[visualizer = visualizer_, obj]`) in the vehicle, path, ground-grid,
local-map, and camera-follow/rotate handoffs. Snapshot values read from
`state_` (translation, yaw) are now computed eagerly on the worker
thread rather than read from `state_` inside the lambda.

These lambdas are currently drained synchronously at the end of
`updateVisualization` (so `[this]` was not itself a bug), but the tighter
captures make it much harder to accidentally reintroduce a cross-thread
`state_` read if that batch is ever moved.

## Not included (follow-ups)

- **MolaViz-side clone in `update_3d_object`**: the proper one-shot fix
  that makes the "caller can keep mutating `obj`" contract hold for every
  MolaViz user. Separate PR in `mola_viz`.
- **Defensive `background_scene_mtx` inside MolaViz task closures**:
  same follow-up PR.
- **Renderables pointing into `state_.local_map` layers**: confirmed not
  an issue: `get_visualization()` already deep-copies XYZ into new
  renderable buffers, it does not keep `CPointsMap` references.
- **Shrinking `state_mtx_` scope inside `processLidarScan`** and dropping
  the `recursive_mutex`: larger audits of `MethodState` field ownership,
  deferred.

## Test plan

- [X] Build on Release; no warnings.
- [x] Run a dataset end-to-end with GUI enabled; verify vehicle model,
      trajectory, ground grid, and local map still render correctly and
      camera-follow / camera-rotate options still work.
- [x] Trigger a `map_save` mid-run; verify no stall on the GUI thread
      during serialization (regression guard for #63).
