### PR TITLE
Carry per-keyframe velocity metadata in shared-keyframe push

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -1172,6 +1172,14 @@ private:
     const mp2p_icp::metric_map_t::Ptr & observation, const mrpt::Clock::time_point & scan_ref_time,
     const mrpt::maps::CPointsMap::Ptr & deskewedCloud);
 
+  /** Appends a "metadata" CObservationComment (frame bbox + the local velocity
+   *  buffer needed for precise later deskew) to a keyframe's sensory frame.
+   *  Shared by the self-built simplemap and the shared-keyframe-map push so both
+   *  carry the same per-keyframe velocity window. */
+  void appendKeyframeMetadataObs(
+    mrpt::obs::CSensoryFrame & keyframe_obs, const mrpt::Clock::time_point & scan_ref_time,
+    const mp2p_icp::metric_map_t & observation);
+
 #if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)
   /// Pushes one keyframe to state_.shared_keyframe_map_sink, using
   /// state_.last_lidar_pose as the pose in this instance's own odometry frame

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -1179,16 +1179,6 @@ private:
   void appendKeyframeMetadataObs(
     mrpt::obs::CSensoryFrame & keyframe_obs, const mrpt::Clock::time_point & scan_ref_time,
     const mp2p_icp::metric_map_t & observation);
-
-#if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)
-  /// Pushes one keyframe to state_.shared_keyframe_map_sink, using
-  /// state_.last_lidar_pose as the pose in this instance's own odometry frame
-  /// (params_.publish_reference_frame). Only called when a sink is present
-  /// and the keyframe-sparsity criterion (distance_enough_sm) fired, mirroring
-  /// the self-written simplemap's keyframing.
-  void pushKeyframeToSharedKeyframeMap(
-    const mrpt::obs::CSensoryFrame & sf, const mrpt::Clock::time_point & scan_ref_time);
-#endif
 };
 
 namespace detail

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -957,7 +957,11 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     req.timestamp = scan_ref_time;
     req.source_frame_id = params_.publish_reference_frame + "_kf";
     req.pose_in_source = state_.last_lidar_pose;
+    // Enrich the shared keyframe with the same "metadata" comment (bbox + the
+    // local velocity buffer) the self-built simplemap carries, so downstream
+    // consumers can deskew the raw scan with the per-keyframe velocity window:
     req.observations = sf;
+    appendKeyframeMetadataObs(req.observations, scan_ref_time, *observation);
     req.quality = std::clamp(state_.last_icp_quality, 0.0, 1.0);
     pendingKfReq = std::move(req);
     pendingKfSink = state_.shared_keyframe_map_sink;
@@ -1198,6 +1202,42 @@ mrpt::obs::CSensoryFrame LidarOdometry::collectRawObservations(
   return sf;
 }
 
+void LidarOdometry::appendKeyframeMetadataObs(
+  mrpt::obs::CSensoryFrame & keyframe_obs, const mrpt::Clock::time_point & scan_ref_time,
+  const mp2p_icp::metric_map_t & observation)
+{
+  using namespace std::string_literals;
+
+  auto metadataObs = mrpt::obs::CObservationComment::Create();
+  metadataObs->timestamp = scan_ref_time;
+  metadataObs->sensorLabel = "metadata";
+
+  mrpt::containers::yaml kf_metadata = mrpt::containers::yaml::Map();
+  std::optional<mrpt::math::TBoundingBoxf> bbox;
+  for (const auto & [layerName, layerMap] : observation.layers) {
+    if (bbox) {
+      bbox = bbox->unionWith(layerMap->boundingBox());
+    } else {
+      bbox = layerMap->boundingBox();
+    }
+  }
+  if (bbox) {
+    kf_metadata["frame_bbox_min"] = "'"s + bbox->min.asString() + "'"s;
+    kf_metadata["frame_bbox_max"] = "'"s + bbox->max.asString() + "'"s;
+  }
+
+  // Store local velocity buffer in the KF metadata so it is possible to deskew
+  // the scan later on with precision.
+  kf_metadata["local_velocity_buffer"] = state_.parameter_source.localVelocityBuffer.toYAML();
+
+  // convert yaml to string:
+  std::stringstream ss;
+  ss << kf_metadata;
+  metadataObs->text = ss.str();
+
+  keyframe_obs.insert(metadataObs);
+}
+
 void LidarOdometry::doUpdateSimpleMap(
   const mrpt::obs::CSensoryFrame & sf, const bool distance_enough_sm,
   const mp2p_icp::metric_map_t::Ptr & observation, const mrpt::Clock::time_point & scan_ref_time,
@@ -1253,35 +1293,8 @@ void LidarOdometry::doUpdateSimpleMap(
     ASSERT_(params_.simplemap.add_non_keyframes_too);
   }
 
-  // Add metadata ("comment") observation:
-  auto metadataObs = mrpt::obs::CObservationComment::Create();
-  metadataObs->timestamp = scan_ref_time;
-  metadataObs->sensorLabel = "metadata";
-
-  mrpt::containers::yaml kf_metadata = mrpt::containers::yaml::Map();
-  std::optional<mrpt::math::TBoundingBoxf> bbox;
-  for (const auto & [layerName, layerMap] : observation->layers) {
-    if (bbox) {
-      bbox = bbox->unionWith(layerMap->boundingBox());
-    } else {
-      bbox = layerMap->boundingBox();
-    }
-  }
-  if (bbox) {
-    kf_metadata["frame_bbox_min"] = "'"s + bbox->min.asString() + "'"s;
-    kf_metadata["frame_bbox_max"] = "'"s + bbox->max.asString() + "'"s;
-  }
-
-  // Store local velocity buffer in the KF metadata so it is possible to deskew the scan later on with precision
-  kf_metadata["local_velocity_buffer"] = state_.parameter_source.localVelocityBuffer.toYAML();
-
-  // convert yaml to string:
-  std::stringstream ss;
-  ss << kf_metadata;
-  metadataObs->text = ss.str();
-
-  // insert it:
-  *keyframe_obs += metadataObs;
+  // Add metadata ("comment") observation with bbox + velocity buffer:
+  appendKeyframeMetadataObs(*keyframe_obs, scan_ref_time, *observation);
 
   // Add keyframe to simple map:
   MRPT_LOG_DEBUG_STREAM("New SimpleMap KeyFrame. SF=" << keyframe_obs->size() << " observations.");

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -955,7 +955,17 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
   if (pushToSharedKeyframeMapNow) {
     mola::SharedKeyframeMap::KeyframeInsertRequest req;
     req.timestamp = scan_ref_time;
+    // A DEDICATED source_frame_id, distinct from params_.publish_reference_frame:
+    // that one is shared by the dense, every-good-ICP-scan fuse_pose() calls (for
+    // short-term prediction), which tie every such scan absolutely to
+    // F(publish_reference_frame). Reusing the same frame here would let the sink's
+    // anchor-once tie collide with that dense, already-present tie on the very
+    // same (relocalization-seeded) first keyframe, which produced a
+    // gtsam::IndeterminantLinearSystemException at startup in practice.
     req.source_frame_id = params_.publish_reference_frame + "_kf";
+    // state_.last_lidar_pose is this instance's own odometry estimate (in its
+    // own, possibly drift-prone frame), exactly as written to the self-built
+    // simplemap: the sink chains it via *relative* motion, not absolute.
     req.pose_in_source = state_.last_lidar_pose;
     // Enrich the shared keyframe with the same "metadata" comment (bbox + the
     // local velocity buffer) the self-built simplemap carries, so downstream
@@ -1028,11 +1038,11 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       pendingKfSink->requestInsertKeyframe(*pendingKfReq);
     } catch (const std::exception & e) {
       MRPT_LOG_WARN_STREAM(
-        "pushKeyframeToSharedKeyframeMap failed at t="
+        "shared keyframe map push failed at t="
         << mrpt::system::dateTimeToString(pendingKfReq->timestamp) << ": " << e.what());
     } catch (...) {
       MRPT_LOG_WARN_STREAM(
-        "pushKeyframeToSharedKeyframeMap failed at t="
+        "shared keyframe map push failed at t="
         << mrpt::system::dateTimeToString(pendingKfReq->timestamp) << " (unknown exception)");
     }
   }
