### PR TITLE
feat: Add optional gravity-alignment at the local-map level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ find_package(mola_imu_preintegration REQUIRED)
 # define lib:
 set(LIB_SRCS
   module/src/GravityMapAligner.cpp
+  module/src/LidarOdometry_GravityRebake.cpp
   module/src/TrajectoryRebaker.cpp
   module/src/LidarOdometry_Main.cpp
   module/src/LidarOdometry_Relocalization.cpp

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -552,7 +552,7 @@ public:
       bool enabled = true;
 
       /// Sigma [degrees] for the gravity-derived pitch/roll prior.
-      /// Lower values = more trust in IMU. Typical: 1–5 deg.
+      /// Lower values = more trust in IMU. Typical: 1-5 deg.
       double sigma_deg = 2.0;
 
       /// Number of recent accelerometer samples to average for gravity estimation.
@@ -561,6 +561,26 @@ public:
       /// Maximum age [seconds] for accelerometer samples used in averaging.
       /// Samples older than this are discarded. 0 = no age limit.
       double max_age_seconds = 2.0;
+
+      struct TiltRebake
+      {
+        /// If true, when the local map accumulates more pitch/roll tilt than
+        /// trigger_deg (measured against IMU gravity), rotate all active KFs
+        /// in the local map and the in-progress simplemap so the world z-axis
+        /// re-aligns with gravity. Pivot: oldest active KF. Publishing a
+        /// corrected pose will produce a discontinuous jump in pitch/roll.
+        bool enabled = false;
+
+        /// Tilt threshold in degrees that triggers a correction. [default 2.0]
+        double trigger_deg = 2.0;
+
+        /// Minimum wall-clock seconds between two consecutive corrections.
+        double min_interval_sec = 5.0;
+
+        /// Minimum number of active keyframes before the feature is allowed.
+        uint32_t min_active_keyframes = 5;
+      };
+      TiltRebake tilt_rebake;
 
       void initialize(const Yaml & c);
     };
@@ -783,6 +803,10 @@ private:
     };
 
     GravityEstimator gravity_estimator;
+
+    /// Throttling: last time a tilt correction was applied (steady_clock).
+    std::optional<mrpt::Clock::time_point> last_gravity_rebake_tim;
+    bool gravity_rebake_unsupported_warned = false;
 
     mrpt::poses::CPose3DPDFGaussian last_lidar_pose;  //!< in local map
 
@@ -1101,6 +1125,13 @@ private:
     const mrpt::obs::CSensoryFrame & sf, bool distance_enough_sm,
     const mp2p_icp::metric_map_t::Ptr & observation, const mrpt::Clock::time_point & scan_ref_time,
     const mrpt::maps::CPointsMap::Ptr & deskewedCloud);
+
+  /// Checks accumulated tilt of the local map vs. measured gravity and, if
+  /// excessive, rotates active KFs (and the in-progress simplemap) so the
+  /// local-map z-axis re-aligns with measured gravity.
+  /// Must be called from the lidar worker thread, with state_mtx_ held.
+  /// Returns true if a correction was applied.
+  bool maybeApplyGravityTiltCorrection();
 };
 
 namespace detail

