### PR TITLE
feat: optional adaptive-threshold recovery on sustained ICP failure

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -346,6 +346,16 @@ public:
       double alpha = 0.99;
       double icp_quality_controller_setpoint = 0.85;
 
+      // Sustained-failure recovery (opt-in).
+      // KISS-ICP only updates sigma on good ICP, so a streak of bad ICPs
+      // freezes sigma at its last (typically small) value. With a small
+      // matcher window the system cannot recover from a perturbation that
+      // exceeds 2*sigma. When enabled, sigma is multiplicatively grown
+      // toward maximum_sigma after recover_after_n_bad consecutive failures.
+      bool recover_on_sustained_failure = false;
+      int recover_after_n_bad = 5;
+      double recover_growth_factor = 1.5;
+
       void initialize(const Yaml & c);
     };
     AdaptiveThreshold adaptive_threshold;
@@ -785,6 +795,10 @@ private:
 
     // KISS-ICP-like adaptive threshold method:
     double adapt_thres_sigma = 0;  // 0: initial
+
+    // Counter of consecutive bad ICPs; drives the optional sustained-failure
+    // recovery in AdaptiveThreshold.
+    int consecutive_bad_icps = 0;
 
     // Automatic estimation of the observation bounding-radius (measured from
     // base_link, not from the sensor — see ESTIMATED_OBSERVATION_RADIUS docs):

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -91,6 +91,18 @@ void LidarOdometry::Parameters::AdaptiveThreshold::initialize(const Yaml & cfg)
   YAML_LOAD_REQ(alpha, double);
   YAML_LOAD_OPT(maximum_sigma, double);
   YAML_LOAD_OPT(icp_quality_controller_setpoint, double);
+
+  YAML_LOAD_OPT(recover_on_sustained_failure, bool);
+  YAML_LOAD_OPT(recover_after_n_bad, int);
+  YAML_LOAD_OPT(recover_growth_factor, double);
+
+  ASSERTMSG_(
+    recover_after_n_bad >= 1,
+    mrpt::format("adaptive_threshold: recover_after_n_bad (%d) must be >= 1", recover_after_n_bad));
+  ASSERTMSG_(
+    recover_growth_factor > 1.0,
+    mrpt::format(
+      "adaptive_threshold: recover_growth_factor (%.3f) must be > 1.0", recover_growth_factor));
 }
 
 void LidarOdometry::Parameters::Visualization::initialize(const Yaml & cfg)

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -594,6 +594,40 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
                                      << " motionModelError=" << motionModelError.asString());
     }  // end adaptive threshold
 
