### PR TITLE
feat: new option to include multiple scans per space volume

### DIFF
--- a/docs/mola_lo_ros_node.rst
+++ b/docs/mola_lo_ros_node.rst
@@ -274,6 +274,20 @@ runs **MOLA-LO** live on point clouds received from a ROS 2 topic, **demonstrati
     * ``start_active`` (default ``True``):
       Whether MOLA-LO starts active (processing incoming sensor data) or idle.
 
+    * ``min_nearby_poses_occupied`` (default ``1``):
+      Minimum number of stored scans from a pose region before that region is considered
+      "occupied" in the **local map** distance checker and no new keyframe is inserted
+      there. The default of ``1`` reproduces the classic behavior. Increase to ``2`` or
+      more for non-repetitive-scan lidars (e.g. Livox) so that multiple scans are
+      accumulated from each location before moving on.
+      Maps to the env var ``MOLA_MIN_NEARBY_POSES_OCCUPIED`` and the pipeline YAML key
+      ``local_map_updates.min_nearby_poses_occupied``.
+
+    * ``simplemap_min_nearby_poses`` (default ``1``):
+      Same as ``min_nearby_poses_occupied`` but for the **simplemap** keyframe insertion.
+      Maps to the env var ``MOLA_SIMPLEMAP_MIN_NEARBY_POSES`` and the pipeline YAML key
+      ``simplemap.min_nearby_poses_occupied``.
+
     * ``start_mapping_enabled`` (default ``True``):
       Whether MOLA-LO starts with map update enabled, or in localization-only mode.
 

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -224,6 +224,14 @@ public:
              */
       uint32_t check_for_removal_every_n = 100;
 
+      /** Minimum number of stored poses within the threshold distance
+             *  before a volume is considered "occupied" and no new keyframe
+             *  is inserted there. Default=1 gives the classic behavior.
+             *  Increase to 2+ for non-repetitive-scan lidars (e.g. Livox)
+             *  so multiple scans are taken from each location.
+             */
+      uint32_t min_nearby_poses_occupied = 1;
+
       /** Publish updated map via mola::MapSourceBase once every N frames
              */
       uint32_t publish_map_updates_every_n = 5;
@@ -416,6 +424,13 @@ public:
 
       /** If enabled, saved keyframes will contain an additional 'deskewed' observation with the motion-compensated cloud. */
       bool save_deskewed_scans = false;