--- a/module/src/LidarOdometry_GravityRebake.cpp
+++ b/module/src/LidarOdometry_GravityRebake.cpp
@@ -1,0 +1,216 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   LidarOdometry_GravityRebake.cpp
+ * @brief  Online gravity tilt correction for the active local map.
+ *
+ * Implements LidarOdometry::maybeApplyGravityTiltCorrection().
+ *
+ * Design notes:
+ *  - Reuses GravityMapAligner::rotationFromGravity() as a pure static helper
+ *    to build the pitch/roll-only rotation.
+ *  - GravityMapAligner and TrajectoryRebaker are NOT used for this online
+ *    path (they were designed for an offline batch strategy).
+ *  - The mola::KeyframeMapCapable interface (from mola_kernel) is guarded
+ *    with __has_include so this TU builds cleanly without mola_metric_maps.
+ */
+
+#include <mola_lidar_odometry/GravityMapAligner.h>
+#include <mola_lidar_odometry/LidarOdometry.h>
+
+#if defined(__has_include)
+#if __has_include(<mola_kernel/interfaces/KeyframeMapCapable.h>)
+#include <mola_kernel/interfaces/KeyframeMapCapable.h>
+#endif
+#endif
+
+#include <mrpt/math/utils.h>
+#include <mrpt/poses/CPose3DPDFGaussian.h>
+#include <mrpt/system/datetime.h>
+
+#include <cmath>
+
+using namespace mola;
+
+bool LidarOdometry::maybeApplyGravityTiltCorrection()
+{
+#if defined(MOLA_METRIC_MAPS_HAS_KFM_POSE_PLUMBING) && defined(__has_include) && \
+  __has_include(<mola_kernel/interfaces/KeyframeMapCapable.h>)
+
+  const auto & p = params_.imu_gravity_correction.tilt_rebake;
+
+  // --- Throttling ---
+  const auto now = mrpt::Clock::now();
+  if (state_.last_gravity_rebake_tim.has_value()) {
+    const double elapsed = mrpt::system::timeDifference(*state_.last_gravity_rebake_tim, now);
+    if (elapsed < p.min_interval_sec) {
+      return false;
+    }
+  }
+
+  // --- Get gravity pitch/roll from IMU ---
+  const auto gravityPR = state_.gravity_estimator.estimatedPitchRoll(
+    std::min(params_.imu_gravity_correction.averaging_samples, 10u),
+    params_.imu_gravity_correction.max_age_seconds);
+  if (!gravityPR.has_value()) {
+    return false;
+  }
+  const auto [imu_pitch, imu_roll] = *gravityPR;
+
+  // --- Build gravity unit vector in vehicle frame ---
+  // Convention (from estimatedPitchRoll): vehicle level => g_veh = +Z.
+  const double g_veh_x = -std::sin(imu_pitch);
+  const double g_veh_y = std::sin(imu_roll) * std::cos(imu_pitch);
+  const double g_veh_z = std::cos(imu_roll) * std::cos(imu_pitch);
+  const mrpt::math::TVector3D g_veh(g_veh_x, g_veh_y, g_veh_z);
+
+  // --- Express gravity in world (local-map) frame ---
+  const mrpt::math::CMatrixDouble33 R_world = state_.last_lidar_pose.mean.getRotationMatrix();
+  const mrpt::math::TVector3D g_world{
+    R_world(0, 0) * g_veh_x + R_world(0, 1) * g_veh_y + R_world(0, 2) * g_veh_z,
+    R_world(1, 0) * g_veh_x + R_world(1, 1) * g_veh_y + R_world(1, 2) * g_veh_z,
+    R_world(2, 0) * g_veh_x + R_world(2, 1) * g_veh_y + R_world(2, 2) * g_veh_z};
+
+  // --- Compute tilt angle of world z-axis relative to gravity ---
+  const double g_world_z_clamped = std::max(-1.0, std::min(1.0, g_world.z));
+  const double tilt_rad = std::acos(g_world_z_clamped);
+  if (mrpt::RAD2DEG(tilt_rad) < p.trigger_deg) {
+    return false;
+  }
+
+  // --- Find a KeyframeMapCapable layer in the local map ---
+  mola::KeyframeMapCapable * kfCap = nullptr;
+  for (auto & [layerName, layerMap] : state_.local_map->layers) {
+    auto * candidate = dynamic_cast<mola::KeyframeMapCapable *>(layerMap.get());
+    if (candidate != nullptr) {
+      kfCap = candidate;
+      break;
+    }
+  }
+  if (kfCap == nullptr) {
+    if (!state_.gravity_rebake_unsupported_warned) {
+      MRPT_LOG_WARN(
+        "imu_gravity_correction.tilt_rebake is enabled, but the "
+        "configured local map layer does not implement "
+        "mola::KeyframeMapCapable; feature DISABLED for this run.");
+      state_.gravity_rebake_unsupported_warned = true;
+    }
+    return false;
+  }
+
+  // --- Check minimum active keyframe count ---
+  const auto kfPoses = kfCap->keyframePoses();
+  if (kfPoses.size() < p.min_active_keyframes) {
+    return false;
+  }
+
+  // --- Build the world-frame pitch/roll-only correction rotation ---
+  // rotationFromGravity(g_world) returns a CPose3D with t=0 and a pure
+  // pitch/roll rotation sending g_world -> +Z (yaw=0).
+  const mrpt::poses::CPose3D R_correct = mola::GravityMapAligner::rotationFromGravity(g_world);
+
+  // --- Pivot: oldest active KF ---
+  const auto pivotId = kfPoses.begin()->first;
+  const auto & T_pivot = kfPoses.begin()->second;
+
+  // T_correct_world: rotation about pivot's position in world frame.
+  // T_correct_world(p) = t_pivot + R_correct * (p - t_pivot)
+  //                    = R_correct + (t_pivot - R_correct*t_pivot)
+  // For applyPivotTransform: delta_at_pivot = T_pivot^{-1} * R_correct * T_pivot
+  const mrpt::poses::CPose3D delta_at_pivot = (-T_pivot) + R_correct + T_pivot;
+
+  // (i) Rotate active local-map KFs:
+  kfCap->applyPivotTransform(pivotId, delta_at_pivot);
+
+  // T_correct_world applies R_correct about the pivot position in world frame.
+  // We need this explicit form to rotate all other cached state.
+  // t_new = R_correct.R * (t - t_pivot) + t_pivot
+  // As a CPose3D left-multiply: T_correct_world = T_pivot + R_correct + (-T_pivot)
+  const mrpt::poses::CPose3D T_correct_world = T_pivot + R_correct + (-T_pivot);
+
+  // (ii) In-progress simplemap KFs:
+  {
+    auto smLck = mrpt::lockHelper(state_simplemap_mtx_);
+    for (size_t i = 0; i < state_.reconstructed_simplemap.size(); i++) {
+      auto & kf = state_.reconstructed_simplemap.get(i);
+      if (!kf.pose) {
+        continue;
+      }
+      auto pdf = std::dynamic_pointer_cast<mrpt::poses::CPose3DPDFGaussian>(kf.pose);
+      if (!pdf) {
+        continue;
+      }
+      pdf->changeCoordinatesReference(T_correct_world);
+    }
+  }
+
+  // (iii) Cached world-frame state:
+  state_.last_lidar_pose.changeCoordinatesReference(T_correct_world);
+
+  if (state_.last_motion_model_output.has_value()) {
+    // Twist is body-local, do NOT rotate — only the pose.
+    state_.last_motion_model_output->pose.changeCoordinatesReference(T_correct_world);
+  }
+
+  // Rotate every entry in estimated_trajectory:
+  {
+    auto lckTraj = mrpt::lockHelper(state_trajectory_mtx_);
+    mrpt::poses::CPose3DInterpolator updated;
+    for (const auto & [t, p_tpose] : state_.estimated_trajectory) {
+      const mrpt::poses::CPose3D p_old(p_tpose);
+      const mrpt::poses::CPose3D p_new = T_correct_world + p_old;
+      updated.insert(t, p_new.asTPose());
+    }
+    state_.estimated_trajectory = std::move(updated);
+  }
+
+  // Rebuild distance checkers from the corrected estimated_trajectory:
+  if (state_.distance_checker_local_map.has_value()) {
+    state_.distance_checker_local_map.emplace(params_.local_map_updates.measure_from_last_kf_only);
+    for (const auto & [t, p_tpose] : state_.estimated_trajectory) {
+      state_.distance_checker_local_map->insert(mrpt::poses::CPose3D(p_tpose));
+    }
+  }
+  if (state_.distance_checker_simplemap.has_value()) {
+    state_.distance_checker_simplemap.emplace(params_.simplemap.measure_from_last_kf_only);
+    auto smLck = mrpt::lockHelper(state_simplemap_mtx_);
+    for (size_t i = 0; i < state_.reconstructed_simplemap.size(); i++) {
+      const auto & kf = state_.reconstructed_simplemap.get(i);
+      if (kf.pose) {
+        state_.distance_checker_simplemap->insert(kf.pose->getMeanVal());
+      }
+    }
+  }
+
+  // Clear visualization path so it is rebuilt from corrected trajectory:
+  if (state_.glEstimatedPath) {
+    state_.glEstimatedPath->clear();
+  }
+
+  state_.mark_local_map_as_updated(/*force_republish=*/true);
+  state_.last_gravity_rebake_tim = now;
+
+  MRPT_LOG_INFO_FMT(
+    "Tilt rebake applied: tilt was %.2f deg, pivot KF=%lu, "
+    "correction pitch/roll=(%.3f, %.3f) deg",
+    mrpt::RAD2DEG(tilt_rad), static_cast<unsigned long>(pivotId), mrpt::RAD2DEG(imu_pitch),
+    mrpt::RAD2DEG(imu_roll));
+
+  return true;
+
+#else
+  // Feature not available: mola_metric_maps or mola_kernel not present.
+  (void)this;
+  return false;
+#endif
+}

