### PR TITLE
feat: simplify adaptive sigma algorithm

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -333,19 +333,20 @@ public:
     };
     Visualization visualization;
 
-    // KISS-ICP adaptive threshold method:
+    // Adaptive threshold method based purely on ICP quality
     struct AdaptiveThreshold
     {
       bool enabled = true;
-      double initial_sigma = 0.5;
-      double maximum_sigma = 3.0;
-      double min_motion = 0.10;
+      double initial_sigma = 0.5;    // Units: [m]
+      double maximum_sigma = 3.0;    // Units: [m]
+      double min_motion = 0.10;      // Units: [m]
+      double max_sigma_step = 0.05;  // Units: [m]
       double kp = 5.0;
       double alpha = 0.99;
-      double icp_quality_controller_setpoint = 0.85;
+      double icp_quality_controller_setpoint = 0.85;  // Range: [0,1]
 
       // Sustained-failure recovery (opt-in).
-      // KISS-ICP only updates sigma on good ICP, so a streak of bad ICPs
+      // Updates sigma on good ICP, so a streak of bad ICPs
       // freezes sigma at its last (typically small) value. With a small
       // matcher window the system cannot recover from a perturbation that
       // exceeds 2*sigma. When enabled, sigma is multiplicatively grown
@@ -991,8 +992,8 @@ private:
   void onGPS(const CObservation::ConstPtr & o);
   void onGPSImpl(const CObservation::ConstPtr & o);
 
-  // KISS-ICP adaptive threshold method:
-  void doUpdateAdaptiveThreshold(const mrpt::poses::CPose3D & lastMotionModelError);
+  // Adaptive threshold method:
+  void doUpdateAdaptiveThreshold();
 
   void doInitializeEstimatedObservationRadius(const mrpt::obs::CObservation & o);
   void doUpdateEstimatedObservationRadius(const mp2p_icp::metric_map_t & m);

--- a/module/src/LidarOdometry_AdaptiveVariables.cpp
+++ b/module/src/LidarOdometry_AdaptiveVariables.cpp
@@ -136,58 +136,39 @@ void LidarOdometry::updatePipelineDynamicVariables(const mrpt::Clock::time_point
   state_.parameter_source.realize();
 }
 
-// KISS-ICP adaptive threshold method (MIT License; code adapted to MRPT)
-namespace
-{
-double computeModelError(const mrpt::poses::CPose3D & model_deviation, double max_range)
-{
-  const double theta = mrpt::poses::Lie::SO<3>::log(model_deviation.getRotationMatrix()).norm();
-  const double delta_rot = 2.0 * max_range * std::sin(theta / 2.0);
-  const double delta_trans = model_deviation.translation().norm();
-  return delta_trans + delta_rot;
-}
-}  // namespace
-
-void LidarOdometry::doUpdateAdaptiveThreshold(const mrpt::poses::CPose3D & lastMotionModelError)
+void LidarOdometry::doUpdateAdaptiveThreshold()
 {
   if (!state_.estimated_observation_radius.has_value()) {
     return;
   }
 
-  const double max_range = state_.estimated_observation_radius.value();
-
-  const double ALPHA = params_.adaptive_threshold.alpha;
-
-  const double model_error = computeModelError(lastMotionModelError, max_range);
-  double rot_error = 0;
-  if (state_.last_motion_model_output) {
-    const auto & tw = state_.last_motion_model_output->twist;
-    rot_error = 0.01 * mrpt::math::TVector3D(tw.wx, tw.wy, tw.wz).norm() * max_range;
-  }
-
-  // proportional controller constant
-  const double KP = params_.adaptive_threshold.kp;
-  ASSERT_(KP > 1.0);
-
-  const double new_sigma =
-    (model_error + rot_error) *
-    mrpt::saturate_val(
-      KP * (params_.adaptive_threshold.icp_quality_controller_setpoint - state_.last_icp_quality),
-      0.1, KP);
-
-  if (state_.adapt_thres_sigma == 0) {  // initial
+  // Initialization guard FIRST
+  if (state_.adapt_thres_sigma == 0) {
     state_.adapt_thres_sigma = params_.adaptive_threshold.initial_sigma;
   }
 
-  state_.adapt_thres_sigma = (ALPHA * state_.adapt_thres_sigma) + ((1.0 - ALPHA) * new_sigma);
+  const double ALPHA = params_.adaptive_threshold.alpha;
+  const double KP = params_.adaptive_threshold.kp;
+  ASSERT_(KP > 0.0);  // any positive gain is valid
 
+  // Additive P-controller: positive error → increase sigma
+  const double error =
+    params_.adaptive_threshold.icp_quality_controller_setpoint - state_.last_icp_quality;
+  const double delta = std::clamp(
+    KP * error, -params_.adaptive_threshold.max_sigma_step,
+    params_.adaptive_threshold.max_sigma_step);
+  const double new_sigma = state_.adapt_thres_sigma + delta;
+
+  // EMA smoothing
+  state_.adapt_thres_sigma = ALPHA * state_.adapt_thres_sigma + (1.0 - ALPHA) * new_sigma;
+
+  // Hard bounds last
   mrpt::saturate(
     state_.adapt_thres_sigma, params_.adaptive_threshold.min_motion,
     params_.adaptive_threshold.maximum_sigma);
 
   MRPT_LOG_DEBUG_FMT(
-    "model_error: %f  new_sigma: %f ICP q=%f sigma=%f", model_error, new_sigma,
-    state_.last_icp_quality, state_.adapt_thres_sigma);
+    "delta: %+.4f ICP q=%.3f sigma=%.4f", delta, state_.last_icp_quality, state_.adapt_thres_sigma);
 }
 
 void LidarOdometry::doInitializeEstimatedObservationRadius(const mrpt::obs::CObservation & o)

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -91,6 +91,7 @@ void LidarOdometry::Parameters::AdaptiveThreshold::initialize(const Yaml & cfg)
   YAML_LOAD_REQ(alpha, double);
   YAML_LOAD_OPT(maximum_sigma, double);
   YAML_LOAD_OPT(icp_quality_controller_setpoint, double);
+  YAML_LOAD_OPT(max_sigma_step, double);
 
   YAML_LOAD_OPT(recover_on_sustained_failure, bool);
   YAML_LOAD_OPT(recover_after_n_bad, int);

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -588,23 +588,19 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       "twistCorrectionCount", static_cast<double>(twistCorrectionCount));
     state_.parameter_source.updateVariable("icp_quality", state_.last_icp_quality);
 