+    // Sustained-failure recovery for the adaptive threshold (opt-in).
+    // The KISS-ICP rule above never updates sigma on a bad ICP, which is correct
+    // for isolated failures but creates a deadlock under sustained failure: with
+    // sigma frozen small, the matcher window stays tight and ICP cannot find
+    // enough correspondences to recover. When enabled, after a streak of bad
+    // ICPs we grow sigma multiplicatively (capped at maximum_sigma) to enlarge
+    // the correspondence search radius for the next attempt.
+    if (icpIsGood) {
+      state_.consecutive_bad_icps = 0;
+    } else {
+      state_.consecutive_bad_icps++;
+
+      if (
+        params_.adaptive_threshold.enabled &&
+        params_.adaptive_threshold.recover_on_sustained_failure &&
+        state_.consecutive_bad_icps >= params_.adaptive_threshold.recover_after_n_bad) {
+        if (state_.adapt_thres_sigma == 0) {
+          state_.adapt_thres_sigma = params_.adaptive_threshold.initial_sigma;
+        }
+        const double new_sigma = std::min(
+          state_.adapt_thres_sigma * params_.adaptive_threshold.recover_growth_factor,
+          params_.adaptive_threshold.maximum_sigma);
+        if (new_sigma > state_.adapt_thres_sigma) {
+          MRPT_LOG_THROTTLE_WARN_FMT(
+            2.0,
+            "Sustained ICP failure (n=%d, q=%.2f): widening adaptive threshold "
+            "sigma %.3f -> %.3f m to recover correspondences",
+            state_.consecutive_bad_icps, state_.last_icp_quality, state_.adapt_thres_sigma,
+            new_sigma);
+          state_.adapt_thres_sigma = new_sigma;
+        }
+      }
+    }
+
     // Create distance checker on first usage:
     if (!state_.distance_checker_local_map) {
       state_.distance_checker_local_map.emplace(

--- a/pipelines/lidar3d-gicp-optimize-twist.yaml
+++ b/pipelines/lidar3d-gicp-optimize-twist.yaml
@@ -77,6 +77,13 @@ params:
     icp_quality_controller_setpoint: 0.85
     kp: 2.0
     alpha: ${MOLA_ADAPT_THRESHOLD_ALPHA|0.99}
+    # Optional sustained-failure recovery: if enabled, sigma is grown
+    # multiplicatively after a streak of bad ICPs, capped at maximum_sigma,
+    # so the matcher window can re-open and ICP can recover. With the flag
+    # off (default) behavior is unchanged.
+    recover_on_sustained_failure: ${MOLA_ADAPT_THRESHOLD_RECOVER|false}
+    recover_after_n_bad: ${MOLA_ADAPT_THRESHOLD_RECOVER_AFTER_N_BAD|5}
+    recover_growth_factor: ${MOLA_ADAPT_THRESHOLD_RECOVER_GROWTH_FACTOR|1.5}
 
   # If enabled, a map will be stored in RAM and (if using the CLI) stored
   # to a ".simplemap" file for later use for localization, etc.

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -88,6 +88,13 @@ params:
     icp_quality_controller_setpoint: 0.85
     kp: 2.0
     alpha: ${MOLA_ADAPT_THRESHOLD_ALPHA|0.99}
+    # Optional sustained-failure recovery: if enabled, sigma is grown
+    # multiplicatively after a streak of bad ICPs, capped at maximum_sigma,
+    # so the matcher window can re-open and ICP can recover. With the flag
+    # off (default) behavior is unchanged.
+    recover_on_sustained_failure: ${MOLA_ADAPT_THRESHOLD_RECOVER|false}
+    recover_after_n_bad: ${MOLA_ADAPT_THRESHOLD_RECOVER_AFTER_N_BAD|5}
+    recover_growth_factor: ${MOLA_ADAPT_THRESHOLD_RECOVER_GROWTH_FACTOR|1.5}
 
   # REP-107 diagnostics thresholds published on /diagnostics via mola_bridge_ros2.
   # Any of these can be omitted to keep its built-in default.

--- a/pipelines/lidar3d-icp.yaml
+++ b/pipelines/lidar3d-icp.yaml
@@ -76,6 +76,13 @@ params:
     maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|3.0} # [m]
     kp: 2.0
     alpha: ${MOLA_ADAPT_THRESHOLD_ALPHA|0.90}
+    # Optional sustained-failure recovery: if enabled, sigma is grown
+    # multiplicatively after a streak of bad ICPs, capped at maximum_sigma,
+    # so the matcher window can re-open and ICP can recover. With the flag
+    # off (default) behavior is unchanged.
+    recover_on_sustained_failure: ${MOLA_ADAPT_THRESHOLD_RECOVER|false}
+    recover_after_n_bad: ${MOLA_ADAPT_THRESHOLD_RECOVER_AFTER_N_BAD|5}
+    recover_growth_factor: ${MOLA_ADAPT_THRESHOLD_RECOVER_GROWTH_FACTOR|1.5}
 
   # If enabled, a map will be stored in RAM and (if using the CLI) stored
   # to a ".simplemap" file for later use for localization, etc.

--- a/pipelines/lidar3d-ndt.yaml
+++ b/pipelines/lidar3d-ndt.yaml
@@ -70,6 +70,13 @@ params:
     maximum_sigma: ${MOLA_SIGMA_MAX|0.5} # [m]
     kp: 2.0
     alpha: ${MOLA_ADAPT_THRESHOLD_ALPHA|0.90}
+    # Optional sustained-failure recovery: if enabled, sigma is grown
+    # multiplicatively after a streak of bad ICPs, capped at maximum_sigma,
+    # so the matcher window can re-open and ICP can recover. With the flag
+    # off (default) behavior is unchanged.
+    recover_on_sustained_failure: ${MOLA_ADAPT_THRESHOLD_RECOVER|false}
+    recover_after_n_bad: ${MOLA_ADAPT_THRESHOLD_RECOVER_AFTER_N_BAD|5}
+    recover_growth_factor: ${MOLA_ADAPT_THRESHOLD_RECOVER_GROWTH_FACTOR|1.5}
 
   # If enabled, a map will be stored in RAM and (if using the CLI) stored
   # to a ".simplemap" file for later use for localization, etc.


### PR DESCRIPTION
## Summary

- The KISS-ICP adaptive threshold only updates `adapt_thres_sigma` on a good ICP. This is correct for isolated bad scans, but under a sustained run of bad ICPs sigma stays frozen at whatever (typically small) value it had at the moment things went bad. The matcher window is `2 * sigma`, so once sigma is small the search radius is too tight to find correspondences, ICP stays below `min_icp_goodness`, sigma stays frozen, and the system cannot recover on its own without an external relocalize.
- This patch adds three **opt-in** fields to `AdaptiveThreshold` (defaults preserve current behavior): `recover_on_sustained_failure` (default `false`), `recover_after_n_bad` (default `5`), `recover_growth_factor` (default `1.5`). When enabled, after N consecutive bad ICPs, `adapt_thres_sigma` is multiplied by the growth factor each step (capped at `maximum_sigma`) so the next ICP attempt has a wider correspondence search radius. The counter resets on any good ICP and the standard KISS-ICP rule resumes immediately, re-tightening sigma.
- Strictly additive: with the flag off (default) the code path through `processLidarScan` is unchanged.

Putting this up for your consideration — happy to drop, change shape, or move the recovery elsewhere (e.g. trigger relocalization rather than widening the threshold) if that fits the design better. It's not a blocker for us, we wanted to share the diagnosis and a minimal fix in case it's useful.