### PR TITLE
review: address gravity-aligner / rebaker review comments

### DIFF
--- a/module/include/mola_lidar_odometry/GravityMapAligner.h
+++ b/module/include/mola_lidar_odometry/GravityMapAligner.h
@@ -46,6 +46,10 @@ class GravityMapAligner
 public:
   using KeyFrameID = uint64_t;
 
+  /// Default numerical guard for axis-angle degeneracies in
+  /// rotationFromGravity / Params::axis_eps.
+  static constexpr double kDefaultAxisEps = 1e-9;
+
   struct Params
   {
     /// Don't produce any estimate below this pool size.
@@ -65,7 +69,7 @@ public:
     double expected_g_mps2 = 9.81;
 
     /// Numerical guard for axis-angle near-zero/180°.
-    double axis_eps = 1e-9;
+    double axis_eps = kDefaultAxisEps;
   };
 
   /// One averaged sample per KF.
@@ -83,8 +87,10 @@ public:
   void setParams(Params p) { params_ = std::move(p); }
 
   /// Register a KF and the accelerometer samples taken during its interval.
-  /// Computes and stores the time-averaged `a_body` and intra-KF std of |a|.
-  /// If `samples.a_b` is empty, the KF is NOT added to the pool.
+  /// Computes and stores, from the samples in `window`, the time-averaged
+  /// body-frame acceleration `a_body` and the intra-KF std of |a|.
+  /// If `window` contains no accelerometer samples (e.g., empty), the KF is
+  /// NOT added to the pool.
   void onNewKeyframe(KeyFrameID id, const mola::imu::LocalVelocityBuffer::SamplesByTime & window);
 
   /// Insert a pre-computed sample directly (useful for tests / rehydration).
@@ -124,7 +130,7 @@ public:
    *  Returns identity if `g_hat` is already aligned with +Z within axis_eps.
    */
   static mrpt::poses::CPose3D rotationFromGravity(
-    const mrpt::math::TVector3D & g_hat, double axis_eps = 1e-9);
+    const mrpt::math::TVector3D & g_hat, double axis_eps = kDefaultAxisEps);
 
   /** One-shot pool-wide correction: pitch+roll rotation sending the robust
    *  pool mean of `R_i · a_i` (in the `kf_poses` frame) to +Z.

--- a/module/include/mola_lidar_odometry/TrajectoryRebaker.h
+++ b/module/include/mola_lidar_odometry/TrajectoryRebaker.h
@@ -104,19 +104,21 @@ public:
   /**
    * @brief Compute the publish residual after a rebake.
    *
-   * When a rebake changes the pose of the most-recent KF (id `tail_kf_id`),
-   * the live per-scan pose needs a compensating transform so that the
-   * published pose shows no jump:
+   * Unconditionally returns the residual transform that, when LEFT-composed
+   * onto `tail_pose_after`, reproduces `tail_pose_before`:
    *
-   *   T_grav_publish_new = T_tail_old * T_tail_new.inverse()
+   *   residual + tail_pose_after == tail_pose_before
    *
-   * Contract: applying the residual to the post-rebake tail pose reproduces
-   * the pre-rebake tail pose, i.e. `residual + tail_after == tail_before`.
-   * The caller LEFT-composes this onto the live (post-rebake) pose between
+   * The caller left-composes this onto the live (post-rebake) pose between
    * rebakes (`pose_pub = residual + pose_stored`) so the publish stream is
    * continuous across the rebake event.
    *
-   * Returns identity if `tail_kf_id` is absent from either map.
+   * Callers are responsible for skipping the call when the tail keyframe is
+   * missing from the relevant maps; this function performs no such check.
+   *
+   * @param tail_pose_before  Tail KF pose before the rebake.
+   * @param tail_pose_after   Tail KF pose after the rebake.
+   * @returns                 The residual `tail_pose_before + (-tail_pose_after)`.
    */
   static mrpt::poses::CPose3D computePublishResidual(
     const mrpt::poses::CPose3D & tail_pose_before, const mrpt::poses::CPose3D & tail_pose_after);