-    // KISS-ICP adaptive threshold method:
+    // Adaptive threshold method:
     // Only update on good ICP: a bad ICP may have converged to a local minimum
     // near the initial guess, yielding an artificially small motion model error
     // that would incorrectly shrink the search threshold.
     if (params_.adaptive_threshold.enabled && icpIsGood) {
-      const mrpt::poses::CPose3D motionModelError =
-        out.found_pose_to_wrt_from.mean - mrpt::poses::CPose3D(in.init_guess_local_wrt_global);
+      doUpdateAdaptiveThreshold();
 
-      doUpdateAdaptiveThreshold(motionModelError);
+      MRPT_LOG_DEBUG_STREAM("Adaptive threshold: sigma=" << state_.adapt_thres_sigma);
 
-      MRPT_LOG_DEBUG_STREAM(
-        "Adaptive threshold: sigma=" << state_.adapt_thres_sigma
-                                     << " motionModelError=" << motionModelError.asString());
     }  // end adaptive threshold
 
     // Sustained-failure recovery for the adaptive threshold (opt-in).
-    // The KISS-ICP rule above never updates sigma on a bad ICP, which is correct
+    // The rule above never updates sigma on a bad ICP, which is correct
     // for isolated failures but creates a deadlock under sustained failure: with
     // sigma frozen small, the matcher window stays tight and ICP cannot find
     // enough correspondences to recover. When enabled, after a streak of bad

--- a/pipelines/extras/lidar3d-dual-map.yaml
+++ b/pipelines/extras/lidar3d-dual-map.yaml
@@ -22,11 +22,23 @@ params:
   # Minimum ICP quality to insert it into the map:
   min_icp_goodness: 0.25
 
-  # Adaptive threshold, as in the KISS-ICP paper:
+  # Adaptive threshold:
   adaptive_threshold:
     enabled: true
