### PR TITLE
feat: expose approximate_cov env var in GICP pipeline

### DIFF
--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -313,6 +313,12 @@ localmap_generator:
           max_view_angle_deg: ${MOLA_LOCALMAP_VIEW_DIRECTION_FILTER_ANGLE_DEG|120}
           rotation_distance_weight: 2.0
           num_diverse_keyframes: ${MOLA_LOCALMAP_DIVERSE_KEYFRAMES|1} # Must be < max_search_keyframes
+          # If true, cov-to-cov ICP matching (Matcher_Cov2Cov) queries each active
+          # keyframe's own cached KD-tree + covariances directly, instead of building
+          # a merged submap from the active KF set. Faster (skips the merge/KD-tree
+          # rebuild) at the cost of a slightly less accurate covariance estimate
+          # (computed only from neighbors within the same source keyframe).
+          approximate_cov: ${MOLA_LOCALMAP_APPROXIMATE_COV|false}
         insertOpts:
           remove_frames_farther_than: "${MOLA_LOCAL_MAP_MAX_SIZE|$f{max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}}" # [m]
         likelihoodOpts: ~ # none required


### PR DESCRIPTION
## Summary
- Exposes `mola::KeyframePointCloudMap::TCreationOptions::approximate_cov` (see [MOLAorg/mola#169](https://github.com/MOLAorg/mola/pull/169)) in `pipelines/lidar3d-gicp.yaml` as env var `MOLA_LOCALMAP_APPROXIMATE_COV`, defaulting to `false` (no behavior change by default).
- When set to `true`, the local map's cov-to-cov ICP matching (`Matcher_Cov2Cov`) queries each active keyframe's own cached KD-tree + covariances directly instead of merging the active keyframe set into one submap, trading a bit of covariance exactness for less per-scan setup cost.

Depends on [MOLAorg/mola#169](https://github.com/MOLAorg/mola/pull/169).

## Test plan
- [x] YAML is well-formed (mirrors the existing `use_view_direction_filter` env-var pattern in the same file).
- [ ] Manual smoke run of `lidar3d-gicp.yaml` with `MOLA_LOCALMAP_APPROXIMATE_COV=true` against a dataset once mola#169 is merged into the workspace build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vMS2X5d6Xu3Zo8NCQbCdN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “approximate covariance” mode for local map matching.
  * When enabled, matching can use cached keyframe data directly for faster processing instead of building a combined submap.
  * Added a fallback setting so the feature can be turned on or off through configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->