### PR TITLE
fix: stamp published pose with deskew reference time, not raw obs stamp

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -998,13 +998,13 @@ private:
   void onExternalMapUpdate(const MapSourceBase::MapUpdate & mu);
   void onExternalLocalizationUpdate(const LocalizationSourceBase::LocalizationUpdate & lu);
 
-  void doPublishUpdatedLocalization(const mrpt::Clock::time_point & this_obs_tim);
+  void doPublishUpdatedLocalization(const mrpt::Clock::time_point & scan_ref_time);
 
-  void doPublishUpdatedLocalMap(const mrpt::Clock::time_point & this_obs_tim);
+  void doPublishUpdatedLocalMap(const mrpt::Clock::time_point & scan_ref_time);
 
-  void doPublishDeskewedScan(const mrpt::Clock::time_point & this_obs_tim);
+  void doPublishDeskewedScan(const mrpt::Clock::time_point & scan_ref_time);
 
-  void doWriteDebugTracesFile(const mrpt::Clock::time_point & this_obs_tim);
+  void doWriteDebugTracesFile(const mrpt::Clock::time_point & scan_ref_time);
   std::optional<std::ofstream> debug_traces_of_;
 
   void unloadPastSimplemapObservations(size_t maxSizeUnloadQueue) const;
@@ -1031,7 +1031,7 @@ private:
 
   void doUpdateSimpleMap(
     const mrpt::obs::CSensoryFrame & sf, bool distance_enough_sm,
-    const mp2p_icp::metric_map_t::Ptr & observation, const mrpt::Clock::time_point & this_obs_tim,
+    const mp2p_icp::metric_map_t::Ptr & observation, const mrpt::Clock::time_point & scan_ref_time,
     const mrpt::maps::CPointsMap::Ptr & deskewedCloud);
 };
 

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -584,7 +584,7 @@ void LidarOdometry::onInitializePersistentState()
   }
 }
 
