### PR TITLE
feat: add GravityMapAligner with per-KF IMU pool and robust gravity estimation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,6 +42,7 @@
         "DPDF",
         "ENTYPO",
         "liodom",
+        "rebaker",
         "recolorize",
         "relocalize",
         "thres",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,27 @@ find_package(mola_imu_preintegration REQUIRED)
 
 # -----------------------
 # define lib:
-file(GLOB_RECURSE LIB_SRCS module/src/*.cpp module/src/*.h)
-file(GLOB_RECURSE LIB_PUBLIC_HDRS module/include/*.h)
+set(LIB_SRCS 
+  module/src/GravityMapAligner.cpp
+  module/src/LidarOdometry_Main.cpp
+  module/src/LidarOdometry_Relocalization.cpp
+  module/src/LidarOdometry_Parameters.cpp
+  module/src/LidarOdometry_Initialize.cpp
+  module/src/LidarOdometry_ProcessScan.cpp
+  module/src/LidarOdometry_AdaptiveVariables.cpp
+  module/src/LidarOdometry_MapServer.cpp
+  module/src/LidarOdometry_GUI.cpp
+  module/src/LidarOdometry_SensorCallbacks.cpp
+  module/src/LidarOdometry_Publish.cpp
+  module/src/LidarOdometry_InitialLocalization.cpp
+  # Last:
+  module/src/register.cpp
+)
+
+set(LIB_PUBLIC_HDRS 
+  module/include/mola_lidar_odometry/LidarOdometry.h
+  module/include/mola_lidar_odometry/GravityMapAligner.h
+)
 
 mola_add_library(
   TARGET ${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,9 @@ find_package(mola_imu_preintegration REQUIRED)
 
 # -----------------------
 # define lib:
-set(LIB_SRCS 
+set(LIB_SRCS
   module/src/GravityMapAligner.cpp
+  module/src/TrajectoryRebaker.cpp
   module/src/LidarOdometry_Main.cpp
   module/src/LidarOdometry_Relocalization.cpp
   module/src/LidarOdometry_Parameters.cpp
@@ -48,9 +49,10 @@ set(LIB_SRCS
   module/src/register.cpp
 )
 
-set(LIB_PUBLIC_HDRS 
+set(LIB_PUBLIC_HDRS
   module/include/mola_lidar_odometry/LidarOdometry.h
   module/include/mola_lidar_odometry/GravityMapAligner.h
+  module/include/mola_lidar_odometry/TrajectoryRebaker.h
 )
 
 mola_add_library(

--- a/module/include/mola_lidar_odometry/GravityMapAligner.h
+++ b/module/include/mola_lidar_odometry/GravityMapAligner.h
@@ -1,0 +1,153 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   GravityMapAligner.h
+ * @brief  Per-KF accelerometer pool + robust gravity estimation (pitch/roll only)
+ *
+ * Design reference: TODOs/online-gravity-alignment.md §2.4 and §3.1.
+ * This class is pure: it owns a per-KF pool of averaged body-frame
+ * accelerations, and exposes robust primitives to estimate per-KF
+ * pitch/roll corrections sending the local gravity estimate to +Z.
+ * It does NOT know about the local-map class or any ROS/TF state.
+ */
+#pragma once
+
+#include <mola_imu_preintegration/LocalVelocityBuffer.h>
+#include <mrpt/math/TPoint3D.h>
+#include <mrpt/poses/CPose3D.h>
+
+#include <cstdint>
+#include <map>
+#include <optional>
+
+namespace mola
+{
+/** Per-keyframe accelerometer pool + robust gravity-direction estimator.
+ *
+ * Samples are keyed by an external KeyFrameID (opaque `uint64_t`): the
+ * KeyframePointCloudMap id when used from LIO, or any integer in unit tests.
+ *
+ * Thread-safety: none. Callers serialize access externally.
+ *
+ * \ingroup mola_lidar_odometry_grp
+ */
+class GravityMapAligner
+{
+public:
+  using KeyFrameID = uint64_t;
+
+  struct Params
+  {
+    /// Don't produce any estimate below this pool size.
+    std::size_t min_keyframes = 10;
+
+    /// Huber threshold on |R_i·a_i − ĝ|, in m/s².
+    double huber_threshold_mps2 = 0.5;
+
+    /// KFs with intra-interval accel std above this are heavily down-weighted
+    /// (reject highly dynamic motion). In m/s².
+    double max_kf_acc_std_mps2 = 1.5;
+
+    /// Number of IRLS iterations.
+    std::size_t irls_iterations = 3;
+
+    /// Expected gravity magnitude in m/s² (used only for initial weighting).
+    double expected_g_mps2 = 9.81;
+
+    /// Numerical guard for axis-angle near-zero/180°.
+    double axis_eps = 1e-9;
+  };
+
+  /// One averaged sample per KF.
+  struct KFAccSample
+  {
+    mrpt::math::TVector3D a_body{0, 0, 0};  //!< Time-averaged body-frame accel (m/s²).
+    double a_body_std = 0;                  //!< Intra-KF std of |a|, m/s².
+    std::size_t n_samples = 0;              //!< Number of raw samples averaged.
+  };
+
+  GravityMapAligner() = default;
+  explicit GravityMapAligner(Params p) : params_(std::move(p)) {}
+
+  const Params & params() const { return params_; }
+  void setParams(Params p) { params_ = std::move(p); }
+
+  /// Register a KF and the accelerometer samples taken during its interval.
+  /// Computes and stores the time-averaged `a_body` and intra-KF std of |a|.
+  /// If `samples.a_b` is empty, the KF is NOT added to the pool.
+  void onNewKeyframe(KeyFrameID id, const mola::imu::LocalVelocityBuffer::SamplesByTime & window);
+
+  /// Insert a pre-computed sample directly (useful for tests / rehydration).
+  void onNewKeyframeRaw(KeyFrameID id, const KFAccSample & s);
+
+  /// Drop per-KF data when a KF is evicted from the local map.
+  void onKeyframeDropped(KeyFrameID id);
+
+  /// Reset all state.
+  void clear();
+
+  std::size_t size() const { return samples_.size(); }
+  bool has(KeyFrameID id) const { return samples_.count(id) > 0; }
+
+  const std::map<KeyFrameID, KFAccSample> & samples() const { return samples_; }
+
+  /** Robust weighted mean of the gravity direction in the "map" frame, pooled
+   *  over all currently-stored KFs whose ids are also present in `kf_poses`.
+   *
+   *  @returns  The estimated gravity vector (not normalized) in the `kf_poses`
+   *            frame, or nullopt if pool size is below params_.min_keyframes.
+   */
+  std::optional<mrpt::math::TVector3D> estimateGravityVector(
+    const std::map<KeyFrameID, mrpt::poses::CPose3D> & kf_poses) const;
+
+  /** Robust weighted mean of gravity, pooled over the subset of ids in
+   *  `id_window` that are both present in this aligner and in `kf_poses`.
+   *  Returns nullopt if fewer than `min_pool` KFs in the intersection (or
+   *  if <2 samples, which would make the IRLS ill-conditioned).
+   */
+  std::optional<mrpt::math::TVector3D> estimateGravityVectorOverWindow(
+    const std::map<KeyFrameID, mrpt::poses::CPose3D> & kf_poses,
+    const std::vector<KeyFrameID> & id_window, std::size_t min_pool) const;
+
+  /** Builds the pitch+roll-only rotation that sends the unit vector `g_hat`
+   *  to +Z. Yaw is left at zero (unobservable with gravity only).
+   *  Returns identity if `g_hat` is already aligned with +Z within axis_eps.
+   */
+  static mrpt::poses::CPose3D rotationFromGravity(
+    const mrpt::math::TVector3D & g_hat, double axis_eps = 1e-9);
+
+  /** One-shot pool-wide correction: pitch+roll rotation sending the robust
+   *  pool mean of `R_i · a_i` (in the `kf_poses` frame) to +Z.
+   *  nullopt if pool is below trigger size.
+   */
+  std::optional<mrpt::poses::CPose3D> estimateGlobalCorrection(
+    const std::map<KeyFrameID, mrpt::poses::CPose3D> & kf_poses) const;
+
+  /** For each KF id in `kf_poses` that also has pool samples, compute a
+   *  per-KF pitch+roll rotation `R_grav_i` (sending the windowed robust mean
+   *  of `R_j · a_j` for j in `Window(i)` to +Z). `window_half_width` is `P`
+   *  in `Window(i) = [i-P, i+P]` (truncated at ends).
+   *  @param min_pool_per_kf   Minimum number of pool members in Window(i)
+   *                           required to emit R_grav_i (else KF is skipped).
+   *  @returns map from KF id to R_grav_i.
+   */
+  std::map<KeyFrameID, mrpt::poses::CPose3D> estimatePerKFCorrection(
+    const std::map<KeyFrameID, mrpt::poses::CPose3D> & kf_poses, std::size_t window_half_width,
+    std::size_t min_pool_per_kf) const;
+
+private:
+  Params params_;
+  std::map<KeyFrameID, KFAccSample> samples_;
+};
+
+}  // namespace mola

--- a/module/include/mola_lidar_odometry/TrajectoryRebaker.h
+++ b/module/include/mola_lidar_odometry/TrajectoryRebaker.h
@@ -1,0 +1,125 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   TrajectoryRebaker.h
+ * @brief  Chain-integration trajectory rebake using per-KF gravity corrections
+ *
+ * Design reference: TODOs/online-gravity-alignment.md §2.4.2.
+ *
+ * Takes a map of original ("odom") KF poses and a map of per-KF
+ * pitch/roll corrections (from GravityMapAligner) and produces a new
+ * map of corrected poses where:
+ *
+ *  - The anchor KF's position is frozen (unchanged); only its rotation
+ *    is updated to R_grav_anchor * R_anchor_odom.
+ *  - Each subsequent KF's position is the previous corrected position
+ *    plus the odom relative displacement re-expressed in the corrected
+ *    frame. Short-range odometry (relative motion between adjacent KFs)
+ *    is therefore preserved.
+ *  - Long-range accumulated pitch drift is redistributed along the chain.
+ *
+ * The class is stateless: all methods are static. Caller is responsible
+ * for thread safety and for choosing the anchor KF.
+ */
+#pragma once
+
+#include <mrpt/poses/CPose3D.h>
+
+#include <cstdint>
+#include <map>
+
+namespace mola
+{
+/**
+ * Trajectory rebaker: corrects a chain of KF poses using per-KF
+ * pitch/roll rotations so that the resulting trajectory is
+ * gravity-aligned.
+ *
+ * \ingroup mola_lidar_odometry_grp
+ */
+class TrajectoryRebaker
+{
+public:
+  using KeyFrameID = uint64_t;
+
+  /// Output of a rebake operation.
+  struct Result
+  {
+    /// Corrected poses for every KF that could be processed (i.e. present in
+    /// both odom_poses and r_grav, from anchor onward).
+    std::map<KeyFrameID, mrpt::poses::CPose3D> corrected_poses;
+
+    /// The anchor KF id used (first KF of the processed window).
+    KeyFrameID anchor_id = 0;
+  };
+
+  /**
+   * @brief Rebake a contiguous window of KF poses.
+   *
+   * Processes KFs in ascending id order within the intersection of
+   * `odom_poses` and `r_grav`, starting at `anchor_id`.
+   *
+   * The anchor KF's POSITION is copied verbatim from `odom_poses`;
+   * only its rotation is updated:
+   *   T_anchor_new.R   = R_grav[anchor] * T_anchor_odom.R
+   *   T_anchor_new.pos = T_anchor_odom.pos   (frozen)
+   *
+   * For every subsequent KF `i` (in ascending id order after anchor):
+   *   Δpos_odom  = T_i_odom.pos - T_{i-1}_odom.pos
+   *   Δpos_new   = (R_{i-1}_new * R_{i-1}_odom⁻¹) * Δpos_odom
+   *   T_i_new.pos = T_{i-1}_new.pos + Δpos_new
+   *   T_i_new.R   = R_grav[i] * T_i_odom.R
+   *
+   * KFs before `anchor_id` in `odom_poses` are skipped (their poses are
+   * left unchanged by the caller). KFs in `odom_poses` that have no entry
+   * in `r_grav` are passed through unchanged (identity correction applied).
+   *
+   * @param odom_poses  Original LIO poses keyed by KF id (sorted map).
+   * @param r_grav      Per-KF pitch/roll corrections from GravityMapAligner.
+   *                    KFs missing from this map get identity correction.
+   * @param anchor_id   First KF id to process; its position is frozen.
+   * @returns           Result with corrected_poses for anchor..end of window.
+   */
+  static Result rebake(
+    const std::map<KeyFrameID, mrpt::poses::CPose3D> & odom_poses,
+    const std::map<KeyFrameID, mrpt::poses::CPose3D> & r_grav, KeyFrameID anchor_id);
+
+  /**
+   * @brief Convenience overload: anchor = first KF present in both maps.
+   */
+  static Result rebake(
+    const std::map<KeyFrameID, mrpt::poses::CPose3D> & odom_poses,
+    const std::map<KeyFrameID, mrpt::poses::CPose3D> & r_grav);
+
+  /**
+   * @brief Compute the publish residual after a rebake.
+   *
+   * When a rebake changes the pose of the most-recent KF (id `tail_kf_id`),
+   * the live per-scan pose needs a compensating transform so that the
+   * published pose shows no jump:
+   *
+   *   T_grav_publish_new = T_tail_old * T_tail_new.inverse()
+   *
+   * Contract: applying the residual to the post-rebake tail pose reproduces
+   * the pre-rebake tail pose, i.e. `residual + tail_after == tail_before`.
+   * The caller LEFT-composes this onto the live (post-rebake) pose between
+   * rebakes (`pose_pub = residual + pose_stored`) so the publish stream is
+   * continuous across the rebake event.
+   *
+   * Returns identity if `tail_kf_id` is absent from either map.
+   */
+  static mrpt::poses::CPose3D computePublishResidual(
+    const mrpt::poses::CPose3D & tail_pose_before, const mrpt::poses::CPose3D & tail_pose_after);
+};
+
+}  // namespace mola

--- a/module/src/GravityMapAligner.cpp
+++ b/module/src/GravityMapAligner.cpp
@@ -78,7 +78,8 @@ void GravityMapAligner::onNewKeyframe(
     const double d = a.norm() - mean.norm();
     sum_var += d * d;
   }
-  const double stddev = (a_map.size() >= 2) ? std::sqrt(sum_var / n) : 0.0;
+  constexpr double std_floor = 0.01;  // ~1e-4 variance floor (m/s²)
+  const double stddev = std::max(std_floor, (a_map.size() >= 2) ? std::sqrt(sum_var / n) : 0.0);
 
   KFAccSample s;
   s.a_body = mean;

--- a/module/src/GravityMapAligner.cpp
+++ b/module/src/GravityMapAligner.cpp
@@ -1,0 +1,223 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+#include <mola_lidar_odometry/GravityMapAligner.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+mrpt::math::TVector3D robust_weighted_mean(
+  const std::vector<mrpt::math::TVector3D> & xs, const std::vector<double> & seed_w,
+  double huber_thr, std::size_t iters)
+{
+  if (xs.empty()) {
+    return {0, 0, 0};
+  }
+  std::vector<double> w = seed_w;
+  mrpt::math::TVector3D mean{0, 0, 0};
+
+  auto weighted_mean = [&]() {
+    mrpt::math::TVector3D acc{0, 0, 0};
+    double wsum = 0;
+    for (std::size_t i = 0; i < xs.size(); ++i) {
+      acc += w[i] * xs[i];
+      wsum += w[i];
+    }
+    if (wsum <= 0) {
+      return mrpt::math::TVector3D{0, 0, 0};
+    }
+    return acc / wsum;
+  };
+
+  mean = weighted_mean();
+  for (std::size_t it = 0; it < iters; ++it) {
+    for (std::size_t i = 0; i < xs.size(); ++i) {
+      const mrpt::math::TVector3D d = xs[i] - mean;
+      const double r = d.norm();
+      const double hw = (r <= huber_thr) ? 1.0 : (huber_thr / r);
+      w[i] = seed_w[i] * hw;
+    }
+    mean = weighted_mean();
+  }
+  return mean;
+}
+
+}  // namespace
+
+namespace mola
+{
+void GravityMapAligner::onNewKeyframe(
+  KeyFrameID id, const mola::imu::LocalVelocityBuffer::SamplesByTime & window)
+{
+  const auto & a_map = window.a_b;
+  if (a_map.empty()) {
+    return;
+  }
+
+  mrpt::math::TVector3D mean{0, 0, 0};
+  for (const auto & [t, a] : a_map) {
+    mean += a;
+  }
+  const auto n = static_cast<double>(a_map.size());
+  mean *= 1.0 / n;
+
+  // Intra-KF std of |a|:
+  double sum_var = 0;
+  for (const auto & [t, a] : a_map) {
+    const double d = a.norm() - mean.norm();
+    sum_var += d * d;
+  }
+  const double stddev = (a_map.size() >= 2) ? std::sqrt(sum_var / n) : 0.0;
+
+  KFAccSample s;
+  s.a_body = mean;
+  s.a_body_std = stddev;
+  s.n_samples = a_map.size();
+  samples_[id] = s;
+}
+
+void GravityMapAligner::onNewKeyframeRaw(KeyFrameID id, const KFAccSample & s) { samples_[id] = s; }
+
+void GravityMapAligner::onKeyframeDropped(KeyFrameID id) { samples_.erase(id); }
+
+void GravityMapAligner::clear() { samples_.clear(); }
+
+mrpt::poses::CPose3D GravityMapAligner::rotationFromGravity(
+  const mrpt::math::TVector3D & g_hat, double axis_eps)
+{
+  const double gn = g_hat.norm();
+  if (gn < axis_eps) {
+    return mrpt::poses::CPose3D::Identity();
+  }
+
+  // Normalized gravity direction in the current (odom) frame.
+  const double gx = g_hat.x / gn;
+  const double gy = g_hat.y / gn;
+  const double gz = g_hat.z / gn;
+
+  // Already aligned with +Z :  nothing to do.
+  if (std::abs(gz - 1.0) < axis_eps) {
+    return mrpt::poses::CPose3D::Identity();
+  }
+
+  // Decompose R = Ry(pitch) * Rx(roll), yaw = 0, such that R * g_hat = +Z.
+  //   Rx(roll)  zeroes the Y component:   roll  = atan2(gy, gz)
+  //   Ry(pitch) zeroes the X component:   pitch = atan2(-gx, sqrt(gy²+gz²))
+  // By placing yaw=0 explicitly in the CPose3D constructor (ZYX convention),
+  // getYawPitchRoll() returns exactly zero yaw :  no floating-point accumulation
+  // from quaternion conversion.
+  const double roll = std::atan2(gy, gz);
+  const double pitch = std::atan2(-gx, std::sqrt(gy * gy + gz * gz));
+
+  return {0.0, 0.0, 0.0, 0.0 /*yaw*/, pitch, roll};
+}
+
+std::optional<mrpt::math::TVector3D> GravityMapAligner::estimateGravityVector(
+  const std::map<KeyFrameID, mrpt::poses::CPose3D> & kf_poses) const
+{
+  std::vector<KeyFrameID> all_ids;
+  all_ids.reserve(samples_.size());
+  for (const auto & [id, s] : samples_) {
+    all_ids.push_back(id);
+  }
+  return estimateGravityVectorOverWindow(kf_poses, all_ids, params_.min_keyframes);
+}
+
+std::optional<mrpt::math::TVector3D> GravityMapAligner::estimateGravityVectorOverWindow(
+  const std::map<KeyFrameID, mrpt::poses::CPose3D> & kf_poses,
+  const std::vector<KeyFrameID> & id_window, std::size_t min_pool) const
+{
+  std::vector<mrpt::math::TVector3D> gs;
+  std::vector<double> ws;
+  gs.reserve(id_window.size());
+  ws.reserve(id_window.size());
+
+  for (KeyFrameID id : id_window) {
+    auto its = samples_.find(id);
+    if (its == samples_.end()) {
+      continue;
+    }
+    auto itp = kf_poses.find(id);
+    if (itp == kf_poses.end()) {
+      continue;
+    }
+
+    // Rotate body-frame accel into {odom}: g_odom = R_i_odom · a_body_i
+    const auto & R = itp->second;  // CPose3D; we use its rotation
+    const mrpt::math::TVector3D g_odom = R.rotateVector(its->second.a_body);
+    gs.push_back(g_odom);
+
+    // Seed weight: 1 / (a_body_std² + small). Down-weight very dynamic KFs:
+    const double std_i = its->second.a_body_std;
+    double w = 1.0 / std::max(1e-6, std_i * std_i);
+    if (std_i > params_.max_kf_acc_std_mps2) {
+      w *= 1e-3;  // heavy down-weight
+    }
+    ws.push_back(w);
+  }
+
+  if (gs.size() < std::max<std::size_t>(2, min_pool)) {
+    return std::nullopt;
+  }
+
+  return robust_weighted_mean(gs, ws, params_.huber_threshold_mps2, params_.irls_iterations);
+}
+
+std::optional<mrpt::poses::CPose3D> GravityMapAligner::estimateGlobalCorrection(
+  const std::map<KeyFrameID, mrpt::poses::CPose3D> & kf_poses) const
+{
+  auto g = estimateGravityVector(kf_poses);
+  if (!g) {
+    return std::nullopt;
+  }
+  return rotationFromGravity(*g, params_.axis_eps);
+}
+
+std::map<GravityMapAligner::KeyFrameID, mrpt::poses::CPose3D>
+GravityMapAligner::estimatePerKFCorrection(
+  const std::map<KeyFrameID, mrpt::poses::CPose3D> & kf_poses, std::size_t window_half_width,
+  std::size_t min_pool_per_kf) const
+{
+  std::map<KeyFrameID, mrpt::poses::CPose3D> out;
+  if (samples_.empty() || kf_poses.empty()) {
+    return out;
+  }
+
+  // Ordered id list from kf_poses (std::map is already sorted):
+  std::vector<KeyFrameID> pose_ids;
+  pose_ids.reserve(kf_poses.size());
+  for (const auto & [id, p] : kf_poses) {
+    pose_ids.push_back(id);
+  }
+
+  for (std::size_t k = 0; k < pose_ids.size(); ++k) {
+    const KeyFrameID id_k = pose_ids[k];
+    if (samples_.count(id_k) == 0) {
+      continue;
+    }
+
+    const std::size_t lo = (k > window_half_width) ? (k - window_half_width) : 0;
+    const std::size_t hi = std::min(pose_ids.size(), k + window_half_width + 1);
+    std::vector<KeyFrameID> win(pose_ids.begin() + lo, pose_ids.begin() + hi);
+
+    auto g = estimateGravityVectorOverWindow(kf_poses, win, min_pool_per_kf);
+    if (!g) {
+      continue;
+    }
+    out.emplace(id_k, rotationFromGravity(*g, params_.axis_eps));
+  }
+  return out;
+}
+
+}  // namespace mola