+
+      /** Minimum number of stored poses within the threshold distance
+             *  before a volume is considered "occupied" and no new keyframe
+             *  is inserted there. Default=1 gives the classic behavior.
+             *  Increase to 2+ for non-repetitive-scan lidars (e.g. Livox).
+             */
+      uint32_t min_nearby_poses_occupied = 1;
 
       void initialize(const Yaml & c, Parameters & parent);
     };

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -183,6 +183,11 @@ void LidarOdometry::Parameters::SimpleMapOptions::initialize(const Yaml & cfg, P
   YAML_LOAD_OPT(save_final_map_to_file, std::string);
   YAML_LOAD_OPT(add_non_keyframes_too, bool);
   YAML_LOAD_OPT(measure_from_last_kf_only, bool);
+  YAML_LOAD_OPT(min_nearby_poses_occupied, uint32_t);
+  ASSERTMSG_(
+    min_nearby_poses_occupied >= 1, mrpt::format(
+                                      "simplemap.min_nearby_poses_occupied=%u must be >= 1",
+                                      static_cast<unsigned>(min_nearby_poses_occupied)));
   YAML_LOAD_OPT(generate_lazy_load_scan_files, bool);
   YAML_LOAD_OPT(save_gnss_max_age, double);
   YAML_LOAD_OPT(save_deskewed_scans, bool);
@@ -204,6 +209,11 @@ void LidarOdometry::Parameters::MapUpdateOptions::initialize(const Yaml & cfg, P
   DECLARE_PARAMETER_IN_OPT(cfg, check_for_removal_every_n, parent);
   DECLARE_PARAMETER_IN_OPT(cfg, publish_map_updates_every_n, parent);
   YAML_LOAD_OPT(measure_from_last_kf_only, bool);
+  YAML_LOAD_OPT(min_nearby_poses_occupied, uint32_t);
+  ASSERTMSG_(
+    min_nearby_poses_occupied >= 1, mrpt::format(
+                                      "simplemap.min_nearby_poses_occupied=%u must be >= 1",
+                                      static_cast<unsigned>(min_nearby_poses_occupied)));
   YAML_LOAD_OPT(load_existing_local_map, std::string);
   YAML_LOAD_OPT(save_final_local_map, std::string);
 }
@@ -288,7 +298,7 @@ void LidarOdometry::onParameterUpdate(const mrpt::containers::yaml & names_value
   params_.simplemap.generate =
     names_values.getOrDefault("generate_simplemap", params_.simplemap.generate);
 
-  // Special triggering reset "variabe":
+  // Special triggering reset "variable":
   if (names_values.getOrDefault("reset_state", false)) {
     this->enqueue_request([this]() {
       MRPT_LOG_INFO("Received a reset() command via parameters update.");

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -603,13 +603,38 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       state_.distance_checker_simplemap.emplace(params_.simplemap.measure_from_last_kf_only);
     }
 
+    // Use the lidar sensor pose (in world frame) as the distance-checker key.
+    // This correctly handles moving lidars and non-repetitive scan patterns,
+    // since the sensor itself -- not the base_link -- determines coverage.
+    mrpt::poses::CPose3D sensorPoseInVehicle;
+    obs->getSensorPose(sensorPoseInVehicle);
+    const mrpt::poses::CPose3D lidarPoseInWorld = state_.last_lidar_pose.mean + sensorPoseInVehicle;
+
     // Create a new KF if the distance since the last one is large enough:
     const auto [isFirstPoseInChecker, distanceToClosest] =
-      state_.distance_checker_local_map->check(state_.last_lidar_pose.mean);
+      state_.distance_checker_local_map->check(lidarPoseInWorld);
 
     const double euclidean_dist_since_last = distanceToClosest.norm();
     const double rot_since_last =
       mrpt::poses::Lie::SO<3>::log(distanceToClosest.getRotationMatrix()).norm();
+
+    bool distFarEnoughLocal =
+      (isFirstPoseInChecker ||
+       euclidean_dist_since_last > params_.local_map_updates.min_translation_between_keyframes ||
+       rot_since_last > mrpt::DEG2RAD(params_.local_map_updates.min_rotation_between_keyframes));
+
+#if defined(MOLA_POSE_LIST_HAS_KFM_POSE_PLUMBING)
+    if (!distFarEnoughLocal && params_.local_map_updates.min_nearby_poses_occupied > 1) {
+      const uint32_t nearbyCount = state_.distance_checker_local_map->countNearby(
+        lidarPoseInWorld, params_.local_map_updates.min_translation_between_keyframes,
+        mrpt::DEG2RAD(params_.local_map_updates.min_rotation_between_keyframes));
+      if (nearbyCount < params_.local_map_updates.min_nearby_poses_occupied) {
+        distFarEnoughLocal = true;
+      }
+    }
+#else
+    // Older mola_pose_list: countNearby() unavailable; min_nearby_poses_occupied has no effect.
+#endif
 
     // clang-format off
     updateLocalMap =
@@ -618,15 +643,12 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
        params_.local_map_updates.enabled &&
        // skip map update for the special ICP alignment without motion model
        hasMotionModel &&
-       (isFirstPoseInChecker ||
-        euclidean_dist_since_last > params_.local_map_updates.min_translation_between_keyframes ||
-        rot_since_last >
-          mrpt::DEG2RAD(params_.local_map_updates.min_rotation_between_keyframes))
+       distFarEnoughLocal
        );
     // clang-format on
 
     if (updateLocalMap) {
-      state_.distance_checker_local_map->insert(state_.last_lidar_pose.mean);
+      state_.distance_checker_local_map->insert(lidarPoseInWorld);
 
       if (
         params_.local_map_updates.max_distance_to_keep_keyframes > 0 &&
@@ -639,7 +661,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
         const auto nInit = state_.distance_checker_local_map->size();
 
         state_.distance_checker_local_map->removeAllFartherThan(
-          state_.last_lidar_pose.mean, params_.local_map_updates.max_distance_to_keep_keyframes);
+          lidarPoseInWorld, params_.local_map_updates.max_distance_to_keep_keyframes);
 
         const auto nFinal = state_.distance_checker_local_map->size();
         MRPT_LOG_DEBUG_STREAM("removeAllFartherThan: " << nInit << " => " << nFinal << " KFs");
@@ -647,7 +669,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     }
 
     const auto [isFirstPoseInSMChecker, distanceToClosestSM] =
-      state_.distance_checker_simplemap->check(state_.last_lidar_pose.mean);
+      state_.distance_checker_simplemap->check(lidarPoseInWorld);
 
     const double euclidean_dist_since_last_sm = distanceToClosestSM.norm();
     const double rot_since_last_sm =
@@ -658,6 +680,19 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       euclidean_dist_since_last_sm > params_.simplemap.min_translation_between_keyframes ||
       rot_since_last_sm > mrpt::DEG2RAD(params_.simplemap.min_rotation_between_keyframes);
 
+#if defined(MOLA_POSE_LIST_HAS_KFM_POSE_PLUMBING)
+    if (!distance_enough_sm && params_.simplemap.min_nearby_poses_occupied > 1) {
+      const uint32_t nearbyCountSM = state_.distance_checker_simplemap->countNearby(
+        lidarPoseInWorld, params_.simplemap.min_translation_between_keyframes,
+        mrpt::DEG2RAD(params_.simplemap.min_rotation_between_keyframes));
+      if (nearbyCountSM < params_.simplemap.min_nearby_poses_occupied) {
+        distance_enough_sm = true;
+      }
+    }
+#else
+    // Older mola_pose_list: countNearby() unavailable; min_nearby_poses_occupied has no effect.
+#endif
+
     // clang-format off
     updateSimpleMap =
       params_.simplemap.generate &&
@@ -667,7 +702,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     // clang-format on
 
     if (updateSimpleMap && distance_enough_sm) {
-      state_.distance_checker_simplemap->insert(state_.last_lidar_pose.mean);
+      state_.distance_checker_simplemap->insert(lidarPoseInWorld);
     }
 
     MRPT_LOG_DEBUG_FMT(

--- a/pipelines/extras/lidar3d-edges.yaml
+++ b/pipelines/extras/lidar3d-edges.yaml
@@ -21,6 +21,7 @@ params:
     # Should match the "remove farther than" option of the local metric map. "0" means deletion of distant key-frames is disabled
     max_distance_to_keep_keyframes: "max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)" # [m]
     check_for_removal_every_n: 100
+    min_nearby_poses_occupied: ${MOLA_MIN_NEARBY_POSES_OCCUPIED|1}
 
   # Minimum ICP quality to insert it into the map:
   min_icp_goodness: 0.25

--- a/pipelines/extras/rgbd.yaml
+++ b/pipelines/extras/rgbd.yaml
@@ -39,6 +39,7 @@ params:
     # Should match the "remove farther than" option of the local metric map. "0" means deletion of distant key-frames is disabled
     max_distance_to_keep_keyframes: "max(50.0, 2.50*ESTIMATED_OBSERVATION_RADIUS)" # [m]
     check_for_removal_every_n: 100
+    min_nearby_poses_occupied: ${MOLA_MIN_NEARBY_POSES_OCCUPIED|1}
 
   # Minimum ICP quality to insert it into the map:
   min_icp_goodness: 0.05

--- a/pipelines/lidar2d.yaml
+++ b/pipelines/lidar2d.yaml
@@ -47,6 +47,7 @@ params:
     # Should match the "remove farther than" option of the local metric map. "0" means deletion of distant key-frames is disabled
     max_distance_to_keep_keyframes: "max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)" # [m]
     check_for_removal_every_n: 100
+    min_nearby_poses_occupied: ${MOLA_MIN_NEARBY_POSES_OCCUPIED|1}
 
   # Minimum ICP quality to insert it into the map:
   min_icp_goodness: 0.25

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -69,6 +69,7 @@ params:
     # Should match the "remove farther than" option of the local metric map. "0" means deletion of distant key-frames is disabled
     max_distance_to_keep_keyframes: "${MOLA_LOCAL_MAP_MAX_SIZE|max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
     check_for_removal_every_n: 100
+    min_nearby_poses_occupied: ${MOLA_MIN_NEARBY_POSES_OCCUPIED|1}
     publish_map_updates_every_n: ${MOLA_PUBLISH_LOCAL_MAP_UPDATES_EVERY_N|40}
 
   # Minimum ICP quality to insert it into the map:
@@ -112,6 +113,7 @@ params:
 
     generate_lazy_load_scan_files: ${MOLA_SIMPLEMAP_GENERATE_LAZY_LOAD|false} # If enabled, a directory will be create alongside the .simplemap and pointclouds will be externally serialized there.
     add_non_keyframes_too: ${MOLA_SIMPLEMAP_ALSO_NON_KEYFRAMES|false} # If enabled, all frames are stored in the simplemap, but non-keyframes will be without associated observations.
+    min_nearby_poses_occupied: ${MOLA_SIMPLEMAP_MIN_NEARBY_POSES|1}
     save_gnss_max_age: 1.0 # [s] max age of GNSS observations to keep in the keyframe
 
     # If enabled, this will store deskewed scans into the keyframes of simplemaps.

--- a/pipelines/lidar3d-icp.yaml
+++ b/pipelines/lidar3d-icp.yaml
@@ -62,6 +62,7 @@ params:
     # Should match the "remove farther than" option of the local metric map. "0" means deletion of distant key-frames is disabled
     max_distance_to_keep_keyframes: "${MOLA_LOCAL_MAP_MAX_SIZE|max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
     check_for_removal_every_n: 100
+    min_nearby_poses_occupied: ${MOLA_MIN_NEARBY_POSES_OCCUPIED|1}
     publish_map_updates_every_n: ${MOLA_PUBLISH_LOCAL_MAP_UPDATES_EVERY_N|5}
 
   # Minimum ICP quality to insert it into the map:
@@ -89,6 +90,7 @@ params:
 
     generate_lazy_load_scan_files: ${MOLA_SIMPLEMAP_GENERATE_LAZY_LOAD|false} # If enabled, a directory will be create alongside the .simplemap and pointclouds will be externally serialized there.
     add_non_keyframes_too: ${MOLA_SIMPLEMAP_ALSO_NON_KEYFRAMES|false} # If enabled, all frames are stored in the simplemap, but non-keyframes will be without associated observations.
+    min_nearby_poses_occupied: ${MOLA_SIMPLEMAP_MIN_NEARBY_POSES|1}
     save_gnss_max_age: 1.0 # [s] max age of GNSS observations to keep in the keyframe
 
   # Save the final trajectory in TUM format. Disabled by default.

--- a/pipelines/lidar3d-ndt.yaml
+++ b/pipelines/lidar3d-ndt.yaml
@@ -57,6 +57,7 @@ params:
     # Should match the "remove farther than" option of the local metric map. "0" means deletion of distant key-frames is disabled
     max_distance_to_keep_keyframes: "${MOLA_LOCAL_MAP_MAX_SIZE|max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
     check_for_removal_every_n: 100
+    min_nearby_poses_occupied: ${MOLA_MIN_NEARBY_POSES_OCCUPIED|1}
 
   # Minimum ICP quality to insert it into the map:
   min_icp_goodness: ${MOLA_MINIMUM_ICP_QUALITY|0.25}
@@ -83,6 +84,7 @@ params:
 
     generate_lazy_load_scan_files: ${MOLA_SIMPLEMAP_GENERATE_LAZY_LOAD|false} # If enabled, a directory will be create alongside the .simplemap and pointclouds will be externally serialized there.
     add_non_keyframes_too: ${MOLA_SIMPLEMAP_ALSO_NON_KEYFRAMES|false} # If enabled, all frames are stored in the simplemap, but non-keyframes will be without associated observations.
+    min_nearby_poses_occupied: ${MOLA_SIMPLEMAP_MIN_NEARBY_POSES|1}
     save_gnss_max_age: 1.0 # [s] max age of GNSS observations to keep in the keyframe
 
   # Save the final trajectory in TUM format. Disabled by default.

--- a/ros2-launchs/ros2-lidar-odometry.launch.py
+++ b/ros2-launchs/ros2-lidar-odometry.launch.py
@@ -303,6 +303,19 @@ def generate_launch_description():
     start_mapping_enabled_env_var = SetEnvironmentVariable(
         name='MOLA_MAPPING_ENABLED', value=LaunchConfiguration('start_mapping_enabled'))
 
+    min_nearby_poses_occupied_arg = DeclareLaunchArgument(
+        "min_nearby_poses_occupied", default_value="1",
+        description="Minimum number of scans from a pose region before that region is considered 'occupied' in the local map. "
+                    "Increase to 2+ for non-repetitive-scan lidars (e.g. Livox) to collect more data per location.")
+    min_nearby_poses_occupied_env_var = SetEnvironmentVariable(
+        name='MOLA_MIN_NEARBY_POSES_OCCUPIED', value=LaunchConfiguration('min_nearby_poses_occupied'))
+
+    simplemap_min_nearby_poses_arg = DeclareLaunchArgument(
+        "simplemap_min_nearby_poses", default_value="1",
+        description="Same as min_nearby_poses_occupied but for the simplemap keyframe insertion.")
+    simplemap_min_nearby_poses_env_var = SetEnvironmentVariable(
+        name='MOLA_SIMPLEMAP_MIN_NEARBY_POSES', value=LaunchConfiguration('simplemap_min_nearby_poses'))
+
     start_active_arg = DeclareLaunchArgument(
         "start_active", default_value="True", description="Whether MOLA-LO should start active, that is, processing incoming sensor data (true), or ignoring them (false)")
     start_active_env_var = SetEnvironmentVariable(
@@ -658,6 +671,10 @@ def generate_launch_description():
         start_active_env_var,
         start_mapping_enabled_arg,
         start_mapping_enabled_env_var,
+        min_nearby_poses_occupied_arg,
+        min_nearby_poses_occupied_env_var,
+        simplemap_min_nearby_poses_arg,
+        simplemap_min_nearby_poses_env_var,
         use_mola_gui_arg,
         use_mola_gui_env_var,
         use_rviz_arg,


### PR DESCRIPTION
Useful for Livox scanners, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two occupancy thresholds to control when keyframes are created for local maps and simplemap, allowing finer tuning of map accumulation.
  * Both thresholds are configurable at launch or via environment-style settings for flexible runtime adjustment.

* **Documentation**
  * Added docs describing the new keyframe insertion parameters and how to configure them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->