-void LidarOdometry::doWriteDebugTracesFile(const mrpt::Clock::time_point & this_obs_tim)
+void LidarOdometry::doWriteDebugTracesFile(const mrpt::Clock::time_point & scan_ref_time)
 {
   if (!params_.debug_traces.save_to_file) {
     return;  // disabled
@@ -611,7 +611,7 @@ void LidarOdometry::doWriteDebugTracesFile(const mrpt::Clock::time_point & this_
   auto & of = debug_traces_of_.value();
 
   auto vars = state_.parameter_source.getVariableValues();
-  vars["timestamp"] = mrpt::Clock::toDouble(this_obs_tim);
+  vars["timestamp"] = mrpt::Clock::toDouble(scan_ref_time);
   vars["time_onLidar"] = profiler_.getLastTime("onLidar");
 
   if (firstLine) {

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -215,6 +215,17 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     return;
   }
 
+  // The ICP-derived pose corresponds to the vehicle at t=0 of the deskewed
+  // cloud, i.e. the local velocity buffer's reference_zero_time (set by
+  // Generator to obs.timestamp, then shifted by FilterAdjustTimestamps when
+  // configured, e.g. MiddleIsZero -> mid-scan). Use it consistently for any
+  // pose-time semantics (state fusion, trajectory, published stamps).
+  // With no per-point time adjustment configured this equals obs->timestamp.
+  const double scan_ref_time_s =
+    state_.parameter_source.localVelocityBuffer.get_reference_zero_time();
+  const auto scan_ref_time =
+    scan_ref_time_s > 0 ? mrpt::Clock::fromDouble(scan_ref_time_s) : this_obs_tim;
+
   // local map: used for LIDAR odometry:
   bool updateLocalMap = false;
 
@@ -230,7 +241,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
   ProfilerEntry tleMotion(profiler_, "onLidar.2b.estimated_navstate");
 
   state_.last_motion_model_output =
-    state_.navstate_fuse->estimated_navstate(this_obs_tim, params_.publish_reference_frame);
+    state_.navstate_fuse->estimated_navstate(scan_ref_time, params_.publish_reference_frame);
 
   bool hasMotionModel = state_.last_motion_model_output.has_value();
 
@@ -264,7 +275,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     {
       auto lck = mrpt::lockHelper(state_trajectory_mtx_);
       state_.estimated_trajectory.insert(
-        this_obs_tim, params_.initial_localization.fixed_initial_pose);
+        scan_ref_time, params_.initial_localization.fixed_initial_pose);
     }
 
     // Define the current robot pose at the origin with minimal uncertainty
@@ -273,7 +284,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     initPose.mean = mrpt::poses::CPose3D(params_.initial_localization.fixed_initial_pose);
     initPose.cov.setDiagonal(1e-12);
 
-    state_.navstate_fuse->fuse_pose(this_obs_tim, initPose, params_.publish_reference_frame);
+    state_.navstate_fuse->fuse_pose(scan_ref_time, initPose, params_.publish_reference_frame);
   } else {
     // Register point clouds using ICP:
     // ------------------------------------
@@ -544,7 +555,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       if (state_.step_counter_post_relocalization == 0) {
         // Do integrate info:
         state_.navstate_fuse->fuse_pose(
-          this_obs_tim, out.found_pose_to_wrt_from, params_.publish_reference_frame);
+          scan_ref_time, out.found_pose_to_wrt_from, params_.publish_reference_frame);
       } else {
         // Skip during post-relocalization:
         state_.step_counter_post_relocalization--;
@@ -559,7 +570,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     // Update trajectory too:
     if (icpIsGood) {
       auto lck = mrpt::lockHelper(state_trajectory_mtx_);
-      state_.estimated_trajectory.insert(this_obs_tim, state_.last_lidar_pose.mean);
+      state_.estimated_trajectory.insert(scan_ref_time, state_.last_lidar_pose.mean);
     }
 
     // Update for stats in CSV format:
@@ -735,13 +746,14 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 
   // Optional build simplemap:
   if (updateSimpleMap) {
-    doUpdateSimpleMap(sf, distance_enough_sm, observation, this_obs_tim, fullCloudForVizAndPublish);
+    doUpdateSimpleMap(
+      sf, distance_enough_sm, observation, scan_ref_time, fullCloudForVizAndPublish);
   }
 
   // In any case, publish the vehicle pose, no matter if it's a keyframe or not,
   // if ICP quality was good enough:
   if (state_.last_icp_was_good) {
-    doPublishUpdatedLocalization(this_obs_tim);
+    doPublishUpdatedLocalization(scan_ref_time);
   }
 
   // Prepare deskewed scan for publishing:
@@ -766,14 +778,14 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
   }
 
   // Publish new local map & deskewed scan for visualization on external systems (ROS):
-  doPublishUpdatedLocalMap(this_obs_tim);
+  doPublishUpdatedLocalMap(scan_ref_time);
 
   if (state_.last_icp_was_good) {
-    doPublishDeskewedScan(this_obs_tim);
+    doPublishDeskewedScan(scan_ref_time);
   }
 
   // Optional debug traces to CSV file:
-  doWriteDebugTracesFile(this_obs_tim);
+  doWriteDebugTracesFile(scan_ref_time);
 
   // Optional real-time GUI via MOLA VizInterface:
   if (visualizer_ && state_.local_map && state_.last_icp_was_good) {
@@ -853,7 +865,7 @@ mrpt::obs::CSensoryFrame LidarOdometry::collectRawObservations(
 
 void LidarOdometry::doUpdateSimpleMap(
   const mrpt::obs::CSensoryFrame & sf, const bool distance_enough_sm,
-  const mp2p_icp::metric_map_t::Ptr & observation, const mrpt::Clock::time_point & this_obs_tim,
+  const mp2p_icp::metric_map_t::Ptr & observation, const mrpt::Clock::time_point & scan_ref_time,
   const mrpt::maps::CPointsMap::Ptr & deskewedCloud)
 {
   using namespace std::string_literals;
@@ -869,7 +881,7 @@ void LidarOdometry::doUpdateSimpleMap(
 
     if (params_.simplemap.save_deskewed_scans && deskewedCloud) {
       auto od = mrpt::obs::CObservationPointCloud::Create();
-      od->timestamp = this_obs_tim;
+      od->timestamp = scan_ref_time;
       auto spc = mrpt::maps::CGenericPointsMap::Create();
       spc->insertAnotherMap(deskewedCloud.get(), {});
       od->pointcloud = spc;
@@ -877,7 +889,7 @@ void LidarOdometry::doUpdateSimpleMap(
       keyframe_obs->insert(od);
     }
 
-    const auto curLidarStamp = this_obs_tim;
+    const auto curLidarStamp = scan_ref_time;
 
     // insert GNSS too? Search for a close-enough observation:
     std::optional<double> closestTimeAbsDiff;
@@ -908,7 +920,7 @@ void LidarOdometry::doUpdateSimpleMap(
 
   // Add metadata ("comment") observation:
   auto metadataObs = mrpt::obs::CObservationComment::Create();
-  metadataObs->timestamp = this_obs_tim;
+  metadataObs->timestamp = scan_ref_time;
   metadataObs->sensorLabel = "metadata";
 
   mrpt::containers::yaml kf_metadata = mrpt::containers::yaml::Map();
@@ -956,7 +968,7 @@ void LidarOdometry::doUpdateSimpleMap(
   // We cannot unload them right now, for the case when they are being
   // used in a GUI, etc.
   // (1/2) Add to the list:
-  state_.past_simplemaps_observations[this_obs_tim] = keyframe_obs;
+  state_.past_simplemaps_observations[scan_ref_time] = keyframe_obs;
 
   const ProfilerEntry tleUnloadSM(profiler_, "onLidar.5.unload_past_sm_obs");
 

--- a/module/src/LidarOdometry_Publish.cpp
+++ b/module/src/LidarOdometry_Publish.cpp
@@ -49,7 +49,7 @@ template <typename T> struct has_map_metadata_field<T, std::void_t<decltype(T::m
 namespace mola
 {
 
-void LidarOdometry::doPublishUpdatedLocalization(const mrpt::Clock::time_point & this_obs_tim)
+void LidarOdometry::doPublishUpdatedLocalization(const mrpt::Clock::time_point & scan_ref_time)
 {
   const ProfilerEntry tle(profiler_, "advertiseUpdatedLocalization");
 
@@ -57,7 +57,7 @@ void LidarOdometry::doPublishUpdatedLocalization(const mrpt::Clock::time_point &
   lu.method = "lidar_odometry";
   lu.reference_frame = params_.publish_reference_frame;
   lu.child_frame = params_.publish_vehicle_frame;
-  lu.timestamp = this_obs_tim;
+  lu.timestamp = scan_ref_time;
   lu.pose = state_.last_lidar_pose.mean.asTPose();
   lu.cov = state_.last_lidar_pose.cov;
   lu.quality = state_.last_icp_quality;
@@ -65,7 +65,7 @@ void LidarOdometry::doPublishUpdatedLocalization(const mrpt::Clock::time_point &
   advertiseUpdatedLocalization(lu);
 }
 
-void LidarOdometry::doPublishUpdatedLocalMap(const mrpt::Clock::time_point & this_obs_tim)
+void LidarOdometry::doPublishUpdatedLocalMap(const mrpt::Clock::time_point & scan_ref_time)
 {
   // Publish geo-referenced data for the map, if applicable.
   publishMetricMapGeoreferencingData();
@@ -96,7 +96,7 @@ void LidarOdometry::doPublishUpdatedLocalMap(const mrpt::Clock::time_point & thi
   MapUpdate mu;
   mu.method = "lidar_odometry";
   mu.reference_frame = params_.publish_reference_frame;
-  mu.timestamp = this_obs_tim;
+  mu.timestamp = scan_ref_time;
 
   // publish all local map layers:
   // make map *copies* to make this multithread safe.
@@ -151,7 +151,7 @@ void LidarOdometry::doPublishUpdatedLocalMap(const mrpt::Clock::time_point & thi
   }
 }
 
-void LidarOdometry::doPublishDeskewedScan(const mrpt::Clock::time_point & this_obs_tim)
+void LidarOdometry::doPublishDeskewedScan(const mrpt::Clock::time_point & scan_ref_time)
 {
   if (!state_.last_deskewed_scan_for_publishing) {
     return;
@@ -172,7 +172,7 @@ void LidarOdometry::doPublishDeskewedScan(const mrpt::Clock::time_point & this_o
   MapUpdate mu;
   mu.method = "lidar_odometry";
   mu.reference_frame = params_.publish_reference_frame;
-  mu.timestamp = this_obs_tim;
+  mu.timestamp = scan_ref_time;
   mu.map_name = "deskewed_scan";
   mu.map = deskewedScan;
   mu.keep_last_one_only = false;  // Aggregate all scans


### PR DESCRIPTION
## Summary

- The ICP-derived pose corresponds to the vehicle at `t=0` of the deskewed cloud. With the default `FilterAdjustTimestamps: MiddleIsZero`, that is the *middle* of the scan, while `obs->timestamp` (taken from the LiDAR driver header) is typically the *start* of the scan — so the published `LocalizationUpdate.timestamp` and the timestamp fed back into `navstate_fuse->fuse_pose()` were systematically offset (~half a scan period, ~50 ms at 10 Hz) from the moment the pose actually holds.
- The absolute reference time is already tracked inside `ParameterSource::localVelocityBuffer.get_reference_zero_time()` (`Generator` seeds it with `obs->timestamp`, `FilterAdjustTimestamps` shifts it by the same offset it applies to per-point `t`, and `FilterAbsoluteTimestamp` already uses it as the absolute reference for per-point timestamps). This PR reads it back after the observation pipeline runs as `scan_ref_time` and threads it through every pose-time use site: ICP initial-guess query (`estimated_navstate`), ICP result fusion (`fuse_pose`), `estimated_trajectory`, simplemap keyframe key, and the published `LocalizationUpdate` / map / deskewed-scan / debug-trace timestamps.
- Sensor-cadence uses (rate stats, drop-too-close logic, log context, `last_obs_timestamp`, per-label staleness tracking, the ICP twist-update `dt`) keep the raw `obs->timestamp` since they are about *when the observation arrived*, not *when the pose holds*. With no per-point time adjustment configured, `reference_zero_time == obs->timestamp` and behaviour is unchanged. There is a fallback to `obs->timestamp` if the buffer was somehow never seeded.

This is a best-effort PR — please check whether the framing matches your intent for the timestamp semantics before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp consistency across lidar odometry processing pipeline to ensure scan references use a unified time reference for motion compensation and pose fusion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->