--- a/module/src/LidarOdometry_GravityRebake.cpp
+++ b/module/src/LidarOdometry_GravityRebake.cpp
@@ -42,10 +42,10 @@
 
 using namespace mola;
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 bool LidarOdometry::maybeApplyGravityTiltCorrection()
 {
-#if defined(MOLA_METRIC_MAPS_HAS_KFM_POSE_PLUMBING) && defined(__has_include) && \
-  __has_include(<mola_kernel/interfaces/KeyframeMapCapable.h>)
+#if defined(__has_include) && __has_include(<mola_kernel/interfaces/KeyframeMapCapable.h>)
 
   const auto & p = params_.imu_gravity_correction.tilt_rebake;
 
@@ -84,6 +84,7 @@ bool LidarOdometry::maybeApplyGravityTiltCorrection()
   // --- Compute tilt angle of world z-axis relative to gravity ---
   const double g_world_z_clamped = std::max(-1.0, std::min(1.0, g_world.z));
   const double tilt_rad = std::acos(g_world_z_clamped);
+  MRPT_LOG_DEBUG_FMT("Tilt rebake, estimated tilt angle=%.02lf deg", mrpt::RAD2DEG(tilt_rad));
   if (mrpt::RAD2DEG(tilt_rad) < p.trigger_deg) {
     return false;
   }

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -295,6 +295,40 @@ void LidarOdometry::Parameters::IMUGravityCorrection::initialize(const Yaml & cf
   YAML_LOAD_OPT(averaging_samples, uint32_t);
   YAML_LOAD_OPT(max_age_seconds, double);
 
+  if (cfg.has("tilt_rebake")) {
+    auto & tr = tilt_rebake;
+    const auto trCfg = cfg["tilt_rebake"];
+    if (trCfg.has("enabled")) {
+      tr.enabled = trCfg["enabled"].as<bool>();
+    }
+    if (trCfg.has("trigger_deg")) {
+      tr.trigger_deg = trCfg["trigger_deg"].as<double>();
+    }
+    if (trCfg.has("min_interval_sec")) {
+      tr.min_interval_sec = trCfg["min_interval_sec"].as<double>();
+    }
+    if (trCfg.has("min_active_keyframes")) {
+      tr.min_active_keyframes = trCfg["min_active_keyframes"].as<uint32_t>();
+    }
+
+    if (tr.enabled) {
+      ASSERTMSG_(
+        tr.trigger_deg > 0.0,
+        mrpt::format(
+          "imu_gravity_correction.tilt_rebake.trigger_deg=%.4f must be > 0", tr.trigger_deg));
+      ASSERTMSG_(
+        tr.min_interval_sec >= 0.0,
+        mrpt::format(
+          "imu_gravity_correction.tilt_rebake.min_interval_sec=%.4f must be >= 0",
+          tr.min_interval_sec));
+      ASSERTMSG_(
+        tr.min_active_keyframes >= 1,
+        mrpt::format(
+          "imu_gravity_correction.tilt_rebake.min_active_keyframes=%u must be >= 1",
+          static_cast<unsigned>(tr.min_active_keyframes)));
+    }
+  }
+
   if (enabled) {
     ASSERTMSG_(
       averaging_samples >= 1 && averaging_samples <= 200,

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -838,8 +838,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 
     state_.mark_local_map_as_updated();
 
-#if defined(MOLA_METRIC_MAPS_HAS_KFM_POSE_PLUMBING) && \
-  __has_include(<mola_kernel/interfaces/KeyframeMapCapable.h>)
+#if __has_include(<mola_kernel/interfaces/KeyframeMapCapable.h>)
     if (params_.imu_gravity_correction.tilt_rebake.enabled) {
       maybeApplyGravityTiltCorrection();
     }

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -22,6 +22,15 @@
 // This module:
 #include <mola_lidar_odometry/LidarOdometry.h>
 
+#if defined(__has_include)
+#if __has_include(<mola_metric_maps/KeyframePointCloudMap.h>)
+#include <mola_metric_maps/KeyframePointCloudMap.h>
+#endif
+#if __has_include(<mola_kernel/interfaces/KeyframeMapCapable.h>)
+#include <mola_kernel/interfaces/KeyframeMapCapable.h>
+#endif
+#endif
+
 // mp2p_icp:
 #include <mp2p_icp_filters/FilterDeskew.h>
 
@@ -828,6 +837,13 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     tle3.stop();
 
     state_.mark_local_map_as_updated();
+
+#if defined(MOLA_METRIC_MAPS_HAS_KFM_POSE_PLUMBING) && \
+  __has_include(<mola_kernel/interfaces/KeyframeMapCapable.h>)
+    if (params_.imu_gravity_correction.tilt_rebake.enabled) {
+      maybeApplyGravityTiltCorrection();
+    }
+#endif
 
   }  // end done add a new KF to local map
 

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -45,6 +45,11 @@ params:
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
     max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}
+    tilt_rebake:
+      enabled: ${MOLA_IMU_TILT_REBAKE|false}
+      trigger_deg: ${MOLA_IMU_TILT_REBAKE_TRIGGER_DEG|2.0}
+      min_interval_sec: ${MOLA_IMU_TILT_REBAKE_MIN_INTERVAL_SEC|5.0}
+      min_active_keyframes: ${MOLA_IMU_TILT_REBAKE_MIN_KFS|5}
 
   # When publishing pose updates, the reference frame for both, estimated robot poses, and the local map.
   publish_reference_frame: "${MOLA_LO_PUBLISH_REF_FRAME|odom}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable IMU gravity-based tilt “rebake” (pitch/roll correction) via `params.imu_gravity_correction.tilt_rebake` for the lidar3d-gicp pipeline. When enabled, it triggers when the estimated tilt exceeds `trigger_deg`, throttled by `min_interval_sec`, and requires at least `min_active_keyframes`.
  * When supported, it updates the local map and related in-progress odometry/trajectory state; otherwise it logs a one-time warning and skips.
* **Documentation**
  * Extended `imu_gravity_correction` parameter documentation to include the new `tilt_rebake` block.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->