### PR TITLE
feat: push KFs to central map server

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -24,6 +24,37 @@ thread. This bounds per-scan latency for real-time use. With the default
 `async_backend: false`, `estimated_navstate()` runs the window solve synchronously
 (deterministic, but heavier per call) - see `mola_state_estimation`'s docs.
 
+## SharedKeyframeMap sink (central-map keyframe push, e.g. mola_mapper_3d)
+
+Separately from the dense `navstate_fuse` querying above, `LidarOdometry`
+optionally detects a `mola::SharedKeyframeMap` sink at init
+(`findService<mola::SharedKeyframeMap>()` in `LidarOdometry_Initialize.cpp`,
+guarded by `#if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)` /
+`__has_include(<mola_kernel/interfaces/SharedKeyframeMap.h>)` so this still
+builds against an older `mola_kernel`). Unlike `navstate_fuse`, this is
+OPTIONAL: most systems still write their own local `.simplemap` only and
+never have a sink.
+
+When present, `pushKeyframeToSharedKeyframeMap()`
+(`LidarOdometry_ProcessScan.cpp`) pushes a SPARSE keyframe at the exact same
+`distance_enough_sm` criterion as the self-written simplemap, but
+INDEPENDENTLY of whether `params_.simplemap.generate` is set (the underlying
+distance-checker's `insert()` is now driven by `pushToSharedKeyframeMapNow`
+too, not just `updateSimpleMap` -- this was a real bug, see below). It uses
+`source_frame_id = params_.publish_reference_frame + "_kf"`, a DEDICATED name
+distinct from `publish_reference_frame` (the frame the dense, every-scan
+`fuse_pose()` calls above use): reusing the same name lets the sink's
+anchor-once tie collide with the dense path's tie on the same
+(relocalization-seeded) keyframe, which threw
+`gtsam::IndeterminantLinearSystemException` at startup in real testing
+against KITTI through `mola_mapper_3d`'s
+`mola-cli-launchs/lidar_odometry_mapper3d_from_kitti.yaml`. See that
+package's agents.md ("Real end-to-end validation lessons") for the full list
+of bugs this integration surfaced, several of which were in `mola_mapper_3d`,
+not here -- but two structural changes live in this file:
+`pushKeyframeToSharedKeyframeMap()`'s dedicated frame name, and the
+distance-checker `insert()` gating fix mentioned above.
+
 ## Building
 
 We use colcon, the ROS2 build tool, and mola_common with utility cmake helpers.

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -32,6 +32,10 @@
 #include <mola_kernel/interfaces/MapSourceBase.h>
 #include <mola_kernel/interfaces/NavStateFilter.h>
 #include <mola_kernel/interfaces/Relocalization.h>
+#if __has_include(<mola_kernel/interfaces/SharedKeyframeMap.h>)
+#include <mola_kernel/interfaces/SharedKeyframeMap.h>
+#define MOLA_HAS_SHARED_KEYFRAME_MAP_SINK 1
+#endif
 #include <mola_kernel/version.h>
 
 // Other packages:
@@ -824,6 +828,13 @@ private:
     // navstate_fuse to merge pose estimates, IMU, odom, estimate twist.
     std::shared_ptr<mola::NavStateFilter> navstate_fuse;
 
+#if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)
+    // Central-map backend (e.g. mola_mapper_3d) accepting keyframe-insertion
+    // requests, if any is present in the running MOLA system. Detected the
+    // same way as navstate_fuse, but optional: nullptr if none is found.
+    std::shared_ptr<mola::SharedKeyframeMap> shared_keyframe_map_sink;
+#endif
+
     std::optional<NavState> last_motion_model_output;
 
     /// The source of "dynamic variables" in ICP pipelines:
@@ -1113,6 +1124,16 @@ private:
     const mrpt::obs::CSensoryFrame & sf, bool distance_enough_sm,
     const mp2p_icp::metric_map_t::Ptr & observation, const mrpt::Clock::time_point & scan_ref_time,
     const mrpt::maps::CPointsMap::Ptr & deskewedCloud);
