### PR TITLE
Wire MOLA_IMU_USE_BAG_RECV_TIME env var for IMU bag-recv-time timestamp override

### DIFF
--- a/mola-cli-launchs/lidar_odometry_from_rosbag2.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_rosbag2.yaml
@@ -104,6 +104,13 @@ modules:
           # If present, this will override whatever /tf tells about the sensor pose:
           fixed_sensor_pose: "${IMU_POSE_X|0} ${IMU_POSE_Y|0} ${IMU_POSE_Z|0} ${IMU_POSE_YAW|0} ${IMU_POSE_PITCH|0} ${IMU_POSE_ROLL|0}" # 'x y z yaw_deg pitch_deg roll_deg''
           use_fixed_sensor_pose: ${MOLA_USE_FIXED_IMU_POSE|false}
+          # If true, use the bag's own recv/storage time for this sensor's
+          # observations instead of the ROS message header stamp. Workaround
+          # for drivers that stamp with a monotonic/uptime clock instead of
+          # wall-clock epoch time (seen with some IMU drivers), which
+          # otherwise trips the "mis-timestamped sensors" time reference
+          # reset. Default false.
+          use_bag_recv_time_as_timestamp: ${MOLA_IMU_USE_BAG_RECV_TIME|false}
 
         # 2D wheel odometry (disabled by default)
         - topic: ${MOLA_ODOMETRY_TOPIC|''}


### PR DESCRIPTION
## Summary
- Exposes `mola_input_rosbag2`'s new opt-in `use_bag_recv_time_as_timestamp` flag on the IMU sensor entry in `lidar_odometry_from_rosbag2.yaml`, via a new `MOLA_IMU_USE_BAG_RECV_TIME` env var (default `false`).
- Depends on MOLAorg/mola#175.
- Motivation: some IMU drivers stamp messages with a monotonic/uptime clock instead of wall-clock epoch time, desyncing them from correctly-stamped LiDAR data and repeatedly tripping the "mis-timestamped sensors" time-reference reset.

## Test plan
- [x] Verified end-to-end on a real-world rosbag2 (IMU driver stamped with uptime clock): setting `MOLA_IMU_USE_BAG_RECV_TIME=true` eliminates the "mis-timestamped sensors" warnings and the resulting LiDAR-worker-thread starvation.
- [ ] CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional IMU timestamp setting for ROS bag-based lidar odometry workflows.
  * Users can now choose whether IMU data uses the bag reception time or the message header timestamp, with the default behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->