### PR TITLE
feat: stream ICP time/goodness to mola_viz_imgui plot windows

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -1006,6 +1006,15 @@ private:
   const MethodState & state() const { return state_; }
   MethodState stateCopy() const { return state_; }
 
+#ifdef MOLA_KERNEL_VIZ_HAS_METRICS
+  /** Metric plot channels (mola_viz_imgui "Plots" menu); lazily registered
+   *  from the first onLidarImpl() call, once visualizer_ is available.
+   *  Guarded by the feature macro so this module still builds against an
+   *  older mola_kernel that predates register_metric()/push_metric(). */
+  MetricChannel::Ptr metric_icp_time_ms_;
+  MetricChannel::Ptr metric_icp_goodness_;
+#endif
+
   // Accessing this struct in gui_ requires acquiring state_gui_mtx_
   struct StateUI
   {

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -478,6 +478,9 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     // Run ICP
     // -----------------------------------------------------
     ProfilerEntry tle_icp(profiler_, "onLidar.3.run_icp");
+#ifdef MOLA_KERNEL_VIZ_HAS_METRICS
+    const double icp_t0 = mrpt::Clock::nowDouble();
+#endif
 
     mrpt::math::TPose3D current_solution = in.init_guess_local_wrt_global;
     size_t twistCorrectionCount = 0;
@@ -607,6 +610,22 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     out.found_pose_to_wrt_from = icp_result.optimal_tf;
     out.goodness = icp_result.quality;
     out.icp_iterations = icp_result.nIterations;
+
+#ifdef MOLA_KERNEL_VIZ_HAS_METRICS
+    // Stream ICP metrics to the visualizer's live plot windows, if any
+    // (mola_viz_imgui "Plots" menu; no-op on the nanogui backend / when
+    // nobody is plotting). Registered lazily since visualizer_ may not be
+    // available on the very first calls. Guarded by the feature macro so
+    // this module still builds against an older mola_kernel.
+    if (visualizer_) {
+      if (!metric_icp_time_ms_) {
+        metric_icp_time_ms_ = visualizer_->register_metric("lidar_odom/icp_time_ms", "ms");
+        metric_icp_goodness_ = visualizer_->register_metric("lidar_odom/icp_goodness", "%");
+      }
+      metric_icp_time_ms_->push(1000.0 * (mrpt::Clock::nowDouble() - icp_t0));
+      metric_icp_goodness_->push(100.0 * out.goodness);
+    }
+#endif
 
     MRPT_LOG_DEBUG_FMT(
       "ICP (kind=%u): goodness=%.02f%% iters=%u pose=%s "


### PR DESCRIPTION
## Summary
- Registers `lidar_odom/icp_time_ms` and `lidar_odom/icp_goodness` metric channels via `VizInterface::register_metric()` and pushes a sample per scan from `LidarOdometry::processLidarScan()`.
- Shows up in the new "Plots" menu of the `mola_viz_imgui` backend (see companion PR https://github.com/MOLAorg/mola/pull/172).
- Guarded by `MOLA_KERNEL_VIZ_HAS_METRICS` so this module still builds against an older `mola_kernel` that predates the metrics API.

## Test plan
- [x] `colcon build --packages-select mola_lidar_odometry` — clean
- [x] Ran `mola-cli` against a real MulRan sequence for 1+ minute (ICP pushing metrics every scan) — no crash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional live ICP performance metrics to the lidar odometry visualizer, including processing time and match quality.
  * Metrics are registered automatically when the visualizer is available and displayed during scan processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->