-    initial_sigma: 2.0
-    min_motion: 0.10
+    initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
+    min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
+    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
+    max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
+    icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
+    kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
+    alpha: ${MOLA_ADAPT_THRESHOLD_ALPHA|0.90}
+    # Optional sustained-failure recovery: if enabled, sigma is grown
+    # multiplicatively after a streak of bad ICPs, capped at maximum_sigma,
+    # so the matcher window can re-open and ICP can recover. With the flag
+    # off (default) behavior is unchanged.
+    recover_on_sustained_failure: ${MOLA_ADAPT_THRESHOLD_RECOVER|false}
+    recover_after_n_bad: ${MOLA_ADAPT_THRESHOLD_RECOVER_AFTER_N_BAD|5}
+    recover_growth_factor: ${MOLA_ADAPT_THRESHOLD_RECOVER_GROWTH_FACTOR|1.5}
 
   # If enabled, a map will be stored in RAM and (if using the CLI) stored
   # to a ".simplemap" file for later use for localization, etc.
@@ -115,11 +127,7 @@ icp_settings_with_vel:
         pairingsPerPoint: 1
         allowMatchAlreadyMatchedGlobalPoints: true # faster
         pointLayerMatches:
-          - {
-              global: "localmap_far",
-              local: "decimated_for_icp_near",
-              weight: 1.0,
-            }
+          - { global: "localmap_far", local: "decimated_for_icp_near", weight: 1.0 }
 
   quality:
     - class: mp2p_icp::QualityEvaluator_PairedRatio
@@ -237,32 +245,16 @@ observations_filter_1st_pass:
     params:
       input_pointcloud_layer: "range_filtered"
       outside_pointcloud_layer: "filtered"
-      bounding_box_min:
-        [
-          -0.30*ESTIMATED_OBSERVATION_RADIUS,
-          -0.30*ESTIMATED_OBSERVATION_RADIUS,
-          0.05*ESTIMATED_OBSERVATION_RADIUS,
-        ]
-      bounding_box_max:
-        [
-          0.30*ESTIMATED_OBSERVATION_RADIUS,
-          0.30*ESTIMATED_OBSERVATION_RADIUS,
-          0.40*ESTIMATED_OBSERVATION_RADIUS,
-        ]
+      bounding_box_min: [-0.30*ESTIMATED_OBSERVATION_RADIUS, -0.30*ESTIMATED_OBSERVATION_RADIUS, 0.05*ESTIMATED_OBSERVATION_RADIUS]
+      bounding_box_max: [0.30*ESTIMATED_OBSERVATION_RADIUS, 0.30*ESTIMATED_OBSERVATION_RADIUS, 0.40*ESTIMATED_OBSERVATION_RADIUS]
 
   - class_name: mp2p_icp_filters::FilterBoundingBox
     params:
       input_pointcloud_layer: "filtered"
       inside_pointcloud_layer: "near"
       outside_pointcloud_layer: "far"
-      bounding_box_min:
-        [
-          -0.30*ESTIMATED_OBSERVATION_RADIUS,
-          -0.30*ESTIMATED_OBSERVATION_RADIUS,
-          -1000.0,
-        ]
-      bounding_box_max:
-        [0.30*ESTIMATED_OBSERVATION_RADIUS, 0.30*ESTIMATED_OBSERVATION_RADIUS, -1.0]
+      bounding_box_min: [-0.30*ESTIMATED_OBSERVATION_RADIUS, -0.30*ESTIMATED_OBSERVATION_RADIUS, -1000.0]
+      bounding_box_max: [0.30*ESTIMATED_OBSERVATION_RADIUS, 0.30*ESTIMATED_OBSERVATION_RADIUS, -1.0]
 
   - class_name: mp2p_icp_filters::FilterDecimateVoxels
     params:
@@ -295,8 +287,7 @@ observations_filter_1st_pass:
   # Remove layers to save memory and log file storage
   - class_name: mp2p_icp_filters::FilterDeleteLayer
     params:
-      pointcloud_layer_to_remove:
-        ["raw", "deskewed", "range_filtered", "filtered", "far", "near"]
+      pointcloud_layer_to_remove: ["raw", "deskewed", "range_filtered", "filtered", "far", "near"]
 
 # To populate the local map, one or more observation layers are merged
 # into the local map via this pipeline:
@@ -306,13 +297,11 @@ insert_observation_into_local_map:
       input_pointcloud_layer: "decimated_for_map"
       target_layer: "localmap"
       input_layer_in_local_coordinates: true
