### PR TITLE
docs: add FusionCore to Related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ The latest publication on MOLA is ([ArXiV](https://arxiv.org/abs/2407.20465)).
 }
 ```
 
+## Related projects
+
+[**FusionCore**](https://github.com/manankharwar/fusioncore): ROS 2 UKF that fuses MOLA's LiDAR odometry output with IMU and GPS into a globally-referenced state estimate. Useful for outdoor robots that need a GPS anchor over long distances. One config line:
+
+```yaml
+encoder2.topic: "/mola_lidar_odometry/odometry"
+```
 
 ## License
 Copyright (C) 2018-2026 Jose Luis Blanco <jlblanco@ual.es>, University of Almeria


### PR DESCRIPTION
As discussed in #71: adds FusionCore under a new "Related projects" section before the License block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with a new "Related projects" section introducing FusionCore, an external project for multi-sensor fusion combining MOLA LiDAR odometry with IMU and GPS data to provide globally referenced state estimation. Includes practical configuration example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->