+
+#if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)
+  /// Pushes one keyframe to state_.shared_keyframe_map_sink, using
+  /// state_.last_lidar_pose as the pose in this instance's own odometry frame
+  /// (params_.publish_reference_frame). Only called when a sink is present
+  /// and the keyframe-sparsity criterion (distance_enough_sm) fired, mirroring
+  /// the self-written simplemap's keyframing.
+  void pushKeyframeToSharedKeyframeMap(
+    const mrpt::obs::CSensoryFrame & sf, const mrpt::Clock::time_point & scan_ref_time);
+#endif
 };
 
 namespace detail

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -424,6 +424,19 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
     MRPT_LOG_DEBUG("Attached to the state estimation module");
   }
 
+#if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)
+  // Optional: a central-map backend (e.g. mola_mapper_3d) accepting
+  // keyframe-insertion requests. Unlike navstate_fuse, this is NOT required:
+  // most systems still write their own local .simplemap only.
+  {
+    auto sinks = findService<mola::SharedKeyframeMap>();
+    if (!sinks.empty()) {
+      state_.shared_keyframe_map_sink = std::dynamic_pointer_cast<SharedKeyframeMap>(sinks[0]);
+      MRPT_LOG_DEBUG("Detected a SharedKeyframeMap sink: will push central-map keyframes to it.");
+    }
+  }
+#endif
+
   // If using FromStateEstimator initialization, also subscribe to map updates
   // from the state estimator to receive geo-referencing information:
   if (params_.initial_localization.method == InitLocalization::FromStateEstimator) {

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -248,6 +248,16 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
   bool updateSimpleMap = false;
   bool distance_enough_sm = false;
 
+#if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)
+  // Whether this scan's keyframe will be pushed to a central-map backend
+  // (e.g. mola_mapper_3d), at the same sparsity as the self-written simplemap
+  // but independently of whether params_.simplemap.generate is set:
+  bool pushToSharedKeyframeMapNow = false;
+  // Built inside the lock, invoked after releasing state_mtx_ (see below):
+  std::optional<mola::SharedKeyframeMap::KeyframeInsertRequest> pendingKfReq;
+  std::shared_ptr<mola::SharedKeyframeMap> pendingKfSink;
+#endif
+
   // First time we cannot do ICP since we need at least two pointclouds:
   ASSERT_(state_.local_map);
 
@@ -284,6 +294,9 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     updateLocalMap = true;
     updateSimpleMap = true;     // update SimpleMap too
     distance_enough_sm = true;  // and treat this one as a KeyFrame with SF
+#if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)
+    pushToSharedKeyframeMapNow = static_cast<bool>(state_.shared_keyframe_map_sink);
+#endif
 
     // Update trajectory too:
     {
@@ -309,6 +322,20 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     initPose.cov.setDiagonal(1e-12);
 
     state_.navstate_fuse->fuse_pose(scan_ref_time, initPose, params_.publish_reference_frame);
+
+    // Seed last_lidar_pose and distance_checker_simplemap with the origin so
+    // the next scan's distance check starts from here rather than from "empty"
+    // (an empty checker reports isFirstPoseInSMChecker=true for every pose,
+    // which would spuriously fire a second keyframe on the very next scan):
+    state_.last_lidar_pose = initPose;
+    if (!state_.distance_checker_simplemap) {
+      state_.distance_checker_simplemap.emplace(params_.simplemap.measure_from_last_kf_only);
+    }
+    {
+      mrpt::poses::CPose3D sensorPoseInVehicle;
+      obs->getSensorPose(sensorPoseInVehicle);
+      state_.distance_checker_simplemap->insert(state_.last_lidar_pose.mean + sensorPoseInVehicle);
+    }
   } else {
     // Register point clouds using ICP:
     // ------------------------------------
@@ -799,7 +826,23 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
        );
     // clang-format on
 
-    if (updateSimpleMap && distance_enough_sm) {
+#if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)
+    pushToSharedKeyframeMapNow =
+      static_cast<bool>(state_.shared_keyframe_map_sink) && icpIsGood && distance_enough_sm;
+#endif
+
+    if (
+      (updateSimpleMap
+#if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)
+       || pushToSharedKeyframeMapNow
+#endif
+       ) &&
+      distance_enough_sm) {
+      // Advance the keyframe-sparsity reference point even when
+      // simplemap.generate is disabled, as long as something (the sink)
+      // still needs the distance_enough_sm criterion to actually behave as
+      // "sparse" instead of always firing (an empty checker reports every
+      // pose as "far enough"):
       state_.distance_checker_simplemap->insert(lidarPoseInWorld);
     }
 
@@ -887,6 +930,21 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       sf, distance_enough_sm, observation, scan_ref_time, fullCloudForVizAndPublish);
   }
 
