### PR TITLE
fix(cli): warn when no --state-estimator-param-file is provided

### DIFF
--- a/apps/mola-lidar-odometry-cli.cpp
+++ b/apps/mola-lidar-odometry-cli.cpp
@@ -516,6 +516,14 @@ int main_odometry(Cli & cli)
     const auto seParamsFile = cli.arg_stateEstimatorParams.getValue();
     auto seParams = mrpt::containers::yaml::FromFile(seParamsFile);
     stateEstimator->initialize(mola::parse_yaml(seParams));
+  } else {
+    // Without an explicit YAML, the estimator runs with built-in C++ defaults
+    // which differ from the bundled state-estimator-params/*.yaml shipped with
+    // this package. Surface this so users don't silently get unintended values.
+    std::cerr << "[Warning] No --state-estimator-param-file given; '"
+              << stateEstimator->GetRuntimeClass()->className
+              << "' will use built-in C++ defaults rather than the bundled YAML "
+                 "(see <prefix>/share/mola_lidar_odometry/state-estimator-params/).\n";
   }
 
   // Make both modules discoverables to each other:


### PR DESCRIPTION
## Summary

- When `mola-lidar-odometry-cli` is invoked without `--state-estimator-param-file`, the state estimator is constructed but `initialize()` is never called, so it silently runs with the built-in C++ defaults rather than the bundled `state-estimator-params/*.yaml` shipped under `share/mola_lidar_odometry/`. The corresponding `mola-cli-launchs/*.yaml` files do load those YAMLs, so the CLI and the GUI launcher behave noticeably differently for the same estimator class.
- Add an `else` branch that prints a clear warning naming the active estimator class and pointing at the bundled YAMLs, so users know to pass `--state-estimator-param-file` (or accept the C++ defaults deliberately).
- No behaviour change otherwise; just turns a silent footgun into a visible one.