### PR TITLE
refactor: convert state_mtx_ from recursive_mutex to plain mutex

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -970,7 +970,7 @@ private:
   bool destructor_called_ = false;
   mutable std::mutex is_busy_mtx_;
   mutable std::mutex state_flags_mtx_;
-  mutable std::recursive_mutex state_mtx_;
+  mutable std::mutex state_mtx_;
   mutable std::mutex state_trajectory_mtx_;
   mutable std::recursive_mutex state_simplemap_mtx_;
   mutable std::mutex state_gui_mtx_;
@@ -1071,6 +1071,8 @@ private:
     const mrpt::poses::CPose3DPDFGaussian & initPose, bool resetStateEstimator);
 
   bool isPipelineUsingIMU() const;
+  /// Same as isPipelineUsingIMU(), but assumes state_mtx_ is already held by the caller.
+  bool isPipelineUsingIMU_locked() const;
   void sendLidarScanToProcessQueue(const CObservation::ConstPtr & o);
   mp2p_icp::metric_map_t::Ptr observationFromRawSensor(const mrpt::obs::CSensoryFrame & sf);
   mrpt::obs::CSensoryFrame collectRawObservations(const mrpt::obs::CObservation::ConstPtr & obs);

--- a/module/src/LidarOdometry_InitialLocalization.cpp
+++ b/module/src/LidarOdometry_InitialLocalization.cpp
@@ -199,11 +199,10 @@ void LidarOdometry::handleInitialLocalizationStateEstimation()
   // Check if state estimator has converged
   mrpt::poses::CPose3DPDFGaussian estimatedPose;
 
-  // Snapshot georef state under lock to avoid data race with
-  // onExternalMapUpdate which writes state_.external_georef concurrently.
+  // Note: state_mtx_ is already held by the caller (processLidarScan), which
+  // also serializes us against onExternalMapUpdate (writes
+  // state_.external_georef from another thread under the same mutex).
   {
-    auto lckState = mrpt::lockHelper(state_mtx_);
-
     const bool hasGeoRef =
       state_.local_map->georeferencing.has_value() || state_.external_georef.has_value();
 

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -181,9 +181,13 @@ void LidarOdometry::reset()
 {
   ASSERTMSG_(!lastInitConfig_.empty(), "initialize() must be called first.");
 
-  auto lck = mrpt::lockHelper(state_mtx_);
-
-  state_ = MethodState();
+  // Reset the state under the lock, then re-initialize without holding it:
+  // initialize() (via initialize_frontend()) takes state_mtx_ itself, and
+  // state_mtx_ is a plain (non-recursive) mutex.
+  {
+    auto lck = mrpt::lockHelper(state_mtx_);
+    state_ = MethodState();
+  }
   initialize(lastInitConfig_);
 }
 

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -41,7 +41,11 @@ namespace mola
 bool LidarOdometry::isPipelineUsingIMU() const
 {
   auto lckState = mrpt::lockHelper(state_mtx_);
+  return isPipelineUsingIMU_locked();
+}
 
+bool LidarOdometry::isPipelineUsingIMU_locked() const
+{
   if (state_.isPipelinesUsingIMU.has_value()) {
     return *state_.isPipelinesUsingIMU;
   }
@@ -162,7 +166,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 
   // Use early deskew?
   const bool use_early_deskew =
-    !state_.pc_deskew.empty() && (!params_.optimize_twist || isPipelineUsingIMU());
+    !state_.pc_deskew.empty() && (!params_.optimize_twist || isPipelineUsingIMU_locked());
 
   if (use_early_deskew) {
     ProfilerEntry tle1(profiler_, "onLidar.1.deskew_early");


### PR DESCRIPTION
## Summary
- `state_mtx_` is now a plain `std::mutex` instead of `std::recursive_mutex`.
- `reset()` resets `state_` under the lock, releases it, then calls `initialize()` (which takes `state_mtx_` itself) unlocked, instead of recursively holding the lock across the whole re-initialization.
- `handleInitialLocalizationStateEstimation()` no longer re-locks `state_mtx_`; it is only ever called from `processLidarScan()`, which already holds it (and that's sufficient to serialize against `onExternalMapUpdate`, which writes `state_.external_georef` under the same mutex from another thread).
- `isPipelineUsingIMU()` is split into a locking wrapper and an `isPipelineUsingIMU_locked()` variant; `processLidarScan()` now calls the `_locked` variant since it already holds `state_mtx_`.

## Test plan
- [x] `colcon build --packages-select mola_lidar_odometry`
- [x] `colcon test --packages-select mola_lidar_odometry` (6/6 tests pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced thread safety in state synchronization by refining internal locking mechanisms.
  * Improved handling of concurrent state updates during initialization and localization operations.
  * Eliminated potential conflicts between state access and external map updates.

* **Refactor**
  * Streamlined lock management to reduce overhead across scan processing and state update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->