### PR TITLE
fix: avoid use-after-free during shutdown via LidarOdometry::onQuit()

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -116,6 +116,7 @@ public:
   void initialize_frontend(const Yaml & cfg) override;
   void spinOnce() override;
   void onNewObservation(const CObservation::ConstPtr & o) override;
+  void onQuit() override;
 
   /** Re-initializes the odometry system. It effectively calls initialize()
      *  once again with the same parameters that were used the first time.
@@ -583,6 +584,19 @@ public:
   Parameters params_;
 
   bool isBusy() const;
+
+  /** Drains the worker thread pools and saves the simplemap/trajectory/local
+   *  map to disk, if so configured. Idempotent: safe to call from onQuit()
+   *  and then again from the destructor.
+   *
+   *  Must run to completion (and thus stop calling back into other modules,
+   *  e.g. via VizInterface or BridgeROS2's TF broadcaster) before any other
+   *  module of the running MOLA system is destroyed. onQuit() is invoked by
+   *  MolaLauncherApp for that exact purpose, before any module destructor
+   *  runs.
+   */
+  void shutdownCleanup();
+  std::atomic_bool shutdown_cleanup_done_{false};
 
   bool isActive() const;
   void setActive(bool active);

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -74,11 +74,33 @@ IMPLEMENTS_MRPT_OBJECT(LidarOdometry, FrontEndBase, mola)
 
 LidarOdometry::LidarOdometry() = default;
 
-LidarOdometry::~LidarOdometry()
+LidarOdometry::~LidarOdometry() { shutdownCleanup(); }
+
+void LidarOdometry::onQuit() { shutdownCleanup(); }
+
+// Drains the worker thread pools and saves outputs to disk. Called from
+// onQuit() (while all other MOLA modules are still alive) and again from the
+// destructor (idempotent, no-op the second time) for callers that do not go
+// through MolaLauncherApp.
+//
+// onQuit() is invoked by MolaLauncherApp::executor_thread() for every module,
+// before any module is destroyed (see ExecutableBase::onQuit() docs). This
+// matters because worker_lidar_/worker_others_/worker_viz_ may have an
+// in-flight task (e.g. onLidar()) that calls back into other modules, e.g.
+// BridgeROS2's TF broadcaster via VizInterface/LocalizationSourceBase. If
+// that task is still running when another module's destructor runs (which
+// previously only happened from ~LidarOdometry(), after other modules may
+// have already been destroyed), it can use-after-free that module's
+// resources.
+void LidarOdometry::shutdownCleanup()
 {
   using namespace std::chrono_literals;
 
-  try  // a dtor should never throw
+  if (shutdown_cleanup_done_.exchange(true)) {
+    return;
+  }
+
+  try  // must never throw
   {
     {
       auto lck = mrpt::lockHelper(is_busy_mtx_);
@@ -87,7 +109,7 @@ LidarOdometry::~LidarOdometry()
 
     while (isBusy()) {
       MRPT_LOG_THROTTLE_WARN(
-        2.0, "Destructor: waiting for remaining tasks on the worker threads...");
+        2.0, "shutdownCleanup(): waiting for remaining tasks on the worker threads...");
       std::this_thread::sleep_for(100ms);
     }
     worker_lidar_.clear();
@@ -108,13 +130,13 @@ LidarOdometry::~LidarOdometry()
     // This must come after save map calls above:
     while (worker_disk_io_.pendingTasks() > 0) {
       MRPT_LOG_THROTTLE_WARN(
-        2.0, "Destructor: waiting for pending tasks on the lazy-load write thread...");
+        2.0, "shutdownCleanup(): waiting for pending tasks on the lazy-load write thread...");
       std::this_thread::sleep_for(100ms);
     }
     worker_disk_io_.clear();
 
   } catch (const std::exception & e) {
-    std::cerr << "[~LidarOdometry] Exception: " << e.what();
+    std::cerr << "[LidarOdometry::shutdownCleanup] Exception: " << e.what();
   }
 }
 


### PR DESCRIPTION
## Summary
- `MolaLauncherApp::shutdown()` destroys modules via `running_threads_.clear()`, which iterates a `std::map<std::string, ...>` in alphabetical key order, not dependency order. As a result `~BridgeROS2()` can run before `~LidarOdometry()`.
- `LidarOdometry`'s `worker_lidar_` thread pool may still have an in-flight `onLidar()` task when this happens. That task calls back into `BridgeROS2`'s TF broadcaster (`tf_bc_->sendTransform(...)`), which by then has already been destroyed, causing a SIGSEGV in `rcl_publisher_is_valid_except_context`.
- Reproduced as a crash on stop-recording in a downstream app, with the following backtrace pattern:
  `tf2_ros::TransformBroadcaster::sendTransform` -> `BridgeROS2::broadcastCachedLocalizationTf` -> `LidarOdometry::onLidar` (running on `worker_lidar_`).

## Fix
- `ExecutableBase::onQuit()` is an existing, documented hook called for *every* module before *any* module destructor runs, but `LidarOdometry` did not implement it.
- Extracted the worker-pool draining and disk-saving logic from `~LidarOdometry()` into a new idempotent `shutdownCleanup()` method.
- `onQuit()` now calls `shutdownCleanup()`, ensuring all worker threads (and any callbacks they make into other modules) are fully drained while every other module is still alive.
- `~LidarOdometry()` also calls `shutdownCleanup()` as a no-op fallback (guarded by `std::atomic_bool shutdown_cleanup_done_`) for callers that construct/destroy `LidarOdometry` outside of `MolaLauncherApp`.

## Test plan
- [x] `colcon build --packages-select mola_lidar_odometry` succeeds
- [x] Verified on hardware: the previously-reproducible SIGSEGV on stop-recording no longer occurs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved shutdown behavior for the LidarOdometry module. The module now properly manages worker thread pool cleanup and ensures reliable persistence of configured outputs—including reconstructed maps, estimated trajectories, and local map updates—during application shutdown and termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->