-      robot_pose:
-        [robot_x, robot_y, robot_z, robot_yaw, robot_pitch, robot_roll]
+      robot_pose: [robot_x, robot_y, robot_z, robot_yaw, robot_pitch, robot_roll]
 
   - class_name: mp2p_icp_filters::FilterMerge
     params:
       input_pointcloud_layer: "decimated_for_map_far"
       target_layer: "localmap_far"
       input_layer_in_local_coordinates: true
-      robot_pose:
-        [robot_x, robot_y, robot_z, robot_yaw, robot_pitch, robot_roll]
+      robot_pose: [robot_x, robot_y, robot_z, robot_yaw, robot_pitch, robot_roll]

--- a/pipelines/extras/lidar3d-edges.yaml
+++ b/pipelines/extras/lidar3d-edges.yaml
@@ -26,11 +26,23 @@ params:
   # Minimum ICP quality to insert it into the map:
   min_icp_goodness: 0.25
 
-  # Adaptive threshold, as in the KISS-ICP paper:
+  # Adaptive threshold:
   adaptive_threshold:
     enabled: true
-    initial_sigma: 2.0
-    min_motion: 0.10
+    initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
+    min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
+    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
+    max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
+    icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
+    kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
+    alpha: ${MOLA_ADAPT_THRESHOLD_ALPHA|0.90}
+    # Optional sustained-failure recovery: if enabled, sigma is grown
+    # multiplicatively after a streak of bad ICPs, capped at maximum_sigma,
+    # so the matcher window can re-open and ICP can recover. With the flag
+    # off (default) behavior is unchanged.
+    recover_on_sustained_failure: ${MOLA_ADAPT_THRESHOLD_RECOVER|false}
+    recover_after_n_bad: ${MOLA_ADAPT_THRESHOLD_RECOVER_AFTER_N_BAD|5}
+    recover_growth_factor: ${MOLA_ADAPT_THRESHOLD_RECOVER_GROWTH_FACTOR|1.5}
 
   # If enabled, a map will be stored in RAM and (if using the CLI) stored
   # to a ".simplemap" file for later use for localization, etc.
@@ -111,16 +123,8 @@ icp_settings_with_vel:
         pairingsPerPoint: 1
         allowMatchAlreadyMatchedGlobalPoints: true # faster
         pointLayerMatches:
-          - {
-              global: "localmap_large_curvature",
-              local: "decimated_for_icp_large_curvature",
-              weight: 1.0,
-            }
-          - {
-              global: "localmap_small_curvature",
-              local: "decimated_for_icp_smaller_curvature",
-              weight: 1.0,
-            }
+          - { global: "localmap_large_curvature", local: "decimated_for_icp_large_curvature", weight: 1.0 }
+          - { global: "localmap_small_curvature", local: "decimated_for_icp_smaller_curvature", weight: 1.0 }
 
   quality:
     - class: mp2p_icp::QualityEvaluator_PairedRatio
@@ -237,18 +241,8 @@ observations_filter_1st_pass:
     params:
       input_pointcloud_layer: "range_filtered"
       outside_pointcloud_layer: "filtered"
-      bounding_box_min:
-        [
-          -0.30*ESTIMATED_OBSERVATION_RADIUS,
-          -0.30*ESTIMATED_OBSERVATION_RADIUS,
-          0.05*ESTIMATED_OBSERVATION_RADIUS,
-        ]
-      bounding_box_max:
-        [
-          0.30*ESTIMATED_OBSERVATION_RADIUS,
-          0.30*ESTIMATED_OBSERVATION_RADIUS,
-          0.40*ESTIMATED_OBSERVATION_RADIUS,
-        ]
+      bounding_box_min: [-0.30*ESTIMATED_OBSERVATION_RADIUS, -0.30*ESTIMATED_OBSERVATION_RADIUS, 0.05*ESTIMATED_OBSERVATION_RADIUS]
+      bounding_box_max: [0.30*ESTIMATED_OBSERVATION_RADIUS, 0.30*ESTIMATED_OBSERVATION_RADIUS, 0.40*ESTIMATED_OBSERVATION_RADIUS]
 
   - class_name: mp2p_icp_filters::FilterCurvature
     params:
@@ -291,15 +285,7 @@ observations_filter_1st_pass:
   # Remove layers to save memory and log file storage
   - class_name: mp2p_icp_filters::FilterDeleteLayer
     params:
-      pointcloud_layer_to_remove:
-        [
-          "raw",
-          "deskewed",
-          "filtered",
-          "range_filtered",
-          "large_curvature",
-          "smaller_curvature",
-        ]
+      pointcloud_layer_to_remove: ["raw", "deskewed", "filtered", "range_filtered", "large_curvature", "smaller_curvature"]
 
 # To populate the local map, one or more observation layers are merged
 # into the local map via this pipeline:
@@ -309,13 +295,11 @@ insert_observation_into_local_map:
       input_pointcloud_layer: "decimated_for_map_smaller_curvature"
       target_layer: "localmap_small_curvature"
       input_layer_in_local_coordinates: true
-      robot_pose:
-        [robot_x, robot_y, robot_z, robot_yaw, robot_pitch, robot_roll]
+      robot_pose: [robot_x, robot_y, robot_z, robot_yaw, robot_pitch, robot_roll]
 
   - class_name: mp2p_icp_filters::FilterMerge
     params:
       input_pointcloud_layer: "decimated_for_map_large_curvature"
       target_layer: "localmap_large_curvature"
       input_layer_in_local_coordinates: true
-      robot_pose:
-        [robot_x, robot_y, robot_z, robot_yaw, robot_pitch, robot_roll]
+      robot_pose: [robot_x, robot_y, robot_z, robot_yaw, robot_pitch, robot_roll]

--- a/pipelines/extras/rgbd.yaml
+++ b/pipelines/extras/rgbd.yaml
@@ -44,11 +44,23 @@ params:
   # Minimum ICP quality to insert it into the map:
   min_icp_goodness: 0.05
 
-  # Adaptive threshold, as in the KISS-ICP paper:
+  # Adaptive threshold:
   adaptive_threshold:
     enabled: true
-    initial_sigma: 0.20
-    min_motion: ${MOLA_SIGMA_MIN_MOTION|0.10}
+    initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
+    min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
+    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
+    max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
+    icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
+    kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
+    alpha: ${MOLA_ADAPT_THRESHOLD_ALPHA|0.90}
+    # Optional sustained-failure recovery: if enabled, sigma is grown
+    # multiplicatively after a streak of bad ICPs, capped at maximum_sigma,
+    # so the matcher window can re-open and ICP can recover. With the flag
+    # off (default) behavior is unchanged.
+    recover_on_sustained_failure: ${MOLA_ADAPT_THRESHOLD_RECOVER|false}
+    recover_after_n_bad: ${MOLA_ADAPT_THRESHOLD_RECOVER_AFTER_N_BAD|5}
+    recover_growth_factor: ${MOLA_ADAPT_THRESHOLD_RECOVER_GROWTH_FACTOR|1.5}
 
   # If enabled, a map will be stored in RAM and (if using the CLI) stored
   # to a ".simplemap" file for later use for localization, etc.
@@ -278,13 +290,11 @@ insert_observation_into_local_map:
       input_pointcloud_layer: "edges_for_map"
       target_layer: "localmap_edges"
       input_layer_in_local_coordinates: true
-      robot_pose:
-        [robot_x, robot_y, robot_z, robot_yaw, robot_pitch, robot_roll]
+      robot_pose: [robot_x, robot_y, robot_z, robot_yaw, robot_pitch, robot_roll]
 
   - class_name: mp2p_icp_filters::FilterMerge
     params:
       input_pointcloud_layer: "planes_for_map"
       target_layer: "localmap_planes"
       input_layer_in_local_coordinates: true
-      robot_pose:
-        [robot_x, robot_y, robot_z, robot_yaw, robot_pitch, robot_roll]
+      robot_pose: [robot_x, robot_y, robot_z, robot_yaw, robot_pitch, robot_roll]

--- a/pipelines/lidar2d.yaml
+++ b/pipelines/lidar2d.yaml
@@ -52,13 +52,23 @@ params:
   # Minimum ICP quality to insert it into the map:
   min_icp_goodness: 0.25
 
-  # Adaptive threshold, as in the KISS-ICP paper:
+  # Adaptive threshold:
   adaptive_threshold:
     enabled: true
