### PR TITLE
fix: bugs in gravity-alignment from IMU accelerometer

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -99,6 +99,9 @@ class LidarOdometry : public mola::FrontEndBase,
 {
   DEFINE_MRPT_OBJECT(LidarOdometry, mola)
 
+private:
+  constexpr static std::size_t IMU_BUFFER_SIZE = 4096;
+
 public:
   LidarOdometry();
   ~LidarOdometry() override;
@@ -769,7 +772,7 @@ private:
         std::array<double, 3> acc = {0, 0, 0};
       };
 
-      mrpt::containers::circular_buffer<TimestampedAcc> acc_buffer{4096};
+      mrpt::containers::circular_buffer<TimestampedAcc> acc_buffer{IMU_BUFFER_SIZE};
       mrpt::poses::CPose3D imu_sensor_pose;  ///< last known IMU extrinsics
       double imu_sensor_pose_timestamp = 0;  ///< timestamp of last sensor pose update
 

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -784,6 +784,15 @@ private:
 
     GravityEstimator gravity_estimator;
 
+    /// Gravity-derived (pitch, roll), in radians, captured at the time the first
+    /// keyframe (map origin) was created. The IMU gravity estimator reports
+    /// *absolute* tilt with respect to true vertical, while the map/global frame
+    /// may itself not be exactly level (e.g. `fixed_initial_pose` has nonzero
+    /// pitch/roll, or the vehicle was on a slope at start-up). This calibration
+    /// offset is required to correctly re-express later absolute IMU tilt
+    /// readings relative to the (possibly non-level) map frame.
+    std::optional<std::pair<double, double>> gravity_calib_pitch_roll;
+
     mrpt::poses::CPose3DPDFGaussian last_lidar_pose;  //!< in local map
 
     std::map<std::string, mrpt::Clock::time_point> last_obs_tim_by_label;

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -732,7 +732,7 @@ void LidarOdometry::updateVisualizationGravityVector(
   const ProfilerEntry tle2(profiler_, "updateVisualization.update_gravity");
 
   const auto gravityPR = state_.gravity_estimator.estimatedPitchRoll(
-    std::min(params_.imu_gravity_correction.averaging_samples, 3u),
+    params_.imu_gravity_correction.averaging_samples,
     params_.imu_gravity_correction.max_age_seconds);
 
   if (!gravityPR.has_value()) {

--- a/module/src/LidarOdometry_InitialLocalization.cpp
+++ b/module/src/LidarOdometry_InitialLocalization.cpp
@@ -114,6 +114,7 @@ void LidarOdometry::handleInitialLocalization()
         doRemoveCloudsWithDecay();
 
         state_.local_map->clear();
+        state_.gravity_calib_pitch_roll.reset();  // new map origin: recapture at next first KF
         ASSERT_(state_.local_map->empty());
         {
           auto lckSM = mrpt::lockHelper(state_simplemap_mtx_);

--- a/module/src/LidarOdometry_MapServer.cpp
+++ b/module/src/LidarOdometry_MapServer.cpp
@@ -92,6 +92,7 @@ MapServer::ReturnStatus LidarOdometry::map_load_impl(const std::string & path)
 
     ASSERT_(state_.local_map);
     state_.local_map->clear();
+    state_.gravity_calib_pitch_roll.reset();  // new map origin: recapture at next first KF
 
     // Mark for GUI / publishing even if we fail to load (so the map is shown
     // as empty rather than stale):

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -297,10 +297,10 @@ void LidarOdometry::Parameters::IMUGravityCorrection::initialize(const Yaml & cf
 
   if (enabled) {
     ASSERTMSG_(
-      averaging_samples >= 1 && averaging_samples <= 200,
+      averaging_samples >= 1 && averaging_samples < IMU_BUFFER_SIZE,
       mrpt::format(
-        "imu_gravity_correction.averaging_samples=%u is out of valid range [1, 200]",
-        static_cast<unsigned>(averaging_samples)));
+        "imu_gravity_correction.averaging_samples=%u is out of valid range [1, %zu]",
+        static_cast<unsigned>(averaging_samples), IMU_BUFFER_SIZE));
 
     ASSERTMSG_(
       sigma_deg > 0, mrpt::format("imu_gravity_correction.sigma_deg=%.4f must be > 0", sigma_deg));

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -291,6 +291,16 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
         scan_ref_time, params_.initial_localization.fixed_initial_pose);
     }
 
+    // Record, once, the absolute IMU-derived tilt at the map origin (if
+    // available yet). This is the calibration offset needed to later
+    // re-express absolute IMU tilt readings relative to this (possibly
+    // non-level) map frame instead of true vertical:
+    if (params_.imu_gravity_correction.enabled && !state_.gravity_calib_pitch_roll) {
+      state_.gravity_calib_pitch_roll = state_.gravity_estimator.estimatedPitchRoll(
+        params_.imu_gravity_correction.averaging_samples,
+        params_.imu_gravity_correction.max_age_seconds);
+    }
+
     // Define the current robot pose at the origin with minimal uncertainty
     // (cannot be zero).
     mrpt::poses::CPose3DPDFGaussian initPose;
@@ -330,9 +340,10 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
           m.z(0);
           m.setYawPitchRoll(m.yaw(), .0, .0);
 
+          // MRPT cov_inv order: x[0] y[1] z[2] yaw[3] pitch[4] roll[5]
           in.prior->cov_inv(2, 2) = large_certainty;  // dz
-          in.prior->cov_inv(3, 3) = large_certainty;  // rx
-          in.prior->cov_inv(4, 4) = large_certainty;  // ry
+          in.prior->cov_inv(4, 4) = large_certainty;  // pitch
+          in.prior->cov_inv(5, 5) = large_certainty;  // roll
         }
 
         MRPT_LOG_DEBUG_STREAM("ICP prior=" << *in.prior);