--- a/module/src/TrajectoryRebaker.cpp
+++ b/module/src/TrajectoryRebaker.cpp
@@ -25,6 +25,17 @@ TrajectoryRebaker::Result TrajectoryRebaker::rebake(
     return result;
   }
 
+  // Make sure there's at least one KF >= anchor_id so the loop will enter the
+  // anchor branch; otherwise corrected_poses would silently be empty while
+  // result.anchor_id still claimed the requested id. Slide the anchor forward
+  // to the first available id in that case, and report it back to the caller.
+  auto anchor_it = odom_poses.lower_bound(anchor_id);
+  if (anchor_it == odom_poses.end()) {
+    return result;
+  }
+  anchor_id = anchor_it->first;
+  result.anchor_id = anchor_id;
+
   // Identity correction for KFs absent from r_grav.
   const mrpt::poses::CPose3D identity = mrpt::poses::CPose3D::Identity();
 
@@ -80,12 +91,7 @@ TrajectoryRebaker::Result TrajectoryRebaker::rebake(
       const mrpt::poses::CPose3D C = prev_new + (-prev_odom);  // R_new * R_odom^-1
 
       // Rotate the odom displacement into the corrected frame:
-      mrpt::math::TPoint3D dp_local(delta_odom.x, delta_odom.y, delta_odom.z);
-      mrpt::math::TPoint3D dp_world, origin_world;
-      C.composePoint(dp_local, dp_world);
-      C.composePoint(mrpt::math::TPoint3D(0, 0, 0), origin_world);
-      const mrpt::math::TVector3D delta_new{
-        dp_world.x - origin_world.x, dp_world.y - origin_world.y, dp_world.z - origin_world.z};
+      const mrpt::math::TVector3D delta_new = C.rotateVector(delta_odom);
 
       // New corrected rotation: R_grav_i * R_i_odom.
       mrpt::poses::CPose3D T_new = Rg + T_odom;
@@ -109,10 +115,9 @@ TrajectoryRebaker::Result TrajectoryRebaker::rebake(
   const std::map<KeyFrameID, mrpt::poses::CPose3D> & odom_poses,
   const std::map<KeyFrameID, mrpt::poses::CPose3D> & r_grav)
 {
-  if (odom_poses.empty()) {
-    return {};
-  }
-  return rebake(odom_poses, r_grav, odom_poses.begin()->first);
+  // Three-arg overload already handles the empty-input case.
+  const KeyFrameID anchor = odom_poses.empty() ? KeyFrameID{0} : odom_poses.begin()->first;
+  return rebake(odom_poses, r_grav, anchor);
 }
 
 mrpt::poses::CPose3D TrajectoryRebaker::computePublishResidual(

--- a/test/test_gravity_map_aligner.cpp
+++ b/test/test_gravity_map_aligner.cpp
@@ -43,16 +43,16 @@ CPose3D makePitch(double angle_rad)
   return {q, 0, 0, 0};
 }
 
-// Body-frame gravity when the robot is pitched by angle_rad in world frame.
-// World gravity = (0,0,-g). Body frame = world rotated by pitch.
-// a_body = R_body_world · (0,0,-g)  = R_world_body^T · (0,0,-g).
+// Body-frame proper acceleration (= -gravity, the value an accelerometer
+// measures) when the robot is pitched by angle_rad about +Y (nose up).
+// Accelerometer convention: with the robot upright, gravity is (0,0,-g) in
+// world, the accelerometer reads (0,0,+g) in body (pointing "up" through the
+// floor). Pitched by angle_rad:
+//   a_body.x = g * sin(pitch_rad)
+//   a_body.y = 0
+//   a_body.z = +g * cos(pitch_rad)
 TVector3D bodyGravity(double pitch_rad, double g = 9.81)
 {
-  // With pure pitch by angle_rad about Y (nose up):
-  //   a_body.x = g * sin(pitch_rad)
-  //   a_body.y = 0
-  //   a_body.z = -g * cos(pitch_rad)
-  // (proper acceleration = -gravity in body frame, pointing "up" through the floor)
   return {g * std::sin(pitch_rad), 0.0, g * std::cos(pitch_rad)};
 }
 
@@ -80,12 +80,7 @@ double maxGravityErrorDeg(
       continue;
     }
     const CPose3D corrected = R_corr + itp->second;  // R_corr left-multiplied
-    mrpt::math::TPoint3D ab_local(s.a_body.x, s.a_body.y, s.a_body.z);
-    mrpt::math::TPoint3D ab_world, orig_world;
-    corrected.composePoint(ab_local, ab_world);
-    corrected.composePoint(mrpt::math::TPoint3D(0, 0, 0), orig_world);
-    const TVector3D g_world{
-      ab_world.x - orig_world.x, ab_world.y - orig_world.y, ab_world.z - orig_world.z};
+    const TVector3D g_world = corrected.rotateVector(s.a_body);
     max_err = std::max(max_err, angleToPlusZ_deg(g_world));
   }
   return max_err;