--- a/module/src/TrajectoryRebaker.cpp
+++ b/module/src/TrajectoryRebaker.cpp
@@ -1,0 +1,129 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+#include <mola_lidar_odometry/TrajectoryRebaker.h>
+
+namespace mola
+{
+TrajectoryRebaker::Result TrajectoryRebaker::rebake(
+  const std::map<KeyFrameID, mrpt::poses::CPose3D> & odom_poses,
+  const std::map<KeyFrameID, mrpt::poses::CPose3D> & r_grav, KeyFrameID anchor_id)
+{
+  Result result;
+  result.anchor_id = anchor_id;
+
+  if (odom_poses.empty()) {
+    return result;
+  }
+
+  // Identity correction for KFs absent from r_grav.
+  const mrpt::poses::CPose3D identity = mrpt::poses::CPose3D::Identity();
+
+  // Helper: look up r_grav or return identity.
+  auto get_r_grav = [&](KeyFrameID id) -> const mrpt::poses::CPose3D & {
+    auto it = r_grav.find(id);
+    return (it != r_grav.end()) ? it->second : identity;
+  };
+
+  // Iterate odom_poses in ascending id order, starting from anchor_id.
+  bool in_window = false;
+  mrpt::poses::CPose3D prev_odom, prev_new;
+
+  for (const auto & [id, T_odom] : odom_poses) {
+    if (id < anchor_id) {
+      continue;
+    }
+
+    const mrpt::poses::CPose3D & Rg = get_r_grav(id);
+
+    if (!in_window) {
+      // ---- Anchor KF: freeze position, correct rotation. ----
+      // T_new.R   = R_grav * R_odom
+      // T_new.pos = T_odom.pos  (unchanged)
+      mrpt::poses::CPose3D T_new = Rg + T_odom;  // left-multiply: applies Rg rotation
+      // Restore original position (Rg + T_odom shifts position; undo that):
+      T_new.x(T_odom.x());
+      T_new.y(T_odom.y());
+      T_new.z(T_odom.z());
+
+      result.corrected_poses[id] = T_new;
+
+      prev_odom = T_odom;
+      prev_new = T_new;
+      in_window = true;
+    } else {
+      // ---- Subsequent KF: re-integrate relative displacement. ----
+      //
+      // Δpos_odom = T_i.pos - T_{i-1}.pos  (in odom frame)
+      // The displacement in odom frame, re-expressed in corrected frame:
+      //   Δpos_new = (R_{i-1}_new * R_{i-1}_odom⁻¹) * Δpos_odom
+      //
+      // R_{i-1}_odom⁻¹  maps odom vectors → body frame of KF i-1.
+      // R_{i-1}_new      maps that body frame → corrected world frame.
+      // Together they convert an odom displacement to corrected-world displacement.
+
+      const mrpt::math::TVector3D delta_odom{
+        T_odom.x() - prev_odom.x(), T_odom.y() - prev_odom.y(), T_odom.z() - prev_odom.z()};
+
+      // Build C = R_{i-1}_new * R_{i-1}_odom⁻¹  as a pure-rotation CPose3D.
+      // CPose3D stores rotation + translation; we only need the rotation part.
+      // prev_new.R * prev_odom.R^T = prev_new * prev_odom.inverse() (rotation only).
+      const mrpt::poses::CPose3D C = prev_new + (-prev_odom);  // R_new * R_odom^-1
+
+      // Rotate the odom displacement into the corrected frame:
+      mrpt::math::TPoint3D dp_local(delta_odom.x, delta_odom.y, delta_odom.z);
+      mrpt::math::TPoint3D dp_world, origin_world;
+      C.composePoint(dp_local, dp_world);
+      C.composePoint(mrpt::math::TPoint3D(0, 0, 0), origin_world);
+      const mrpt::math::TVector3D delta_new{
+        dp_world.x - origin_world.x, dp_world.y - origin_world.y, dp_world.z - origin_world.z};
+
+      // New corrected rotation: R_grav_i * R_i_odom.
+      mrpt::poses::CPose3D T_new = Rg + T_odom;
+
+      // Override position with the re-integrated one:
+      T_new.x(prev_new.x() + delta_new.x);
+      T_new.y(prev_new.y() + delta_new.y);
+      T_new.z(prev_new.z() + delta_new.z);
+
+      result.corrected_poses[id] = T_new;
+
+      prev_odom = T_odom;
+      prev_new = T_new;
+    }
+  }
+
+  return result;
+}
+
+TrajectoryRebaker::Result TrajectoryRebaker::rebake(
+  const std::map<KeyFrameID, mrpt::poses::CPose3D> & odom_poses,
+  const std::map<KeyFrameID, mrpt::poses::CPose3D> & r_grav)
+{
+  if (odom_poses.empty()) {
+    return {};
+  }
+  return rebake(odom_poses, r_grav, odom_poses.begin()->first);
+}
+
+mrpt::poses::CPose3D TrajectoryRebaker::computePublishResidual(
+  const mrpt::poses::CPose3D & tail_pose_before, const mrpt::poses::CPose3D & tail_pose_after)
+{
+  // T_grav_publish = T_tail_before.inverse() * T_tail_after
+  // This is the transform the caller should left-compose onto the live pose
+  // so that T_live_new + T_grav_publish_new == T_live_old + T_grav_publish_old.
+  // Caller applies residual as: pose_pub = residual + pose_stored_new.
+  // For continuity: residual ∘ T_new = T_old, so residual = T_old ∘ T_new⁻¹.
+  return tail_pose_before + (-tail_pose_after);
+}
+
+}  // namespace mola

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,9 @@
 ament_add_gtest(test_gravity_map_aligner test_gravity_map_aligner.cpp)
 target_link_libraries(test_gravity_map_aligner mola::mola_lidar_odometry)
 