+#if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)
+  // Build the keyframe request while holding state_mtx_; the actual sink call
+  // is deferred to after all state accesses so state_mtx_ can be released first:
+  if (pushToSharedKeyframeMapNow) {
+    mola::SharedKeyframeMap::KeyframeInsertRequest req;
+    req.timestamp = scan_ref_time;
+    req.source_frame_id = params_.publish_reference_frame + "_kf";
+    req.pose_in_source = state_.last_lidar_pose;
+    req.observations = sf;
+    req.quality = std::clamp(state_.last_icp_quality, 0.0, 1.0);
+    pendingKfReq = std::move(req);
+    pendingKfSink = state_.shared_keyframe_map_sink;
+  }
+#endif
+
   // In any case, publish the vehicle pose, no matter if it's a keyframe or not,
   // if ICP quality was good enough:
   if (state_.last_icp_was_good) {
@@ -937,6 +995,25 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       updateVisualizationAlways();
     }
   }
+
+#if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)
+  // All state_ accesses are done; release state_mtx_ before invoking the sink
+  // so it no longer blocks other state-mutex users during IPC/slow operations:
+  if (pendingKfReq) {
+    lckState.unlock();
+    try {
+      pendingKfSink->requestInsertKeyframe(*pendingKfReq);
+    } catch (const std::exception & e) {
+      MRPT_LOG_WARN_STREAM(
+        "pushKeyframeToSharedKeyframeMap failed at t="
+        << mrpt::system::dateTimeToString(pendingKfReq->timestamp) << ": " << e.what());
+    } catch (...) {
+      MRPT_LOG_WARN_STREAM(
+        "pushKeyframeToSharedKeyframeMap failed at t="
+        << mrpt::system::dateTimeToString(pendingKfReq->timestamp) << " (unknown exception)");
+    }
+  }
+#endif
 }
 
 mp2p_icp::metric_map_t::Ptr LidarOdometry::observationFromRawSensor(
@@ -1215,5 +1292,30 @@ void LidarOdometry::doUpdateSimpleMap(
   constexpr size_t MAX_SIZE_UNLOAD_QUEUE = 100;
   unloadPastSimplemapObservations(MAX_SIZE_UNLOAD_QUEUE);
 }
+
+#if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)
+void LidarOdometry::pushKeyframeToSharedKeyframeMap(
+  const mrpt::obs::CSensoryFrame & sf, const mrpt::Clock::time_point & scan_ref_time)
+{
+  mola::SharedKeyframeMap::KeyframeInsertRequest req;
+  req.timestamp = scan_ref_time;
+  // A DEDICATED source_frame_id, distinct from params_.publish_reference_frame:
+  // that one is shared by the dense, every-good-ICP-scan fuse_pose() calls
+  // above (for short-term prediction), which tie every such scan absolutely
+  // to F(publish_reference_frame). Reusing the same frame here would let the
+  // sink's anchor-once tie collide with that dense, already-present tie on
+  // the very same (relocalization-seeded) first keyframe, which produced a
+  // gtsam::IndeterminantLinearSystemException at startup in practice.
+  req.source_frame_id = params_.publish_reference_frame + "_kf";
+  // state_.last_lidar_pose is this instance's own odometry estimate (in its
+  // own, possibly drift-prone frame), exactly as written to the self-built
+  // simplemap above: the sink chains it via *relative* motion, not absolute.
+  req.pose_in_source = state_.last_lidar_pose;
+  req.observations = sf;
+  req.quality = std::clamp(state_.last_icp_quality, 0.0, 1.0);
+
+  state_.shared_keyframe_map_sink->requestInsertKeyframe(req);
+}
+#endif
 
 }  // namespace mola


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When available, lidar odometry can push sparse keyframes to a shared central-map backend.
  * Keyframes are published under a dedicated `*_kf` source frame name to avoid collisions with the normal pose flow.

* **Bug Fixes**
  * Shared keyframe insertion now follows the same distance/sparsity rules as local mapping, including early/disabled mapping scenarios.
  * Improved keyframe integration to resolve validation failures from prior shared-backend mismatches.

* **Documentation**
  * Added guidance on the shared keyframe map sink behavior and insertion semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->