-    initial_sigma: 0.20
-    min_motion: ${MOLA_SIGMA_MIN_MOTION|0.10}
-    kp: 2.0
-    alpha: 0.99
+    initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
+    min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
+    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
+    max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
+    icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
+    kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
+    alpha: ${MOLA_ADAPT_THRESHOLD_ALPHA|0.90}
+    # Optional sustained-failure recovery: if enabled, sigma is grown
+    # multiplicatively after a streak of bad ICPs, capped at maximum_sigma,
+    # so the matcher window can re-open and ICP can recover. With the flag
+    # off (default) behavior is unchanged.
+    recover_on_sustained_failure: ${MOLA_ADAPT_THRESHOLD_RECOVER|false}
+    recover_after_n_bad: ${MOLA_ADAPT_THRESHOLD_RECOVER_AFTER_N_BAD|5}
+    recover_growth_factor: ${MOLA_ADAPT_THRESHOLD_RECOVER_GROWTH_FACTOR|1.5}
 
   # If enabled, a map will be stored in RAM and (if using the CLI) stored
   # to a ".simplemap" file for later use for localization, etc.

--- a/pipelines/lidar3d-gicp-optimize-twist.yaml
+++ b/pipelines/lidar3d-gicp-optimize-twist.yaml
@@ -68,14 +68,15 @@ params:
   # Minimum ICP quality to insert it into the map:
   min_icp_goodness: ${MOLA_MINIMUM_ICP_QUALITY|0.50}
 
-  # Adaptive threshold, as in the KISS-ICP paper:
+  # Adaptive threshold:
   adaptive_threshold:
     enabled: true
-    initial_sigma: 0.50 # [m]
+    initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
     min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
     maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
-    icp_quality_controller_setpoint: 0.85
-    kp: 2.0
+    max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
+    icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
+    kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
     alpha: ${MOLA_ADAPT_THRESHOLD_ALPHA|0.90}
     # Optional sustained-failure recovery: if enabled, sigma is grown
     # multiplicatively after a streak of bad ICPs, capped at maximum_sigma,
@@ -173,14 +174,7 @@ initial_localization:
   method: "${MOLA_LO_INITIAL_LOCALIZATION_METHOD|InitLocalization::FixedPose}"
   # Format: x(m) y(m) z(m) yaw(deg) pitch(deg) roll(deg)
   fixed_initial_pose:
-    [
-      "${MOLA_INITIAL_X|0.0}",
-      "${MOLA_INITIAL_Y|0.0}",
-      "${MOLA_INITIAL_Z|0.0}",
-      "${MOLA_INITIAL_YAW|0.0}",
-      "${MOLA_INITIAL_PITCH|0.0}",
-      "${MOLA_INITIAL_ROLL|0.0}",
-    ]
+    ["${MOLA_INITIAL_X|0.0}", "${MOLA_INITIAL_Y|0.0}", "${MOLA_INITIAL_Z|0.0}", "${MOLA_INITIAL_YAW|0.0}", "${MOLA_INITIAL_PITCH|0.0}", "${MOLA_INITIAL_ROLL|0.0}"]
   imu_initial_calibration_sample_count: "${MOLA_LO_INITIAL_IMU_SAMPLES|400}"
   imu_initial_calibration_max_age: 5.0
   use_imu_orientation: "${MOLA_LO_INITIAL_IMU_USE_ORIENTATION|true}"
@@ -232,10 +226,7 @@ icp_settings_with_vel:
         allowMatchAlreadyMatchedGlobalPoints: true # faster
         # Both layers here must be of type 'mola::KeyframePointCloudMap'
         layerMatches:
-          - {
-              global: "${MOLA_LOCALMAP_LAYER_NAME|localmap}",
-              local: "observation",
-            }
+          - { global: "${MOLA_LOCALMAP_LAYER_NAME|localmap}", local: "observation" }
 
   quality:
     - class: mp2p_icp::QualityEvaluator_PairedRatio
@@ -414,13 +405,7 @@ observations_filter_final_pass:
   # Remove layers to save memory and log file storage
   - class_name: mp2p_icp_filters::FilterDeleteLayer
     params:
-      pointcloud_layer_to_remove:
-        [
-          "raw",
-          "decimated_unfiltered",
-          "decimated_skewed_for_map",
-          "decimated_skewed_for_icp",
-        ]
+      pointcloud_layer_to_remove: ["raw", "decimated_unfiltered", "decimated_skewed_for_map", "decimated_skewed_for_icp"]
 
 # To populate the local map, one or more observation layers are merged
 # into the local map via this pipeline:
@@ -431,8 +416,7 @@ insert_observation_into_local_map:
       input_pointcloud_layer: "decimated_for_map"
       target_layer: "${MOLA_LOCALMAP_LAYER_NAME|localmap}"
       input_layer_in_local_coordinates: true