+ament_add_gtest(test_trajectory_rebaker test_trajectory_rebaker.cpp)
+target_link_libraries(test_trajectory_rebaker mola::mola_lidar_odometry)
+
 # -----------------------------------------------------------------------
 # Data-dependent integration tests (require optional packages):
 # -----------------------------------------------------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,14 @@
 # Unit tests:
 
+# -----------------------------------------------------------------------
+# Standalone unit test for GravityMapAligner — no external datasets needed.
+# -----------------------------------------------------------------------
+ament_add_gtest(test_gravity_map_aligner test_gravity_map_aligner.cpp)
+target_link_libraries(test_gravity_map_aligner mola::mola_lidar_odometry)
+
+# -----------------------------------------------------------------------
+# Data-dependent integration tests (require optional packages):
+# -----------------------------------------------------------------------
 find_package(mola_test_datasets)
 find_package(mola_metric_maps)
 find_package(mola_input_rosbag2)

--- a/test/test_gravity_map_aligner.cpp
+++ b/test/test_gravity_map_aligner.cpp
@@ -1,0 +1,315 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * Unit tests for GravityMapAligner.
+ * Tests §5.1 and §5.2 of TODOs/online-gravity-alignment.md.
+ *
+ * No external datasets needed — all synthetic.
+ */
+
+#include <gtest/gtest.h>
+#include <mola_lidar_odometry/GravityMapAligner.h>
+#include <mrpt/math/CQuaternion.h>
+#include <mrpt/poses/CPose3D.h>
+
+#include <cmath>
+#include <random>
+
+using namespace mola;
+using mrpt::math::TVector3D;
+using mrpt::poses::CPose3D;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+namespace
+{
+// Pitch rotation about Y by angle_rad (positive = nose up).
+CPose3D makePitch(double angle_rad)
+{
+  mrpt::math::CQuaternionDouble q;
+  q.fromRodriguesVector(mrpt::math::TVector3D(0.0, angle_rad, 0.0));
+  return {q, 0, 0, 0};
+}
+
+// Body-frame gravity when the robot is pitched by angle_rad in world frame.
+// World gravity = (0,0,-g). Body frame = world rotated by pitch.
+// a_body = R_body_world · (0,0,-g)  = R_world_body^T · (0,0,-g).
+TVector3D bodyGravity(double pitch_rad, double g = 9.81)
+{
+  // With pure pitch by angle_rad about Y (nose up):
+  //   a_body.x = g * sin(pitch_rad)
+  //   a_body.y = 0
+  //   a_body.z = -g * cos(pitch_rad)
+  // (proper acceleration = -gravity in body frame, pointing "up" through the floor)
+  return {g * std::sin(pitch_rad), 0.0, g * std::cos(pitch_rad)};
+}
+
+// Angle between vector v and +Z, in degrees.
+double angleToPlusZ_deg(const TVector3D & v)
+{
+  const double n = std::sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+  if (n < 1e-12) {
+    return 0.0;
+  }
+  const double cz = std::max(-1.0, std::min(1.0, v.z / n));
+  return std::acos(cz) * 180.0 / M_PI;
+}
+
+// After applying R_corr to kf_poses, check that every mapped gravity vector
+// is within tol_deg of +Z.
+double maxGravityErrorDeg(
+  const std::map<GravityMapAligner::KeyFrameID, CPose3D> & kf_poses,
+  const GravityMapAligner & aligner, const CPose3D & R_corr)
+{
+  double max_err = 0;
+  for (const auto & [id, s] : aligner.samples()) {
+    auto itp = kf_poses.find(id);
+    if (itp == kf_poses.end()) {
+      continue;
+    }
+    const CPose3D corrected = R_corr + itp->second;  // R_corr left-multiplied
+    mrpt::math::TPoint3D ab_local(s.a_body.x, s.a_body.y, s.a_body.z);
+    mrpt::math::TPoint3D ab_world, orig_world;
+    corrected.composePoint(ab_local, ab_world);
+    corrected.composePoint(mrpt::math::TPoint3D(0, 0, 0), orig_world);
+    const TVector3D g_world{
+      ab_world.x - orig_world.x, ab_world.y - orig_world.y, ab_world.z - orig_world.z};
+    max_err = std::max(max_err, angleToPlusZ_deg(g_world));
+  }
+  return max_err;
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Test 1: below-threshold → nullopt
+// ---------------------------------------------------------------------------
+TEST(GravityMapAligner, BelowMinKeyframes_returnsNullopt)
+{
+  GravityMapAligner::Params p;
+  p.min_keyframes = 10;
+  GravityMapAligner aligner(p);
+
+  std::map<GravityMapAligner::KeyFrameID, CPose3D> poses;
+  for (uint64_t i = 0; i < 9; ++i) {
+    aligner.onNewKeyframeRaw(i, {{0, 0, 9.81}, 0.01, 10});
+    poses[i] = CPose3D::Identity();
+  }
+
+  EXPECT_FALSE(aligner.estimateGravityVector(poses).has_value());
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: identity world (no tilt) → correction is near-identity
+// ---------------------------------------------------------------------------
+TEST(GravityMapAligner, ZeroTilt_identityCorrection)
+{
+  GravityMapAligner::Params p;
+  p.min_keyframes = 5;
+  GravityMapAligner aligner(p);
+
+  // All KFs perfectly upright: a_body = (0,0,g) in body frame, identity pose.
+  std::map<GravityMapAligner::KeyFrameID, CPose3D> poses;
+  for (uint64_t i = 0; i < 20; ++i) {
+    aligner.onNewKeyframeRaw(i, {{0.0, 0.0, 9.81}, 0.02, 10});
+    poses[i] = CPose3D::Identity();
+  }
+
+  auto corr = aligner.estimateGlobalCorrection(poses);
+  ASSERT_TRUE(corr.has_value());
+
+  // The correction should be nearly identity: all angles < 0.01°.
+  double yaw = 0, pitch = 0, roll = 0;
+  corr->getYawPitchRoll(yaw, pitch, roll);
+
+  EXPECT_NEAR(roll * 180.0 / M_PI, 0.0, 0.05);
+  EXPECT_NEAR(pitch * 180.0 / M_PI, 0.0, 0.05);
+  EXPECT_NEAR(yaw * 180.0 / M_PI, 0.0, 0.05);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: known 2° pitch tilt → estimator converges to within 0.1°
+//
+// Scenario: all KF poses are identity (odom == world), body-frame gravity
+// is (sin(tilt)*g, 0, cos(tilt)*g) + noise. This models a 2° tilt of the
+// odom frame relative to world gravity. The estimator should recover a
+// correction with pitch ≈ -tilt_deg, roll ≈ 0°, yaw = 0° exactly.
+// We test the ESTIMATOR accuracy (pool mean), not per-sample noise residuals.
+// ---------------------------------------------------------------------------
+TEST(GravityMapAligner, KnownPitchTilt_converges)
+{
+  const double tilt_deg = 2.0;
+  const double tilt_rad = tilt_deg * M_PI / 180.0;
+
+  GravityMapAligner::Params p;
+  p.min_keyframes = 10;
+  p.huber_threshold_mps2 = 0.5;
+  p.irls_iterations = 3;
+  GravityMapAligner aligner(p);
+
+  std::mt19937 rng(42);
+  std::normal_distribution<double> noise(0.0, 0.04);  // ~0.04 m/s²
+
+  std::map<GravityMapAligner::KeyFrameID, CPose3D> poses;
+  for (uint64_t i = 0; i < 30; ++i) {
+    // g_odom = I * a_body ≈ (sin(tilt)*g, 0, cos(tilt)*g). Pool mean converges
+    // to within 0.04/sqrt(30) ≈ 0.007° of the true direction.
+    const TVector3D a_clean = bodyGravity(tilt_rad);
+    GravityMapAligner::KFAccSample s;
+    s.a_body = {a_clean.x + noise(rng), a_clean.y + noise(rng), a_clean.z + noise(rng)};
+    s.a_body_std = 0.04;
+    s.n_samples = 50;
+    aligner.onNewKeyframeRaw(i, s);
+    poses[i] = CPose3D::Identity();
+  }
+
+  auto corr = aligner.estimateGlobalCorrection(poses);
+  ASSERT_TRUE(corr.has_value());
+
+  // R_corr = rotationFromGravity(g_odom_mean) sends g_odom_mean to +Z.
+  // For g_odom_mean ≈ (sin(tilt),0,cos(tilt))*g, the extracted pitch is ≈ -tilt_deg.
+  double yaw = 0, pitch = 0, roll = 0;
+  corr->getYawPitchRoll(yaw, pitch, roll);
+  EXPECT_NEAR(pitch * 180.0 / M_PI, -tilt_deg, 0.1)
+    << "Pitch correction should cancel the known tilt";
+  EXPECT_NEAR(roll * 180.0 / M_PI, 0.0, 0.1);
+  EXPECT_NEAR(yaw * 180.0 / M_PI, 0.0, 1e-8);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: 20 % outlier KFs (high linear accel) → Huber keeps estimate stable
+// ---------------------------------------------------------------------------
+TEST(GravityMapAligner, HuberRobustness_outliersIgnored)
+{
+  const double tilt_deg = 2.0;
+  const double tilt_rad = tilt_deg * M_PI / 180.0;
+
+  GravityMapAligner::Params p;
+  p.min_keyframes = 10;
+  p.huber_threshold_mps2 = 0.5;
+  p.max_kf_acc_std_mps2 = 1.5;
+  p.irls_iterations = 3;
+  GravityMapAligner aligner(p);
+
+  std::mt19937 rng(7);
+  std::normal_distribution<double> small_noise(0.0, 0.04);
+  std::normal_distribution<double> big_noise(0.0, 3.0);  // outlier
+
+  std::map<GravityMapAligner::KeyFrameID, CPose3D> poses;
+  for (uint64_t i = 0; i < 50; ++i) {
+    const TVector3D a_clean = bodyGravity(tilt_rad);
+    const bool outlier = (i % 5 == 0);  // exactly 20 %
+    const double std_used = outlier ? 2.5 : 0.04;
+    auto & nd = outlier ? big_noise : small_noise;
+    GravityMapAligner::KFAccSample s;
+    s.a_body = {a_clean.x + nd(rng), a_clean.y + nd(rng), a_clean.z + nd(rng)};
+    s.a_body_std = std_used;
+    s.n_samples = 50;
+    aligner.onNewKeyframeRaw(i, s);
+    poses[i] = CPose3D::Identity();
+  }
+
+  auto corr = aligner.estimateGlobalCorrection(poses);
+  ASSERT_TRUE(corr.has_value());
+
+  // Despite 20 % outlier KFs the estimator should still recover pitch ≈ -tilt_deg.
+  // The per-std down-weighting (1e-3 for std_i > max_kf_acc_std_mps2) combined
+  // with Huber IRLS suppresses the large-noise KFs.
+  double yaw = 0, pitch = 0, roll = 0;
+  corr->getYawPitchRoll(yaw, pitch, roll);
+  EXPECT_NEAR(pitch * 180.0 / M_PI, -tilt_deg, 0.2)
+    << "Huber test: pitch estimate should survive 20% outlier KFs";
+  EXPECT_NEAR(yaw * 180.0 / M_PI, 0.0, 1e-8);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: onKeyframeDropped removes the KF; dropping enough falls below min
+// ---------------------------------------------------------------------------
+TEST(GravityMapAligner, DropKeyframe_poolShrinks)
+{
+  GravityMapAligner::Params p;
+  p.min_keyframes = 10;
+  GravityMapAligner aligner(p);
+
+  std::map<GravityMapAligner::KeyFrameID, CPose3D> poses;
+  for (uint64_t i = 0; i < 12; ++i) {
+    aligner.onNewKeyframeRaw(i, {{0, 0, 9.81}, 0.01, 10});
+    poses[i] = CPose3D::Identity();
+  }
+  EXPECT_TRUE(aligner.estimateGravityVector(poses).has_value());
+
+  // Drop until we're below threshold.
+  aligner.onKeyframeDropped(0);
+  aligner.onKeyframeDropped(1);
+  aligner.onKeyframeDropped(2);  // now 9 remain
+  EXPECT_EQ(aligner.size(), 9u);
+  EXPECT_FALSE(aligner.estimateGravityVector(poses).has_value());
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: rotationFromGravity is pitch/roll-only (yaw == 0)
+// ---------------------------------------------------------------------------
+TEST(GravityMapAligner, rotationFromGravity_noYaw)
+{
+  // Arbitrary tilted vector.
+  const TVector3D g{0.3, 0.1, 9.8};
+  const CPose3D R = GravityMapAligner::rotationFromGravity(g);
+
+  double yaw = 0, pitch = 0, roll = 0;
+  R.getYawPitchRoll(yaw, pitch, roll);
+  EXPECT_NEAR(yaw * 180.0 / M_PI, 0.0, 1e-8) << "rotationFromGravity must not produce yaw";
+
+  // After applying R, the vector should point to +Z.
+  mrpt::math::TPoint3D p_local(g.x, g.y, g.z);
+  mrpt::math::TPoint3D p_world, orig_world;
+  R.composePoint(p_local, p_world);
+  R.composePoint(mrpt::math::TPoint3D(0, 0, 0), orig_world);
+  const TVector3D r{p_world.x - orig_world.x, p_world.y - orig_world.y, p_world.z - orig_world.z};
+  EXPECT_LT(angleToPlusZ_deg(r), 0.001) << "rotationFromGravity must send g to +Z";
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: per-KF window correction
+// ---------------------------------------------------------------------------
+TEST(GravityMapAligner, PerKFCorrection_windowedResult)
+{
+  // 20 KFs all with the same 2° pitch — every KF should get a correction.
+  const double tilt_rad = 2.0 * M_PI / 180.0;
+
+  GravityMapAligner::Params p;
+  p.min_keyframes = 3;
+  GravityMapAligner aligner(p);
+
+  std::map<GravityMapAligner::KeyFrameID, CPose3D> poses;
+  for (uint64_t i = 0; i < 20; ++i) {
+    aligner.onNewKeyframeRaw(i, {bodyGravity(tilt_rad), 0.02, 20});
+    poses[i] = makePitch(tilt_rad);
+  }
+
+  const auto per_kf = aligner.estimatePerKFCorrection(poses, /*P=*/5, /*min_pool=*/3);
+  EXPECT_EQ(per_kf.size(), 20u) << "All 20 KFs should have a per-KF correction";
+
+  // Each per-KF correction must have zero yaw.
+  for (const auto & [id, R] : per_kf) {
+    double yaw = 0, pitch = 0, roll = 0;
+    R.getYawPitchRoll(yaw, pitch, roll);
+    EXPECT_NEAR(yaw * 180.0 / M_PI, 0.0, 1e-7) << "Per-KF correction must have zero yaw, KF " << id;
+  }
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_trajectory_rebaker.cpp
+++ b/test/test_trajectory_rebaker.cpp
@@ -1,0 +1,306 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * Unit tests for TrajectoryRebaker.
+ * Tests §5.3 and §5.4 of TODOs/online-gravity-alignment.md.
+ * All synthetic; no external datasets.
+ */
+
+#include <gtest/gtest.h>
+#include <mola_lidar_odometry/GravityMapAligner.h>
+#include <mola_lidar_odometry/TrajectoryRebaker.h>
+#include <mrpt/poses/CPose3D.h>
+
+#include <cmath>
+
+using namespace mola;
+using mrpt::poses::CPose3D;
+using KeyFrameID = TrajectoryRebaker::KeyFrameID;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+namespace
+{
+CPose3D makePose(double x, double y, double z, double yaw, double pitch, double roll)
+{
+  return CPose3D(x, y, z, yaw, pitch, roll);
+}
+
+// Pitch-only rotation about Y by angle_rad.
+CPose3D makeRot(double pitch_rad, double roll_rad = 0.0)
+{
+  return {0, 0, 0, 0.0, pitch_rad, roll_rad};
+}
+
+// Extract pitch in degrees from a CPose3D.
+double pitchDeg(const CPose3D & p)
+{
+  double y, pitch, r;
+  p.getYawPitchRoll(y, pitch, r);
+  return pitch * 180.0 / M_PI;
+}
+
+// Extract position z from a CPose3D.
+double zPos(const CPose3D & p) { return p.z(); }
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Test 1: empty inputs → empty result.
+// ---------------------------------------------------------------------------
+TEST(TrajectoryRebaker, EmptyInput_returnsEmpty)
+{
+  std::map<KeyFrameID, CPose3D> poses, r_grav;
+  const auto result = TrajectoryRebaker::rebake(poses, r_grav);
+  EXPECT_TRUE(result.corrected_poses.empty());
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: single KF (anchor only) → position unchanged, rotation corrected.
+// ---------------------------------------------------------------------------
+TEST(TrajectoryRebaker, SingleKF_anchorRotationCorrected)
+{
+  const double tilt = 3.0 * M_PI / 180.0;
+
+  std::map<KeyFrameID, CPose3D> poses, r_grav;
+  poses[0] = makePose(10.0, 5.0, 2.0, 0.0, tilt, 0.0);
+  r_grav[0] = makeRot(-tilt);  // corrects the tilt
+
+  const auto result = TrajectoryRebaker::rebake(poses, r_grav, 0);
+  ASSERT_EQ(result.corrected_poses.size(), 1u);
+
+  const CPose3D & corrected = result.corrected_poses.at(0);
+
+  // Position must be unchanged.
+  EXPECT_NEAR(corrected.x(), 10.0, 1e-9);
+  EXPECT_NEAR(corrected.y(), 5.0, 1e-9);
+  EXPECT_NEAR(corrected.z(), 2.0, 1e-9);
+
+  // Rotation: R_grav * R_odom = Ry(-tilt) * Ry(tilt) = identity → pitch ≈ 0.
+  EXPECT_NEAR(pitchDeg(corrected), 0.0, 1e-6);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: two KFs — anchor frozen, second KF position re-integrated.
+// ---------------------------------------------------------------------------
+TEST(TrajectoryRebaker, TwoKFs_relativeGeometryPreserved)
+{
+  // Robot drives 10 m forward (along X) in a frame with 5° pitch drift.
+  const double tilt = 5.0 * M_PI / 180.0;
+
+  std::map<KeyFrameID, CPose3D> poses, r_grav;
+  // KF 0: at origin, pitched 5°.
+  poses[0] = makePose(0.0, 0.0, 0.0, 0.0, tilt, 0.0);
+  // KF 1: 10 m ahead in the (tilted) odom frame.
+  poses[1] = makePose(10.0, 0.0, 0.0, 0.0, tilt, 0.0);
+
+  // Same correction for both KFs: undo the 5° tilt.
+  r_grav[0] = makeRot(-tilt);
+  r_grav[1] = makeRot(-tilt);
+
+  const auto result = TrajectoryRebaker::rebake(poses, r_grav, 0);
+  ASSERT_EQ(result.corrected_poses.size(), 2u);
+
+  const CPose3D & c0 = result.corrected_poses.at(0);
+  const CPose3D & c1 = result.corrected_poses.at(1);
+
+  // Anchor position is frozen.
+  EXPECT_NEAR(c0.x(), 0.0, 1e-9);
+  EXPECT_NEAR(c0.y(), 0.0, 1e-9);
+  EXPECT_NEAR(c0.z(), 0.0, 1e-9);
+
+  // Both KFs should now have ~0° pitch.
+  EXPECT_NEAR(pitchDeg(c0), 0.0, 1e-6);
+  EXPECT_NEAR(pitchDeg(c1), 0.0, 1e-6);
+
+  // The 10 m travel should be preserved in magnitude.
+  const double dist = std::sqrt(
+    std::pow(c1.x() - c0.x(), 2) + std::pow(c1.y() - c0.y(), 2) + std::pow(c1.z() - c0.z(), 2));
+  EXPECT_NEAR(dist, 10.0, 1e-6);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: §5.3 — 100 KFs, straight horizontal path, 10° linear pitch drift.
+//
+// The odom frame accumulates 10° of pitch drift linearly (0.1°/KF) so that
+// what should be a flat horizontal path appears to go uphill. R_grav[i] is
+// the ground-truth correction (undo the drift at that KF). After rebake:
+//  - Per-KF pitch residual < 0.05°.
+//  - Z-position drift from true path < 5 cm per 100 m traversed.
+// ---------------------------------------------------------------------------
+TEST(TrajectoryRebaker, LinearDrift_recoversHorizontalPath)
+{
+  const int N_KFS = 100;
+  const double step_m = 1.0;      // 1 m between KFs
+  const double max_drift = 10.0;  // total drift in degrees
+
+  std::map<KeyFrameID, CPose3D> odom_poses, r_grav;
+
+  // Build drifted odom poses: odom frame tilted by pitch_rad at each KF.
+  // The robot physically moves 1 m forward (world X) per step. In the tilted
+  // odom frame this appears as (cos(p), 0, -sin(p)) per step — flat forward
+  // motion looks slightly downward in a forward-tilted odom frame.
+  // R_grav[i] = Ry(-pitch_i): undoes the tilt at each KF.
+  double x_odom = 0.0, z_odom = 0.0;
+  for (int i = 0; i < N_KFS; ++i) {
+    const double drift_deg = max_drift * static_cast<double>(i) / (N_KFS - 1);
+    const double pitch_rad = drift_deg * M_PI / 180.0;
+
+    // T_i.R = Ry(pitch_rad): robot flat in world, odom frame tilted by pitch_rad.
+    odom_poses[i] = makePose(x_odom, 0.0, z_odom, 0.0, pitch_rad, 0.0);
+
+    // Physical forward motion (world X) in the tilted odom frame: (cos(p), 0, -sin(p)).
+    if (i < N_KFS - 1) {
+      x_odom += step_m * std::cos(pitch_rad);
+      z_odom -= step_m * std::sin(pitch_rad);
+    }
+
+    // g_odom = Ry(pitch) * (0,0,g) = (sin(p)*g, 0, cos(p)*g).
+    // rotationFromGravity returns Ry(-pitch), which sends g_odom to +Z.
+    r_grav[i] = GravityMapAligner::rotationFromGravity(
+      {std::sin(pitch_rad) * 9.81, 0.0, std::cos(pitch_rad) * 9.81});
+  }
+
+  const auto result = TrajectoryRebaker::rebake(odom_poses, r_grav, 0);
+  ASSERT_EQ(result.corrected_poses.size(), static_cast<std::size_t>(N_KFS));
+
+  // Anchor position must be unchanged.
+  EXPECT_NEAR(result.corrected_poses.at(0).x(), odom_poses.at(0).x(), 1e-9);
+  EXPECT_NEAR(result.corrected_poses.at(0).z(), odom_poses.at(0).z(), 1e-9);
+
+  // Check all KFs after anchor.
+  for (int i = 0; i < N_KFS; ++i) {
+    const CPose3D & c = result.corrected_poses.at(i);
+
+    // Pitch residual < 0.05°.
+    EXPECT_NEAR(pitchDeg(c), 0.0, 0.05) << "KF " << i << " pitch residual too large";
+
+    // Z should be ~0 (flat path). Tolerance: 5 cm per 100 m → 5 cm total here.
+    EXPECT_NEAR(zPos(c), 0.0, 0.05) << "KF " << i << " Z drift too large";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: §5.4 — non-monotonic drift (grows to 5° then decays to 1°).
+//
+// Confirms that the rebake distributes correction non-uniformly along the
+// chain: it is NOT a single global rotation (which would fail here).
+// ---------------------------------------------------------------------------
+TEST(TrajectoryRebaker, NonMonotonicDrift_nonUniformCorrection)
+{
+  const int N_KFS = 100;
+  const double step_m = 1.0;
+
+  // Drift profile: rises linearly to 5° at midpoint, falls to 1° at end.
+  auto drift_deg = [&](int i) -> double {
+    const double t = static_cast<double>(i) / (N_KFS - 1);
+    if (t <= 0.5) {
+      return 5.0 * (2.0 * t);  // 0 → 5°
+    }
+    return 5.0 - (5.0 - 1.0) * (2.0 * (t - 0.5));  // 5° → 1°
+  };
+
+  std::map<KeyFrameID, CPose3D> odom_poses, r_grav;
+
+  double x_odom = 0.0, z_odom = 0.0;
+  for (int i = 0; i < N_KFS; ++i) {
+    const double pitch_rad = drift_deg(i) * M_PI / 180.0;
+    odom_poses[i] = makePose(x_odom, 0.0, z_odom, 0.0, pitch_rad, 0.0);
+
+    if (i < N_KFS - 1) {
+      x_odom += step_m * std::cos(pitch_rad);
+      z_odom -= step_m * std::sin(pitch_rad);  // tilted odom: flat forward looks downward
+    }
+
+    r_grav[i] = GravityMapAligner::rotationFromGravity(
+      {std::sin(pitch_rad) * 9.81, 0.0, std::cos(pitch_rad) * 9.81});
+  }
+
+  const auto result = TrajectoryRebaker::rebake(odom_poses, r_grav, 0);
+  ASSERT_EQ(result.corrected_poses.size(), static_cast<std::size_t>(N_KFS));
+
+  // All KFs should have near-zero pitch after rebake.
+  for (int i = 0; i < N_KFS; ++i) {
+    EXPECT_NEAR(pitchDeg(result.corrected_poses.at(i)), 0.0, 0.05)
+      << "KF " << i << " (non-monotonic drift test) pitch residual";
+  }
+
+  // The midpoint correction must differ from the endpoint correction,
+  // proving a single global rotation was NOT applied.
+  // With a global rotation of, say, -3° (average drift), midpoint KFs would
+  // still have ~2° residual. Our rebake should bring both to ~0°.
+  EXPECT_NEAR(pitchDeg(result.corrected_poses.at(0)), 0.0, 0.05);
+  EXPECT_NEAR(pitchDeg(result.corrected_poses.at(50)), 0.0, 0.05);
+  EXPECT_NEAR(pitchDeg(result.corrected_poses.at(99)), 0.0, 0.05);
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: KFs missing from r_grav get identity correction (pass-through).
+// ---------------------------------------------------------------------------
+TEST(TrajectoryRebaker, MissingRgrav_identityFallback)
+{
+  // Three KFs: only the middle one has a correction.
+  std::map<KeyFrameID, CPose3D> poses, r_grav;
+  const double tilt = 4.0 * M_PI / 180.0;
+
+  poses[0] = makePose(0.0, 0.0, 0.0, 0.0, tilt, 0.0);
+  poses[1] = makePose(5.0, 0.0, 0.0, 0.0, tilt, 0.0);
+  poses[2] = makePose(10.0, 0.0, 0.0, 0.0, tilt, 0.0);
+
+  // Only r_grav for KF 0 (anchor) — others fall back to identity.
+  r_grav[0] = makeRot(-tilt);
+
+  const auto result = TrajectoryRebaker::rebake(poses, r_grav, 0);
+  ASSERT_EQ(result.corrected_poses.size(), 3u);
+
+  // Anchor: rotation corrected.
+  EXPECT_NEAR(pitchDeg(result.corrected_poses.at(0)), 0.0, 1e-6);
+
+  // KF 1 & 2: identity correction → rotation = tilt (not corrected by r_grav).
+  // Their positions ARE re-integrated relative to the corrected anchor though.
+  EXPECT_NEAR(pitchDeg(result.corrected_poses.at(1)), pitchDeg(poses.at(1)), 1e-6);
+  EXPECT_NEAR(pitchDeg(result.corrected_poses.at(2)), pitchDeg(poses.at(2)), 1e-6);
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: computePublishResidual — result is T_before⁻¹ * T_after.
+// ---------------------------------------------------------------------------
+TEST(TrajectoryRebaker, PublishResidual_inverseCompose)
+{
+  const CPose3D before = makePose(1.0, 2.0, 0.0, 0.1, 0.05, 0.0);
+  const CPose3D after = makePose(1.0, 2.0, 0.0, 0.1, 0.0, 0.0);  // pitch corrected
+
+  const CPose3D residual = TrajectoryRebaker::computePublishResidual(before, after);
+
+  // Publish-continuity contract: residual + after == before, so that
+  // immediately after a rebake the published pose does not jump.
+  const CPose3D reconstructed = residual + after;
+
+  EXPECT_NEAR(reconstructed.x(), before.x(), 1e-9);
+  EXPECT_NEAR(reconstructed.y(), before.y(), 1e-9);
+  EXPECT_NEAR(reconstructed.z(), before.z(), 1e-9);
+
+  double y_r, p_r, r_r;
+  reconstructed.getYawPitchRoll(y_r, p_r, r_r);
+  double y_b, p_b, r_b;
+  before.getYawPitchRoll(y_b, p_b, r_b);
+  EXPECT_NEAR(p_r, p_b, 1e-9);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
New class GravityMapAligner stores one time-averaged body-frame accelerometer sample per keyframe and provides:
- estimateGravityVector / estimatePerKFCorrection: IRLS/Huber-robust weighted mean of R_i·a_body_i to estimate gravity direction in the odom frame, with per-window support for the per-KF rebake path.
- rotationFromGravity: pitch/roll-only correction (zero yaw by construction) that sends the estimated gravity vector to +Z.
- onNewKeyframe / onKeyframeDropped for pool lifecycle management.

Unit tests cover: nullopt below threshold, zero-tilt identity correction, 2° pitch convergence (<0.1°), Huber robustness with 20% outlier KFs, pool eviction, yaw-free output, and per-KF windowed estimation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gravity map aligner component to process per-keyframe accelerometer measurements and estimate gravity-corrected orientations.
  * Added trajectory rebaker utility to generate gravity-adjusted pose trajectories with per-keyframe corrections.

* **Tests**
  * Added comprehensive unit tests for gravity alignment and trajectory correction components.

* **Chores**
  * Refactored build configuration for explicit source file enumeration.
  * Updated development settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->