@@ -362,11 +373,35 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     // Apply IMU gravity correction to ICP prior (pitch/roll):
     if (params_.imu_gravity_correction.enabled) {
       const auto gravityPR = state_.gravity_estimator.estimatedPitchRoll(
-        std::min(params_.imu_gravity_correction.averaging_samples, 3u),
+        params_.imu_gravity_correction.averaging_samples,
         params_.imu_gravity_correction.max_age_seconds);
 
       if (gravityPR.has_value()) {
         const auto [imu_pitch, imu_roll] = *gravityPR;
+
+        // The gravity estimator reports *absolute* tilt w.r.t. true vertical,
+        // but the map/global frame may not itself be exactly level (e.g. a
+        // nonzero `fixed_initial_pose` orientation, or the vehicle starting
+        // on a slope). Re-express the absolute IMU tilt relative to the map
+        // frame using the tilt recorded at the map origin as a calibration
+        // offset. Both readings share the same (gauge) yaw=0 convention, which
+        // is valid since pitch/roll extracted from gravity alone are
+        // independent of the (unobservable) yaw used to express them.
+        double map_pitch = imu_pitch;
+        double map_roll = imu_roll;
+        if (state_.gravity_calib_pitch_roll.has_value()) {
+          const auto [pitch0, roll0] = *state_.gravity_calib_pitch_roll;
+
+          const mrpt::poses::CPose3D R_map_veh0(
+            mrpt::poses::CPose3D(params_.initial_localization.fixed_initial_pose));
+          const mrpt::poses::CPose3D R_grav_veh0(0, 0, 0, 0, pitch0, roll0);
+          const mrpt::poses::CPose3D R_grav_veh_t(0, 0, 0, 0, imu_pitch, imu_roll);
+
+          const mrpt::poses::CPose3D R_map_veh_t = R_map_veh0 + (-R_grav_veh0) + R_grav_veh_t;
+
+          map_pitch = R_map_veh_t.pitch();
+          map_roll = R_map_veh_t.roll();
+        }
 
         if (!in.prior.has_value()) {
           // Create a prior from current initial guess:
@@ -377,9 +412,9 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 
         // Override pitch & roll in the prior mean:
         const double cur_yaw = in.prior->mean.yaw();
-        in.prior->mean.setYawPitchRoll(cur_yaw, imu_pitch, imu_roll);
+        in.prior->mean.setYawPitchRoll(cur_yaw, map_pitch, map_roll);
 
-        // Increase confidence for roll (idx=3) and pitch (idx=4):
+        // Increase confidence for pitch (idx=4) and roll (idx=5):
         const double sigma_rad = mrpt::DEG2RAD(params_.imu_gravity_correction.sigma_deg);
         const double inv_var = 1.0 / (sigma_rad * sigma_rad);
 
@@ -772,6 +807,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     // Re-start the local map:
     state_.local_map->clear();
     state_.estimated_trajectory.clear();
+    state_.gravity_calib_pitch_roll.reset();  // new map origin: recapture at next first KF
     updateLocalMap = false;
     state_.last_icp_was_good = true;
 

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -471,6 +471,21 @@ void LidarOdometry::MethodState::GravityEstimator::add(
     return;
   }
 
+  // Also reject readings taken while the vehicle is rotating: a quasi-static
+  // |acc|≈g does not guarantee the *direction* of the specific-force vector
+  // is unbiased (e.g. during turns or fast attitude changes), so gate on
+  // angular rate too, if available:
+  if (imu.has(mrpt::obs::IMU_WX) && imu.has(mrpt::obs::IMU_WY) && imu.has(mrpt::obs::IMU_WZ)) {
+    const double wx = imu.get(mrpt::obs::IMU_WX);
+    const double wy = imu.get(mrpt::obs::IMU_WY);
+    const double wz = imu.get(mrpt::obs::IMU_WZ);
+    const double w_norm = std::sqrt(wx * wx + wy * wy + wz * wz);
+    constexpr double max_angular_rate_for_quasi_static = mrpt::DEG2RAD(5.0);
+    if (w_norm > max_angular_rate_for_quasi_static) {
+      return;
+    }
+  }
+
   const double stamp = mrpt::Clock::toDouble(imu.timestamp);
 
   // Trim buffer to the desired averaging window:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved gravity alignment by capturing a pitch/roll calibration at the initial map origin and using it to re-express later IMU gravity tilt relative to the map frame.

* **Bug Fixes**
  * Improved gravity correction reliability by ignoring IMU samples during fast rotation (angular rate threshold).
  * Corrected scan-matching pitch/roll covariance mapping to improve ICP prior stability.

* **Other**
  * Ensured gravity calibration is reset to re-capture when restarting with an empty map, during initialization, or when loading a saved map.
  * Visualization gravity-vector updates now use the configured averaging samples directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->