@@ -185,6 +180,12 @@ TEST(GravityMapAligner, KnownPitchTilt_converges)
     << "Pitch correction should cancel the known tilt";
   EXPECT_NEAR(roll * 180.0 / M_PI, 0.0, 0.1);
   EXPECT_NEAR(yaw * 180.0 / M_PI, 0.0, 1e-8);
+
+  // Sanity: applying R_corr to each pooled accel should put it near +Z.
+  // This is a per-KF MAX (not a pool mean), so per-sample accel noise of
+  // ~0.04 m/s² translates to ~0.04/9.81 rad ≈ 0.23° per axis, and the max
+  // over 30 KFs can reasonably reach ~1°.
+  EXPECT_LT(maxGravityErrorDeg(poses, aligner, *corr), 1.0);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/test_trajectory_rebaker.cpp
+++ b/test/test_trajectory_rebaker.cpp
@@ -136,7 +136,12 @@ TEST(TrajectoryRebaker, TwoKFs_relativeGeometryPreserved)
 //
 // The odom frame accumulates 10° of pitch drift linearly (0.1°/KF) so that
 // what should be a flat horizontal path appears to go uphill. R_grav[i] is
-// the ground-truth correction (undo the drift at that KF). After rebake:
+// constructed via GravityMapAligner::rotationFromGravity for each KF, so
+// R_grav[i] EXACTLY cancels T_odom[i].R per KF (perfect per-KF correction
+// scenario). The 5 cm Z tolerance is valid under that assumption; a
+// global/noisy r_grav scenario would need a looser tolerance and is not
+// covered here.
+// After rebake:
 //  - Per-KF pitch residual < 0.05°.
 //  - Z-position drift from true path < 5 cm per 100 m traversed.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
- Fix stale Doxygen on onNewKeyframe (window param) and computePublishResidual (drop tail_kf_id reference, document unconditional residual contract).
- TrajectoryRebaker::rebake: slide anchor forward to lower_bound when no KF
  >= anchor_id exists, so corrected_poses and reported anchor_id stay
  consistent.
- Remove redundant empty-input guard in two-arg rebake overload.
- Replace composePoint+subtraction delta computation with rotateVector in TrajectoryRebaker and the test helper.
- Extract kDefaultAxisEps single source of truth used by Params and rotationFromGravity.
- Fix sign in test bodyGravity comment (a_body.z = +g*cos), clarify accelerometer convention.
- Wire maxGravityErrorDeg into KnownPitchTilt_converges as a sanity check.
- Clarify LinearDrift_recoversHorizontalPath comment that R_grav per-KF exactly cancels T_odom.R (scenario justifying the 5cm Z tolerance).