-      robot_pose:
-        [robot_x, robot_y, robot_z, robot_yaw, robot_pitch, robot_roll]
+      robot_pose: [robot_x, robot_y, robot_z, robot_yaw, robot_pitch, robot_roll]
 
 # Pipeline starting from raw observations (passed through "Generator"), to be
 # sent out for visualization of the sliding-window of recent clouds as a dense local map

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -79,7 +79,7 @@ params:
   # Useful to debug mapping issues. If empty, only the env var MP2P_ICP_GENERATE_DEBUG_FILES and the icp.params setting will define when to save logs.
   write_debug_icp_log_if_quality_under: ${MOLA_WRITE_DEBUG_ICP_LOG_IF_QUALITY_UNDER|""}
 
-  # Adaptive threshold, as in the KISS-ICP paper:
+  # Adaptive threshold:
   adaptive_threshold:
     enabled: true
     initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
@@ -87,7 +87,7 @@ params:
     maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
     max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
     icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
-    kp: 2.0
+    kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
     alpha: ${MOLA_ADAPT_THRESHOLD_ALPHA|0.90}
     # Optional sustained-failure recovery: if enabled, sigma is grown
     # multiplicatively after a streak of bad ICPs, capped at maximum_sigma,

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -85,7 +85,8 @@ params:
     initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
     min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
     maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
-    icp_quality_controller_setpoint: 0.85
+    max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
+    icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
     kp: 2.0
     alpha: ${MOLA_ADAPT_THRESHOLD_ALPHA|0.90}
     # Optional sustained-failure recovery: if enabled, sigma is grown

--- a/pipelines/lidar3d-icp.yaml
+++ b/pipelines/lidar3d-icp.yaml
@@ -68,13 +68,15 @@ params:
   # Minimum ICP quality to insert it into the map:
   min_icp_goodness: ${MOLA_MINIMUM_ICP_QUALITY|0.25}
 
-  # Adaptive threshold, as in the KISS-ICP paper:
+  # Adaptive threshold:
   adaptive_threshold:
     enabled: true
-    initial_sigma: ${MOLA_SIGMA_INITIAL|2.0} # [m]
-    min_motion: ${MOLA_SIGMA_MIN_MOTION|0.10} # [m]
-    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|3.0} # [m]
-    kp: 2.0
+    initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
+    min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
+    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
+    max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
+    icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
+    kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
     alpha: ${MOLA_ADAPT_THRESHOLD_ALPHA|0.90}
     # Optional sustained-failure recovery: if enabled, sigma is grown
     # multiplicatively after a streak of bad ICPs, capped at maximum_sigma,

--- a/pipelines/lidar3d-ndt.yaml
+++ b/pipelines/lidar3d-ndt.yaml
@@ -62,13 +62,15 @@ params:
   # Minimum ICP quality to insert it into the map:
   min_icp_goodness: ${MOLA_MINIMUM_ICP_QUALITY|0.25}
 
-  # Adaptive threshold, as in the KISS-ICP paper:
+  # Adaptive threshold:
   adaptive_threshold:
     enabled: true
-    initial_sigma: 2.0 # [m]
-    min_motion: ${MOLA_SIGMA_MIN_MOTION|0.10} # [m]
-    maximum_sigma: ${MOLA_SIGMA_MAX|0.5} # [m]
-    kp: 2.0
+    initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
+    min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
+    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
+    max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
+    icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
+    kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
     alpha: ${MOLA_ADAPT_THRESHOLD_ALPHA|0.90}
     # Optional sustained-failure recovery: if enabled, sigma is grown
     # multiplicatively after a streak of bad ICPs, capped at maximum_sigma,


### PR DESCRIPTION
It now uses just the ICP quality as P-controller setpoint, dropping the original KISS-ICP-like modelError algorithm.

Small dataset tests show an improvement of ~1cm less average errors in unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adaptive-threshold update now relies only on ICP quality (removed dependence on motion-model error) and uses a simplified controller with smoothing and clamping.

* **New Features**
  * Added max_sigma_step and made adaptive-threshold parameters (initial_sigma, kp, setpoint, alpha, maximum_sigma, etc.) configurable via environment variables.
  * Added optional sustained-failure recovery controls (recover_on_sustained_failure, recover_after_n_bad, recover_growth_factor).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->