### PR TITLE
feat: frame-aware decay clouds and camera look-at for mapper_3d

### DIFF
--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -424,8 +424,15 @@ void LidarOdometry::updateVisualization(
   // ---------------------------
   if (params_.visualization.camera_follows_vehicle) {
     const auto t = state_.last_lidar_pose.mean.translation();
+#if defined(MOLA_KERNEL_VIZ_HAS_MOVABLE_FRAMES)
+    const std::string lookAtFrame = vizParentFrame();
+    updateTasks.emplace_back([visualizer = visualizer_, t, lookAtFrame]() {
+      visualizer->update_viewport_look_at(t, "main", "main", lookAtFrame);
+    });
+#else
     updateTasks.emplace_back(
       [visualizer = visualizer_, t]() { visualizer->update_viewport_look_at(t); });
+#endif
   }
 
   if (params_.visualization.camera_rotates_with_vehicle) {
@@ -659,7 +666,11 @@ void LidarOdometry::updateVisualizationCurrentObservation(
         cloud->setPose(currentPose);
         doRecolorize(decayColormap, decayColorField, deskewed.get(), cloud);
 
+#if defined(MOLA_KERNEL_VIZ_HAS_MOVABLE_FRAMES)
+        viz->insert_point_cloud_with_decay(cloud, decaySeconds, "main", "main", vizFrame);
+#else
         viz->insert_point_cloud_with_decay(cloud, decaySeconds);
+#endif
       }
     } else if (!showDecay) {
       viz->clear_all_point_clouds_with_decay();


### PR DESCRIPTION
## Summary

- `insert_point_cloud_with_decay()`: deskewed/decaying scan clouds now pass `vizParentFrame()` as `parentFrame`, making them children of the movable `{odom_lidar}` frame node. They move with the frame when `mola_mapper_3d` adjusts it after geo-ref convergence or loop closure.
- `update_viewport_look_at()`: when `camera_follows_vehicle` is enabled, the look-at target is now expressed in the frame node's local space. The backend (updated in MOLAorg/mola#162) composes the frame's current world pose before moving the camera, so the view tracks the vehicle in map space rather than in raw odometry space.
- Both call sites are guarded by `#if defined(MOLA_KERNEL_VIZ_HAS_MOVABLE_FRAMES)` so the package still builds against an older `mola_kernel`.

## Depends on

MOLAorg/mola#162 (extends `VizInterface` with `parentFrame` on both APIs).

## Test plan

- [ ] Build against updated `mola` — green locally on Jazzy.
- [ ] Run `mola-cli` with LIO + `mola_mapper_3d` on MulRan DCC01; confirm deskewed clouds and camera follow position stay aligned with the local map after geo-ref convergence.
- [ ] Confirm standalone LIO (no `mola_mapper_3d`, frame at identity) is visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visualization behavior for lidar odometry when the camera follows the vehicle.
  * Fixed point cloud rendering so decaying deskewed clouds display correctly across both newer and older visualization modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->