### PR TITLE
fix: preserve x/y/z/yaw prior in InitLocalization::PitchAndRollFromIMU

### DIFF
--- a/module/src/LidarOdometry_InitialLocalization.cpp
+++ b/module/src/LidarOdometry_InitialLocalization.cpp
@@ -99,9 +99,9 @@ void LidarOdometry::handleInitialLocalization()
 
         MRPT_LOG_INFO_STREAM("IMU automatic calibration done: " << imu_calib_opt->asString());
 
-        // Set as the initial pose:
-        il.fixed_initial_pose =
-          mrpt::math::TPose3D(0, 0, 0, 0, imu_calib_opt->pitch, imu_calib_opt->roll);
+        // Overwrite pitch & roll from the IMU, keeping the configured x/y/z/yaw prior:
+        il.fixed_initial_pose.pitch = imu_calib_opt->pitch;
+        il.fixed_initial_pose.roll = imu_calib_opt->roll;
 
         MRPT_LOG_INFO_STREAM(
           "Initial re-localization done from IMU pitch/roll with pose: "


### PR DESCRIPTION
## Summary
- `InitLocalization::PitchAndRollFromIMU` previously overwrote `fixed_initial_pose` entirely with `(0,0,0,0,pitch,roll)`, silently discarding any configured x/y/z/yaw prior.
- Now it only overwrites pitch and roll, leaving x/y/z/yaw as set from config (or a prior `FixedPose`/relocalization step).
- This makes IMU-based leveling usable for any robot with a nonzero initial pose (e.g. non-anchor robots in a multi-robot mapping setup), not just one starting at the origin.

## Test plan
- [x] Rebuilt `mola_lidar_odometry` and re-ran a 3-robot multi-robot LIO mapping pipeline (one robot at the map origin, two with nonzero x/y/z/yaw priors) with `use_imu_initial_leveling` enabled for all three; confirmed each robot's IMU-derived pitch/roll calibration completes without discarding the configured position/yaw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the configured initial position and heading during IMU-based localization setup, while still applying pitch and roll from calibration.
  - Prevented the initial pose from being unintentionally reset to zero values when initializing from sensor data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->