### PR TITLE
ci: scope arm64 apt-cacher-ng proxy to apt only (fix xmllint test)

### DIFF
--- a/.github/workflows/build-ros.yml
+++ b/.github/workflows/build-ros.yml
@@ -88,10 +88,15 @@ jobs:
           apt-get -y install git curl gnupg2 ca-certificates
           git clone https://$TOKEN@github.com/$GITHUB_REPOSITORY.git --recursive "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          # On pull_request events GITHUB_SHA is the auto-generated merge commit,
-          # which is not present in a plain branch clone. Fetch GITHUB_REF so that
-          # both push (refs/heads/...) and PR (refs/pull/N/merge) events work.
-          git fetch origin "$GITHUB_REF"
+          # Check out the exact commit the event points at. On push, GITHUB_SHA
+          # is immutable (GITHUB_REF would track the branch tip, which may have
+          # advanced). On pull_request, GITHUB_SHA is the auto-generated merge
+          # commit (not fetchable by SHA), so fetch GITHUB_REF (refs/pull/N/merge).
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            git fetch origin "$GITHUB_REF"
+          else
+            git fetch origin "$GITHUB_SHA"
+          fi
           git checkout FETCH_HEAD
           git submodule update --init --recursive
 

--- a/.github/workflows/build-ros.yml
+++ b/.github/workflows/build-ros.yml
@@ -88,7 +88,11 @@ jobs:
           apt-get -y install git curl gnupg2 ca-certificates
           git clone https://$TOKEN@github.com/$GITHUB_REPOSITORY.git --recursive "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git checkout $GITHUB_SHA
+          # On pull_request events GITHUB_SHA is the auto-generated merge commit,
+          # which is not present in a plain branch clone. Fetch GITHUB_REF so that
+          # both push (refs/heads/...) and PR (refs/pull/N/merge) events work.
+          git fetch origin "$GITHUB_REF"
+          git checkout FETCH_HEAD
           git submodule update --init --recursive
 
       # Pre-built ros:* images have ROS base but need colcon/rosdep tooling.

--- a/.github/workflows/build-ros.yml
+++ b/.github/workflows/build-ros.yml
@@ -210,8 +210,6 @@ jobs:
     runs-on: [ self-hosted, Linux, ARM64 ]
     env:
       DEBIAN_FRONTEND: noninteractive
-      http_proxy: http://host.docker.internal:3142 # apt-cacher-ng
-      https_proxy: http://host.docker.internal:3142 # apt-cacher-ng handles HTTPS too via CONNECT
 
     strategy:
       fail-fast: false
@@ -244,6 +242,15 @@ jobs:
       options: --add-host=host.docker.internal:host-gateway # for apt-cacher-ng
 
     steps:
+      # Scope the apt-cacher-ng proxy to apt only. A global http_proxy/https_proxy
+      # also routed non-apt downloads (e.g. ament_xmllint fetching
+      # package_format3.xsd from download.ros.org) through the package cache,
+      # which it cannot serve, breaking the xmllint test.
+      - name: Configure apt proxy (apt-cacher-ng)
+        run: |
+          printf 'Acquire::http::Proxy "http://host.docker.internal:3142";\n' > /etc/apt/apt.conf.d/01proxy
+          printf 'Acquire::https::Proxy "http://host.docker.internal:3142";\n' >> /etc/apt/apt.conf.d/01proxy
+
       - name: Install Git
         run: apt-get update && apt-get install -y git
 


### PR DESCRIPTION
## Problem

The newly-added self-hosted **arm64** CI jobs (`build_self_hosted`) fail on the **`xmllint`** test:

```
warning: failed to load external entity "http://download.ros.org/schema/package_format3.xsd"
Schemas parser error : Failed to locate the main schema resource ...
```

The job sets `http_proxy`/`https_proxy` **globally** to the apt-cacher-ng instance. `ament_xmllint` downloads `package_format3.xsd` from `download.ros.org` over HTTP, and apt-cacher-ng (a *package* cache) cannot serve that arbitrary fetch, so schema validation fails. The x86_64 jobs have no proxy and pass.

## Fix

Configure the apt-cacher-ng proxy via `/etc/apt/apt.conf.d/01proxy` (apt-scoped) instead of global `http_proxy`/`https_proxy` env vars. apt still uses the cache; `ament_xmllint` and other tools reach the network directly.

## Scope / not included

This PR intentionally does **not** touch the separate, arm64-only failure of `test_lidar_odometry_kitti` (`trajectory.size()=0`). That is a genuine platform-specific behavior in the LiDAR-only (no-IMU) pipeline — the `mulran` (IMU) and `rslidar` tests pass on arm64, and the identical kitti test passes on x86_64 with the same dataset. It needs on-device debugging and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Scoped proxy configuration for ARM64 builds so only package manager traffic uses the build cache, avoiding unintended proxying of other downloads.
  * Improved CI checkout logic for pull-request runs so merge commits are available in the clone, ensuring accurate PR builds and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->