@@ -1324,30 +1334,5 @@ void LidarOdometry::doUpdateSimpleMap(
   constexpr size_t MAX_SIZE_UNLOAD_QUEUE = 100;
   unloadPastSimplemapObservations(MAX_SIZE_UNLOAD_QUEUE);
 }
-
-#if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)
-void LidarOdometry::pushKeyframeToSharedKeyframeMap(
-  const mrpt::obs::CSensoryFrame & sf, const mrpt::Clock::time_point & scan_ref_time)
-{
-  mola::SharedKeyframeMap::KeyframeInsertRequest req;
-  req.timestamp = scan_ref_time;
-  // A DEDICATED source_frame_id, distinct from params_.publish_reference_frame:
-  // that one is shared by the dense, every-good-ICP-scan fuse_pose() calls
-  // above (for short-term prediction), which tie every such scan absolutely
-  // to F(publish_reference_frame). Reusing the same frame here would let the
-  // sink's anchor-once tie collide with that dense, already-present tie on
-  // the very same (relocalization-seeded) first keyframe, which produced a
-  // gtsam::IndeterminantLinearSystemException at startup in practice.
-  req.source_frame_id = params_.publish_reference_frame + "_kf";
-  // state_.last_lidar_pose is this instance's own odometry estimate (in its
-  // own, possibly drift-prone frame), exactly as written to the self-built
-  // simplemap above: the sink chains it via *relative* motion, not absolute.
-  req.pose_in_source = state_.last_lidar_pose;
-  req.observations = sf;
-  req.quality = std::clamp(state_.last_icp_quality, 0.0, 1.0);
-
-  state_.shared_keyframe_map_sink->requestInsertKeyframe(req);
-}
-#endif
 
 }  // namespace mola


### PR DESCRIPTION
## Summary

The self-built simplemap keyframes already include a `metadata` comment observation (frame bbox + the `local_velocity_buffer`) needed to **deskew the raw scan with precision**. The `SharedKeyframeMap` push, however, sent only the bare raw scan (`req.observations = sf`), so downstream consumers, e.g. the mapper's loop-closure thread, had no per-keyframe velocity window for deskew.

## Change

- Factor the metadata-comment builder out of `doUpdateSimpleMap()` into a shared `appendKeyframeMetadataObs()` helper.
- Call it at the shared-keyframe push site so both paths emit identical enriched keyframes (raw scan + velocity-buffer comment).

Behavior-preserving for the self-built simplemap; additive for the shared-keyframe push.

## Notes

Per-point timestamps remain sensor-dependent (e.g. KITTI has none); the velocity comment enables precise deskew wherever timestamps exist, and a deskew-free LC pipeline covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyframes now include additional per-scan metadata (frame bounds and motion/velocity context) to support more accurate later deskewing.
  * Both the local mapping and shared-keyframe mapping paths now store this metadata consistently, improving uniformity in saved outputs.
* **Bug Fixes**
  * Centralized keyframe metadata attachment to reduce duplication and ensure the same information is applied across insertion paths.
* **Chores**
  * Refined shared keyframe insertion failure logging for clearer messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->