### PR TITLE
debug: env-gated ICP quality / adaptive-threshold trace

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -85,6 +85,31 @@ over multiple frames. Two consequences for pipeline tuning:
 See `mola-cli-launchs/lidar_odometry_from_botanicgarden_livox.yaml` for a
 complete example with all three env vars set.
 
+## Environment Variables (Debug/Tracing Flags)
+
+Debug/tracing flags in C++ code use `mrpt::get_env<T>(name, default)` (from
+`<mrpt/core/get_env.h>`), never plain `::getenv`/`std::getenv`. (The
+`MOLA_MIN_NEARBY_POSES_OCCUPIED`-style vars above are a different mechanism:
+they are resolved by `mola_yaml`'s `${VAR|default}` expansion inside the
+pipeline YAML, not read directly in C++.)
+
+| Variable | Type | Default | Location | Purpose |
+|----------|------|---------|----------|---------|
+| `MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP` | double | 0 | `module/src/LidarOdometry_ProcessScan.cpp` | Start of a timestamp range for forcing ICP debug-log dumps (paired with `..._TO_TIMESTAMP`) |
+| `MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP` | double | 0 | `module/src/LidarOdometry_ProcessScan.cpp` | End of the timestamp range above |
+| `MOLA_LO_DEBUG_ICP_QUALITY` | bool | false | `module/src/LidarOdometry_ProcessScan.cpp` | Trace ICP quality metrics per scan |
+| `LO_PIPELINE_YAML` | string | (unset) | `test/test_lidar_odometry_rawlog.cpp`, `test/test_lidar_odometry_rosbag2.cpp` | Path to the LO pipeline YAML used by the test |
+| `LO_STATE_ESTIM_YAML` | string | (unset) | same tests | Path to the state-estimator YAML used by the test |
+| `LO_TEST_RAWLOG` | string | (unset) | `test/test_lidar_odometry_rawlog.cpp` | Path to the input rawlog dataset |
+| `LO_TEST_ROSBAG2` | string | (unset) | `test/test_lidar_odometry_rosbag2.cpp` | Path to the input rosbag2 dataset |
+| `LO_TEST_LIDAR_TOPIC` | string | (unset) | `test/test_lidar_odometry_rosbag2.cpp` | LiDAR topic name to read from the rosbag2 |
+| `LO_TEST_GT_TUM` | string | (unset) | both tests above | Path to the ground-truth trajectory (TUM format) |
+
+Plain `getenv()` calls remain only in `module/src/libcfgpath/cfgpath.h`
+(vendored third-party code resolving standard XDG base directories:
+`XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_CACHE_HOME`, `HOME`) — these are OS
+path-resolution lookups, not app debug flags, and are left untouched.
+
 ## Building
 
 We use colcon, the ROS2 build tool, and mola_common with utility cmake helpers.

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -698,6 +698,20 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 
     }  // end adaptive threshold
 
+    {
+      thread_local auto MOLA_LO_DEBUG_ICP_QUALITY =
+        mrpt::get_env<bool>("MOLA_LO_DEBUG_ICP_QUALITY", false);
+      if (MOLA_LO_DEBUG_ICP_QUALITY) {
+        printf(
+          "[LidarOdometry] pathStep=%zu timestamp=%s goodness=%.3f minRequired=%.3f "
+          "iters=%u termReason=%s isGood=%d adapt_thres_sigma=%.4f consecutive_bad=%d\n",
+          state_.estimated_trajectory.size(), mrpt::system::dateTimeToString(this_obs_tim).c_str(),
+          out.goodness, params_.min_icp_goodness, out.icp_iterations,
+          mrpt::typemeta::enum2str(icp_result.terminationReason).c_str(), icpIsGood ? 1 : 0,
+          state_.adapt_thres_sigma, state_.consecutive_bad_icps);
+      }
+    }
+
     // Sustained-failure recovery for the adaptive threshold (opt-in).
     // The rule above never updates sigma on a bad ICP, which is correct
     // for isolated failures but creates a deadlock under sustained failure: with


### PR DESCRIPTION
## Summary
- Adds `MOLA_LO_DEBUG_ICP_QUALITY` (off by default): prints per-scan `pathStep`, `goodness`, ICP termination reason, and the adaptive-threshold `sigma`/consecutive-bad-ICP counter.
- Used this to diagnose a permanent tracking-loss deadlock on a real localization run: the adaptive threshold collapses to its floor during a long smooth stretch, then a single hard ICP failure (triggered by the nearest-keyframe selection bug fixed in MOLAorg/mola#174) can never recover because `recover_on_sustained_failure` defaults to off.

## Test plan
- [x] Confirmed the trace correctly surfaces the exact moment `adapt_thres_sigma` pins at its floor and stays there through a `NoPairings` failure and beyond, with no functional/behavioral change when the env var is unset (default path unaffected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added optional debug output for scan processing (when a debug environment setting is enabled), displaying key ICP quality and adaptive-threshold recovery metrics to help troubleshoot per-scan behavior.
  * Updated internal documentation with a new section describing available environment variables and debug/tracing flag conventions, including how defaults are resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->