### PR TITLE
fix: drop stale LiDAR scans and keep the freshest under overload

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -55,6 +55,28 @@ not here -- but two structural changes live in this file:
 `pushKeyframeToSharedKeyframeMap()`'s dedicated frame name, and the
 distance-checker `insert()` gating fix mentioned above.
 
+## Scan enqueue & overload handling (drop stale, keep freshest)
+
+Incoming LiDAR scans reach a single worker thread (`worker_lidar_`) via
+`onNewObservation` -> `sendLidarScanToProcessQueue`
+(`LidarOdometry_SensorCallbacks.cpp`). Two routes:
+
+- **LO (no IMU de-skew):** the scan is ready immediately and goes straight to
+  `submitReadyLidarScanToWorker()`.
+- **LIO (IMU de-skew):** the scan is parked on `worker_lidar_wait_for_imu_list_`
+  until IMU data covering its whole time span has arrived; `onIMUImpl` then
+  submits the now-ready scans via the same `submitReadyLidarScanToWorker()`.
+
+`submitReadyLidarScanToWorker()` implements a **"drop stale, keep freshest"**
+policy against a single pending slot (`worker_lidar_pending_fresh_scan_`): if the
+worker is idle the scan is dispatched at once; if it is busy the scan replaces
+(drops) any older scan waiting in the slot. `onLidar` processes its scan and then
+drains the slot in a loop, so under overload the worker always advances to the
+*newest* available scan instead of grinding through a deep FIFO backlog. This
+keeps end-to-end latency near a single processing period (so the state-estimator
+prediction is queried only a little into the future) for both LO and LIO.
+`params_.max_lidar_queue_before_drop` now only bounds the IMU wait list.
+
 ## Non-repetitive (solid-state) LiDARs (e.g. Livox AVIA)
 
 Spinning LiDARs (Velodyne, Ouster, ...) cover their full FOV every rotation, so

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -586,6 +586,13 @@ public:
 
     bool start_active = true;
 
+    /** Under overload, incoming scans are processed with a "drop stale, keep
+     *  freshest" policy: the single worker thread always advances to the newest
+     *  ready scan, dropping older ones, so latency stays near one processing
+     *  period regardless of this value. This parameter only bounds the auxiliary
+     *  wait list used while a scan waits for its IMU data (IMU de-skew pipelines):
+     *  if IMU delivery lags, no more than this many scans are kept waiting before
+     *  the oldest are dropped. */
     uint32_t max_lidar_queue_before_drop = 15;
 
     uint32_t gnss_queue_max_size = 100;
@@ -997,6 +1004,18 @@ private:
   std::multimap<double /*timestamp*/, CObservation::ConstPtr> worker_lidar_wait_for_imu_list_;
   std::mutex worker_lidar_wait_for_imu_list_mtx_;
 
+  /** Single-slot holder for the freshest LiDAR scan that is ready to be
+   *  processed but is waiting because the worker thread is still busy with a
+   *  previous scan. Under sustained overload (scans arriving faster than they
+   *  can be processed), a newer ready scan overwrites -- and thus drops -- an
+   *  older one still sitting here, so the worker always resumes on the freshest
+   *  available scan. This keeps end-to-end latency close to a single processing
+   *  period instead of a deep FIFO backlog. Both fields are guarded by the
+   *  mutex below (which is always taken *before* is_busy_mtx_, never after). */
+  CObservation::ConstPtr worker_lidar_pending_fresh_scan_;
+  bool worker_lidar_busy_ = false;
+  std::mutex worker_lidar_pending_fresh_scan_mtx_;
+
   /** The worker thread pool with 1 thread for processing incoming observations*/
   mrpt::WorkerThreadsPool worker_others_{
     1 /*num threads*/, mrpt::WorkerThreadsPool::POLICY_FIFO, "worker_imu"};
@@ -1160,6 +1179,14 @@ private:
   /// Same as isPipelineUsingIMU(), but assumes state_mtx_ is already held by the caller.
   bool isPipelineUsingIMU_locked() const;
   void sendLidarScanToProcessQueue(const CObservation::ConstPtr & o);
+
+  /** Hands a LiDAR scan that is ready for processing (i.e. already has the IMU
+   *  data it needs for de-skew, when applicable) to the single worker thread,
+   *  implementing the "drop stale, keep freshest" policy: if the worker is idle
+   *  the scan is dispatched immediately; if it is busy, the scan is stored in
+   *  the single pending slot, dropping any older scan that was waiting there.
+   *  Safe to call from any thread. */
+  void submitReadyLidarScanToWorker(const CObservation::ConstPtr & o);
   mp2p_icp::metric_map_t::Ptr observationFromRawSensor(const mrpt::obs::CSensoryFrame & sf);
   mrpt::obs::CSensoryFrame collectRawObservations(const mrpt::obs::CObservation::ConstPtr & obs);
 

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -787,9 +787,14 @@ private:
     // ------ ^^^ end of these flags are protected ^^^^      ---------
 
     // ------ these vars are protected by is_busy_mtx_  ---------
+    // worker_tasks_lidar is 1 while onLidar() is actively executing a scan, 0
+    // otherwise (queued-but-not-yet-running scans are tracked separately, by
+    // worker_lidar_.pendingTasks()).
     int worker_tasks_lidar = 0;
     int worker_tasks_others = 0;
+    // ------ ^^^ end of these flags are protected ^^^^      ---------
 
+    // ------ these vars are protected by drop_stats_mtx_  ---------
     static constexpr std::size_t DROP_STATS_WINDOW_LENGTH = 128;
     std::array<bool, DROP_STATS_WINDOW_LENGTH> drop_frames_stats_good =
       create_array<DROP_STATS_WINDOW_LENGTH>(true);
@@ -997,24 +1002,17 @@ private:
 
   };  // end of MethodState
 
-  /** The worker thread pool with 1 thread for processing incoming observations*/
+  /** The worker thread pool with 1 thread for processing incoming observations.
+   *  Uses POLICY_DROP_OLD: when a new scan is enqueued while one is already
+   *  waiting (the worker thread being busy with a previous one), the pool
+   *  itself discards the older, not-yet-started scan, so the worker always
+   *  resumes on the freshest available one instead of grinding through a deep
+   *  backlog ("drop stale, keep freshest"). Running tasks are never aborted. */
   mrpt::WorkerThreadsPool worker_lidar_{
-    1 /*num threads*/, mrpt::WorkerThreadsPool::POLICY_FIFO, "worker_lidar"};
+    1 /*num threads*/, mrpt::WorkerThreadsPool::POLICY_DROP_OLD, "worker_lidar"};
 
   std::multimap<double /*timestamp*/, CObservation::ConstPtr> worker_lidar_wait_for_imu_list_;
   std::mutex worker_lidar_wait_for_imu_list_mtx_;
-
-  /** Single-slot holder for the freshest LiDAR scan that is ready to be
-   *  processed but is waiting because the worker thread is still busy with a
-   *  previous scan. Under sustained overload (scans arriving faster than they
-   *  can be processed), a newer ready scan overwrites -- and thus drops -- an
-   *  older one still sitting here, so the worker always resumes on the freshest
-   *  available scan. This keeps end-to-end latency close to a single processing
-   *  period instead of a deep FIFO backlog. Both fields are guarded by the
-   *  mutex below (which is always taken *before* is_busy_mtx_, never after). */
-  CObservation::ConstPtr worker_lidar_pending_fresh_scan_;
-  bool worker_lidar_busy_ = false;
-  std::mutex worker_lidar_pending_fresh_scan_mtx_;
 
   /** The worker thread pool with 1 thread for processing incoming observations*/
   mrpt::WorkerThreadsPool worker_others_{
@@ -1069,6 +1067,8 @@ private:
 
   bool destructor_called_ = false;
   mutable std::mutex is_busy_mtx_;
+  /// Guards MethodState::drop_frames_stats_* (see addDropStats()/getDropStats()).
+  mutable std::mutex drop_stats_mtx_;
   mutable std::mutex state_flags_mtx_;
   mutable std::mutex state_mtx_;
   mutable std::mutex state_trajectory_mtx_;
@@ -1091,7 +1091,7 @@ private:
   MapServer::ReturnStatus map_load_impl(const std::string & path);
   MapServer::ReturnStatus map_save_impl(const std::string & path);
 
-  /// Locks is_busy_mtx_ internally to update the drop-stats window.
+  /// Locks drop_stats_mtx_ internally to update the drop-stats window.
   void addDropStats(bool frame_is_dropped);
 
   /// Returns the ratio [0,1] of lidar frames dropped due to slow processing in the last few seconds.
@@ -1100,7 +1100,11 @@ private:
   // Process requests_(), at the spinOnce() rate.
   void processPendingUserRequests();
 
-  void onLidar(const CObservation::ConstPtr & o);
+  /// `readyTimestamp` is when the scan became ready for processing (used to
+  /// report the "delay_onNewObs_to_process" queueing-delay metric); it cannot
+  /// be measured via profiler_.enter()/leave() here since worker_lidar_'s
+  /// POLICY_DROP_OLD may discard a queued scan before it ever runs onLidar().
+  void onLidar(const CObservation::ConstPtr & o, double readyTimestamp);
   void processLidarScan(const CObservation::ConstPtr & obs);
 
   void onIMU(const CObservation::ConstPtr & o);
@@ -1181,12 +1185,15 @@ private:
   void sendLidarScanToProcessQueue(const CObservation::ConstPtr & o);
 
   /** Hands a LiDAR scan that is ready for processing (i.e. already has the IMU
-   *  data it needs for de-skew, when applicable) to the single worker thread,
-   *  implementing the "drop stale, keep freshest" policy: if the worker is idle
-   *  the scan is dispatched immediately; if it is busy, the scan is stored in
-   *  the single pending slot, dropping any older scan that was waiting there.
-   *  Safe to call from any thread. */
+   *  data it needs for de-skew, when applicable) to the single worker thread.
+   *  worker_lidar_'s POLICY_DROP_OLD implements the "drop stale, keep freshest"
+   *  policy itself: if the worker is idle the scan starts right away; if it is
+   *  busy, this call replaces any older not-yet-started scan still queued
+   *  behind it. This method only adds the drop-stats bookkeeping the pool
+   *  itself doesn't provide. Safe to call from any thread. */
   void submitReadyLidarScanToWorker(const CObservation::ConstPtr & o);
+  /// Number of LiDAR scans currently running or queued on worker_lidar_ (0, 1, or 2).
+  int pendingLidarScanCount() const;
   mp2p_icp::metric_map_t::Ptr observationFromRawSensor(const mrpt::obs::CSensoryFrame & sf);
   mrpt::obs::CSensoryFrame collectRawObservations(const mrpt::obs::CObservation::ConstPtr & obs);
 

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -1014,6 +1014,28 @@ private:
   std::multimap<double /*timestamp*/, CObservation::ConstPtr> worker_lidar_wait_for_imu_list_;
   std::mutex worker_lidar_wait_for_imu_list_mtx_;
 
+  /// Timestamp (seconds, sensor clock) up to which IMU data has actually been
+  /// *fed* into the de-skew LocalVelocityBuffer (updated at the end of the IMU
+  /// feeding in onIMUImpl). A waiting scan may only be released to the worker
+  /// once this passes its own timestamp by one scan period, i.e. once the IMU
+  /// covering the scan's whole span is available for de-skew. Kept as an atomic
+  /// so the wait-list can be drained (see releaseReadyLidarScansToWorker) from
+  /// the sensor-input thread too, without waiting for the (FIFO, possibly
+  /// backed-up) IMU worker to run its own drain -- decoupling scan release from
+  /// IMU-processing latency.
+  std::atomic<double> latest_fed_imu_time_{0};
+
+  /// Cached estimate of the LiDAR scan period [s], read lock-free by
+  /// releaseReadyLidarScansToWorker(). Estimated from consecutive scan *arrival*
+  /// (sensor) timestamps rather than the processed-scan rate: under heavy
+  /// dropping the processed rate collapses, which would otherwise inflate this
+  /// period and make scans wait for far more IMU than they actually need,
+  /// needlessly deepening the wait list.
+  std::atomic<double> lidar_scan_period_{0.1};
+  /// Sensor timestamp [s] of the previous LiDAR scan seen at input, for the
+  /// arrival-based period estimate above. Guarded by the wait-list mutex.
+  double last_lidar_arrival_stamp_ = 0;
+
   /** The worker thread pool with 1 thread for processing incoming observations*/
   mrpt::WorkerThreadsPool worker_others_{
     1 /*num threads*/, mrpt::WorkerThreadsPool::POLICY_FIFO, "worker_imu"};
@@ -1194,6 +1216,16 @@ private:
   void submitReadyLidarScanToWorker(const CObservation::ConstPtr & o);
   /// Number of LiDAR scans currently running or queued on worker_lidar_ (0, 1, or 2).
   int pendingLidarScanCount() const;
+
+  /** Releases to the worker every LiDAR scan on worker_lidar_wait_for_imu_list_
+   *  whose whole time span is already covered by IMU data fed into the de-skew
+   *  buffer (i.e. latest_fed_imu_time_ is more than one scan period past the
+   *  scan timestamp). On an IMU catch-up burst several scans can qualify at
+   *  once; only the freshest is submitted (the pool would drop the rest anyway).
+   *  Takes no heavy locks (only the wait-list mutex + atomics), so it can run on
+   *  the sensor-input thread while onLidar holds state_mtx_; this decouples scan
+   *  release from IMU-worker processing latency. No-op for LO (empty wait list). */
+  void releaseReadyLidarScansToWorker();
   mp2p_icp::metric_map_t::Ptr observationFromRawSensor(const mrpt::obs::CSensoryFrame & sf);
   mrpt::obs::CSensoryFrame collectRawObservations(const mrpt::obs::CObservation::ConstPtr & obs);
 

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -1091,7 +1091,7 @@ private:
   MapServer::ReturnStatus map_load_impl(const std::string & path);
   MapServer::ReturnStatus map_save_impl(const std::string & path);
 
-  /// Must be called from a scope with state_flags_mtx_ already acquired!
+  /// Locks is_busy_mtx_ internally to update the drop-stats window.
   void addDropStats(bool frame_is_dropped);
 
   /// Returns the ratio [0,1] of lidar frames dropped due to slow processing in the last few seconds.

--- a/module/src/LidarOdometry_InitialLocalization.cpp
+++ b/module/src/LidarOdometry_InitialLocalization.cpp
@@ -42,6 +42,15 @@ void LidarOdometry::handleInitialLocalizationDoInitFromPose(
       mrpt::Clock::fromDouble(mrpt::Clock::toDouble(*state_.last_obs_timestamp) - 1e-3);
     state_.navstate_fuse->fuse_pose(t1, initPose, params_.publish_reference_frame);
     state_.navstate_fuse->fuse_pose(t2, initPose, params_.publish_reference_frame);
+
+    // Also skip fusing the next few ICP corrections into the state estimator
+    // (same safeguard used by relocalize_near_pose_pdf()/relocalize_from_gnss()):
+    // the very first ICP correction after this reset is only a tiny "dt" away
+    // from the fake evolution above, so dividing its position delta by that
+    // dt can produce a huge, spurious velocity. Skipping a few steps lets ICP
+    // re-converge on a stable pose before velocity is derived again.
+    state_.step_counter_post_relocalization =
+      params_.initial_localization.additional_uncertainty_after_reloc_how_many_timesteps;
   }
 
   // also, keep it as the last pose for subsequent ICP runs:

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -687,6 +687,7 @@ void LidarOdometry::doWriteDebugTracesFile(const mrpt::Clock::time_point & scan_
 
 void LidarOdometry::addDropStats(bool frame_is_dropped)
 {
+  auto lck = mrpt::lockHelper(is_busy_mtx_);
   state_.drop_frames_stats_good[state_.drop_frames_stats_next_index] = !frame_is_dropped;
   state_.drop_frames_stats_dropped[state_.drop_frames_stats_next_index] = frame_is_dropped;
   if (++state_.drop_frames_stats_next_index >= MethodState::DROP_STATS_WINDOW_LENGTH) {
@@ -696,7 +697,7 @@ void LidarOdometry::addDropStats(bool frame_is_dropped)
 
 double LidarOdometry::getDropStats() const
 {
-  auto lckStateFlags = mrpt::lockHelper(state_flags_mtx_);
+  auto lck = mrpt::lockHelper(is_busy_mtx_);
   const auto good =
     std::count(state_.drop_frames_stats_good.begin(), state_.drop_frames_stats_good.end(), true);
   const auto bad = std::count(

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -687,7 +687,7 @@ void LidarOdometry::doWriteDebugTracesFile(const mrpt::Clock::time_point & scan_
 
 void LidarOdometry::addDropStats(bool frame_is_dropped)
 {
-  auto lck = mrpt::lockHelper(is_busy_mtx_);
+  auto lck = mrpt::lockHelper(drop_stats_mtx_);
   state_.drop_frames_stats_good[state_.drop_frames_stats_next_index] = !frame_is_dropped;
   state_.drop_frames_stats_dropped[state_.drop_frames_stats_next_index] = frame_is_dropped;
   if (++state_.drop_frames_stats_next_index >= MethodState::DROP_STATS_WINDOW_LENGTH) {
@@ -697,7 +697,7 @@ void LidarOdometry::addDropStats(bool frame_is_dropped)
 
 double LidarOdometry::getDropStats() const
 {
-  auto lck = mrpt::lockHelper(is_busy_mtx_);
+  auto lck = mrpt::lockHelper(drop_stats_mtx_);
   const auto good =
     std::count(state_.drop_frames_stats_good.begin(), state_.drop_frames_stats_good.end(), true);
   const auto bad = std::count(

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -118,8 +118,6 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 
   auto lckState = mrpt::lockHelper(state_mtx_);
 
-  profiler_.leave("delay_onNewObs_to_process");
-
   // for rate stats:
   state_.append_lidar_stamp(obs->sensorLabel, obs->timestamp, *this);
 

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -140,10 +140,22 @@ void LidarOdometry::sendLidarScanToProcessQueue(const CObservation::ConstPtr & o
   }
 
   // IMU usage: park on the wait list.
+  const double thisStamp = mrpt::Clock::toDouble(o->getTimeStamp());
   size_t waitListSize = 0;
   {
     auto lck = mrpt::lockHelper(worker_lidar_wait_for_imu_list_mtx_);
-    worker_lidar_wait_for_imu_list_.emplace(mrpt::Clock::toDouble(o->getTimeStamp()), o);
+    worker_lidar_wait_for_imu_list_.emplace(thisStamp, o);
+
+    // Estimate the scan period from consecutive *arrival* timestamps (EMA), so
+    // it reflects the true sensor rate even while scans are being dropped:
+    if (last_lidar_arrival_stamp_ > 0) {
+      const double dt = thisStamp - last_lidar_arrival_stamp_;
+      if (dt > 0 && dt < 1.0) {
+        const double prev = lidar_scan_period_.load();
+        lidar_scan_period_.store(0.9 * prev + 0.1 * dt);
+      }
+    }
+    last_lidar_arrival_stamp_ = thisStamp;
 
     // Safety cap: if IMU data lags badly, keep the wait list from growing without
     // bound by dropping the oldest still-waiting scans (they would be the most
@@ -156,8 +168,52 @@ void LidarOdometry::sendLidarScanToProcessQueue(const CObservation::ConstPtr & o
     waitListSize = worker_lidar_wait_for_imu_list_.size();
   }
 
+  // The IMU covering this or an earlier scan may already have been fed to the
+  // de-skew buffer, so try to release now instead of waiting for the next IMU
+  // callback (which may be stuck behind onLidar on the IMU worker thread):
+  releaseReadyLidarScansToWorker();
+
   const int queued = pendingLidarScanCount() + static_cast<int>(waitListSize);
   profiler_.registerUserMeasure("onNewObservation.lidar_queue_length", static_cast<double>(queued));
+}
+
+void LidarOdometry::releaseReadyLidarScansToWorker()
+{
+  const double fedImuTime = latest_fed_imu_time_.load();
+  if (fedImuTime <= 0) {
+    return;  // no IMU fed yet: nothing can be de-skewed/released
+  }
+  const double lidar_scan_period = lidar_scan_period_.load();
+
+  // Collect every waiting scan whose whole span is already covered by fed IMU
+  // data (fedImuTime more than one scan period past the scan timestamp), in
+  // chronological order, then submit outside the wait-list lock:
+  std::vector<CObservation::ConstPtr> readyScans;
+  {
+    auto lck = mrpt::lockHelper(worker_lidar_wait_for_imu_list_mtx_);
+    for (auto it = worker_lidar_wait_for_imu_list_.begin();
+         it != worker_lidar_wait_for_imu_list_.end();) {
+      const auto [lidarTim, lidarObs] = *it;
+      if (fedImuTime - lidarTim > lidar_scan_period) {
+        readyScans.push_back(lidarObs);
+        it = worker_lidar_wait_for_imu_list_.erase(it);
+      } else {
+        // The list is sorted by timestamp: no later scan can qualify either.
+        break;
+      }
+    }
+  }
+
+  // On an IMU catch-up burst several scans can qualify at once, but only the
+  // newest matters ("keep freshest"): drop-account the older ones directly
+  // instead of submitting each only to have it superseded by the next.
+  if (!readyScans.empty()) {
+    for (std::size_t i = 0; i + 1 < readyScans.size(); i++) {
+      addDropStats(true);
+      profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
+    }
+    submitReadyLidarScanToWorker(readyScans.back());
+  }
 }
 
 void LidarOdometry::submitReadyLidarScanToWorker(const CObservation::ConstPtr & o)
@@ -279,57 +335,25 @@ void LidarOdometry::onIMUImpl(const CObservation::ConstPtr & o)
     mp2p_icp_filters::apply_generators(state_.obs_generators, *imu, dummy_map);
   }
 
+  // Mark how far IMU data has now been fed into the de-skew buffer, so a waiting
+  // scan is only released once the IMU covering its whole span is available.
+  // Monotonic update, to be robust against out-of-order IMU timestamps:
+  {
+    const double imuTim = mrpt::Clock::toDouble(imu->timestamp);
+    double prev = latest_fed_imu_time_.load();
+    while (imuTim > prev && !latest_fed_imu_time_.compare_exchange_weak(prev, imuTim)) {
+    }
+  }
+
   // 3) Gravity estimation for ICP verticality correction:
   if (params_.imu_gravity_correction.enabled) {
     auto lckState2 = mrpt::lockHelper(state_mtx_);
     state_.gravity_estimator.add(*imu, params_.imu_gravity_correction.averaging_samples);
   }
 
-  // Finally, schedule to run those LiDAR scans that were waiting for IMU data:
-  if (isPipelineUsingIMU()) {
-    const auto imuTim = mrpt::Clock::toDouble(imu->timestamp);
-
-    const auto rate_lidar_hz = [&] {
-      auto lckState = mrpt::lockHelper(state_mtx_);
-      auto [rate_lidar, rate_imu_, rate_gnss_] = state_.get_sensor_rates();
-      return rate_lidar;
-    }();
-
-    const double lidar_scan_period = rate_lidar_hz > 0 ? 1.0 / rate_lidar_hz : 0.1;
-
-    // Collect the scans whose whole time span is now covered by IMU data, in
-    // chronological order, then submit them to the worker outside the wait-list
-    // lock (submitReadyLidarScanToWorker takes other mutexes internally):
-    std::vector<CObservation::ConstPtr> readyScans;
-    {
-      auto lck = mrpt::lockHelper(worker_lidar_wait_for_imu_list_mtx_);
-
-      for (auto it = worker_lidar_wait_for_imu_list_.begin();
-           it != worker_lidar_wait_for_imu_list_.end();) {
-        const auto [lidarTim, lidarObs] = *it;
-
-        const double lidar2imu_dt = imuTim - lidarTim;
-        if (lidar2imu_dt > lidar_scan_period) {
-          readyScans.push_back(lidarObs);
-          it = worker_lidar_wait_for_imu_list_.erase(it);
-        } else {
-          ++it;
-        }
-      }
-    }
-
-    // On an IMU catch-up burst, several scans can become ready at once, but
-    // only the newest one matters ("keep freshest"): drop-account the older
-    // ones directly instead of submitting each in turn only to have it
-    // superseded by the next.
-    if (!readyScans.empty()) {
-      for (std::size_t i = 0; i + 1 < readyScans.size(); i++) {
-        addDropStats(true);
-        profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
-      }
-      submitReadyLidarScanToWorker(readyScans.back());
-    }
-  }
+  // Finally, release any waiting LiDAR scan now fully covered by fed IMU data.
+  // No-op for LO (the wait list is only populated by IMU-de-skew pipelines):
+  releaseReadyLidarScansToWorker();
 }
 
 void LidarOdometry::onGPS(const CObservation::ConstPtr & o)

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -32,6 +32,8 @@
 
 // Std:
 #include <regex>
+#include <utility>
+#include <vector>
 
 namespace mola
 {
@@ -111,66 +113,132 @@ void LidarOdometry::onNewObservation(const CObservation::ConstPtr & o)
 
 void LidarOdometry::sendLidarScanToProcessQueue(const CObservation::ConstPtr & o)
 {
-  // If we don't rely on IMU, directly enqueue the task. Otherwise, put it on the wait list until
-  // IMU data for the required timestamps has arrived so we can do de-skew:
-
-  auto queued = [this]() {
-    auto lck = mrpt::lockHelper(is_busy_mtx_);
-    return state_.worker_tasks_lidar + worker_lidar_.pendingTasks();
-  }() + [this]() {
-    auto lck = mrpt::lockHelper(worker_lidar_wait_for_imu_list_mtx_);
-    return static_cast<int>(worker_lidar_wait_for_imu_list_.size());
-  }();
-
-  profiler_.registerUserMeasure("onNewObservation.lidar_queue_length", static_cast<double>(queued));
-  if (queued > params_.max_lidar_queue_before_drop) {
-    MRPT_LOG_THROTTLE_WARN_FMT(
-      1.0, "Dropping observation due to LiDAR worker thread too busy (dropped frames: %.02f%%)",
-      getDropStats() * 100.0);
-    profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
-    addDropStats(true);
-    return;
-  }
-  addDropStats(false);
-  profiler_.enter("delay_onNewObs_to_process");
+  // Two routes to the single worker thread, depending on whether the pipeline
+  // needs IMU data for de-skew:
+  //  - No IMU needed: the scan is ready right away -> hand it to the worker.
+  //  - IMU needed:    park it on the wait list until IMU data covering the whole
+  //                   scan time span has arrived (see onIMUImpl), then submit.
+  // In both cases the worker applies a "drop stale, keep freshest" policy
+  // (submitReadyLidarScanToWorker), so under overload old scans are skipped and
+  // only the newest ready one is processed, keeping latency low.
 
   if (!isPipelineUsingIMU()) {
-    {
-      auto lck = mrpt::lockHelper(is_busy_mtx_);
-      state_.worker_tasks_lidar++;
-    }
+    // Report an instantaneous queue length for the GUI / stats:
+    const int queued = [this]() {
+      auto lck = mrpt::lockHelper(worker_lidar_pending_fresh_scan_mtx_);
+      return (worker_lidar_busy_ ? 1 : 0) + (worker_lidar_pending_fresh_scan_ ? 1 : 0);
+    }();
+    profiler_.registerUserMeasure(
+      "onNewObservation.lidar_queue_length", static_cast<double>(queued));
 
-    auto fut = worker_lidar_.enqueue(&LidarOdometry::onLidar, this, o);
-    (void)fut;
-  } else {
-    // IMU usage:
+    submitReadyLidarScanToWorker(o);
+    return;
+  }
+
+  // IMU usage: park on the wait list.
+  size_t waitListSize = 0;
+  {
     auto lck = mrpt::lockHelper(worker_lidar_wait_for_imu_list_mtx_);
     worker_lidar_wait_for_imu_list_.emplace(mrpt::Clock::toDouble(o->getTimeStamp()), o);
+
+    // Safety cap: if IMU data lags badly, keep the wait list from growing without
+    // bound by dropping the oldest still-waiting scans (they would be the most
+    // stale ones anyway):
+    while (worker_lidar_wait_for_imu_list_.size() > params_.max_lidar_queue_before_drop) {
+      worker_lidar_wait_for_imu_list_.erase(worker_lidar_wait_for_imu_list_.begin());
+      addDropStats(true);
+      profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
+    }
+    waitListSize = worker_lidar_wait_for_imu_list_.size();
+  }
+
+  const int queued = [this]() {
+    auto lck = mrpt::lockHelper(worker_lidar_pending_fresh_scan_mtx_);
+    return (worker_lidar_busy_ ? 1 : 0) + (worker_lidar_pending_fresh_scan_ ? 1 : 0);
+  }() + static_cast<int>(waitListSize);
+  profiler_.registerUserMeasure("onNewObservation.lidar_queue_length", static_cast<double>(queued));
+}
+
+void LidarOdometry::submitReadyLidarScanToWorker(const CObservation::ConstPtr & o)
+{
+  CObservation::ConstPtr supersededScan;
+  bool dispatchNow = false;
+  {
+    auto lck = mrpt::lockHelper(worker_lidar_pending_fresh_scan_mtx_);
+    if (!worker_lidar_busy_) {
+      // Worker is idle: dispatch this scan right away. Mark busy (both flags)
+      // while still holding the slot mutex so isBusy() cannot observe a false
+      // "idle" gap during shutdown draining.
+      worker_lidar_busy_ = true;
+      auto lck2 = mrpt::lockHelper(is_busy_mtx_);
+      state_.worker_tasks_lidar = 1;
+      dispatchNow = true;
+    } else {
+      // Worker is busy: keep only the freshest scan. Any scan already waiting in
+      // the slot is superseded (dropped) by this newer one.
+      supersededScan = std::move(worker_lidar_pending_fresh_scan_);
+      worker_lidar_pending_fresh_scan_ = o;
+    }
+  }
+
+  if (dispatchNow) {
+    profiler_.enter("delay_onNewObs_to_process");
+    auto fut = worker_lidar_.enqueue(&LidarOdometry::onLidar, this, o);
+    (void)fut;
+  } else if (supersededScan) {
+    // We just dropped an older, not-yet-processed scan in favor of a fresher one:
+    addDropStats(true);
+    profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
+    MRPT_LOG_THROTTLE_WARN_FMT(
+      1.0, "Dropping LiDAR scan (worker busy: keeping only the freshest); dropped frames: %.02f%%",
+      getDropStats() * 100.0);
   }
 }
 
 void LidarOdometry::onLidar(const CObservation::ConstPtr & o)
 {
-  const bool abort_running = [this]() {
-    auto lck = mrpt::lockHelper(is_busy_mtx_);
-    return destructor_called_;
-  }();
+  // This worker invocation processes the given scan and then keeps draining the
+  // single pending slot: any fresher scan that arrived while we were busy is
+  // picked up here (older ones having already been dropped by the submitter),
+  // so we always advance to the newest available data.
+  CObservation::ConstPtr cur = o;
+  for (;;) {
+    const bool abort_running = [this]() {
+      auto lck = mrpt::lockHelper(is_busy_mtx_);
+      return destructor_called_;
+    }();
 
-  // All methods that are enqueued into a thread pool should have its own
-  // top-level try-catch:
-  if (!abort_running) {
-    try {
-      processLidarScan(o);
-    } catch (const std::exception & e) {
-      MRPT_LOG_ERROR_STREAM("Exception:\n" << mrpt::exception_to_str(e));
-      auto lckStateFlags = mrpt::lockHelper(state_flags_mtx_);
-      state_.fatal_error = true;
+    // All methods that are enqueued into a thread pool should have its own
+    // top-level try-catch:
+    if (!abort_running) {
+      try {
+        addDropStats(false);
+        processLidarScan(cur);
+      } catch (const std::exception & e) {
+        MRPT_LOG_ERROR_STREAM("Exception:\n" << mrpt::exception_to_str(e));
+        auto lckStateFlags = mrpt::lockHelper(state_flags_mtx_);
+        state_.fatal_error = true;
+      }
     }
-  }
 
-  {
-    auto lck = mrpt::lockHelper(is_busy_mtx_);
-    state_.worker_tasks_lidar--;
+    // Pick up the freshest pending scan, if any arrived while we were busy:
+    auto lck = mrpt::lockHelper(worker_lidar_pending_fresh_scan_mtx_);
+    if (worker_lidar_pending_fresh_scan_ && !abort_running) {
+      cur = std::move(worker_lidar_pending_fresh_scan_);
+      worker_lidar_pending_fresh_scan_.reset();
+      // Re-open the delay stopwatch for the scan we are about to process:
+      profiler_.enter("delay_onNewObs_to_process");
+      continue;
+    }
+
+    // Nothing (more) pending: mark the worker idle and finish this invocation.
+    worker_lidar_pending_fresh_scan_.reset();
+    worker_lidar_busy_ = false;
+    {
+      auto lck2 = mrpt::lockHelper(is_busy_mtx_);
+      state_.worker_tasks_lidar = 0;
+    }
+    break;
   }
 }
 
@@ -255,27 +323,32 @@ void LidarOdometry::onIMUImpl(const CObservation::ConstPtr & o)
 
     const double lidar_scan_period = rate_lidar_hz > 0 ? 1.0 / rate_lidar_hz : 0.1;
 
-    auto lck = mrpt::lockHelper(worker_lidar_wait_for_imu_list_mtx_);
+    // Collect the scans whose whole time span is now covered by IMU data, in
+    // chronological order, then submit them to the worker outside the wait-list
+    // lock (submitReadyLidarScanToWorker takes other mutexes internally):
+    std::vector<CObservation::ConstPtr> readyScans;
+    {
+      auto lck = mrpt::lockHelper(worker_lidar_wait_for_imu_list_mtx_);
 
-    for (auto it = worker_lidar_wait_for_imu_list_.begin();
-         it != worker_lidar_wait_for_imu_list_.end();) {
-      const auto [lidarTim, lidarObs] = *it;
+      for (auto it = worker_lidar_wait_for_imu_list_.begin();
+           it != worker_lidar_wait_for_imu_list_.end();) {
+        const auto [lidarTim, lidarObs] = *it;
 
-      const double lidar2imu_dt = imuTim - lidarTim;
-      if (lidar2imu_dt > lidar_scan_period) {
-        // Enqueue this one:
-        {
-          auto lck2 = mrpt::lockHelper(is_busy_mtx_);
-          state_.worker_tasks_lidar++;
+        const double lidar2imu_dt = imuTim - lidarTim;
+        if (lidar2imu_dt > lidar_scan_period) {
+          readyScans.push_back(lidarObs);
+          it = worker_lidar_wait_for_imu_list_.erase(it);
+        } else {
+          ++it;
         }
-        auto fut = worker_lidar_.enqueue(&LidarOdometry::onLidar, this, lidarObs);
-        (void)fut;
-
-        // and remove from the list:
-        it = worker_lidar_wait_for_imu_list_.erase(it);
-      } else {
-        ++it;
       }
+    }
+
+    // Submit oldest -> newest: if the worker cannot keep up, the "keep freshest"
+    // policy inside submitReadyLidarScanToWorker() ensures only the newest of
+    // these is actually processed and the older ones are dropped.
+    for (const auto & lidarObs : readyScans) {
+      submitReadyLidarScanToWorker(lidarObs);
     }
   }
 }

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -111,6 +111,15 @@ void LidarOdometry::onNewObservation(const CObservation::ConstPtr & o)
   MRPT_TRY_END
 }
 
+int LidarOdometry::pendingLidarScanCount() const
+{
+  const bool executing = [this]() {
+    auto lck = mrpt::lockHelper(is_busy_mtx_);
+    return state_.worker_tasks_lidar != 0;
+  }();
+  return (executing ? 1 : 0) + static_cast<int>(worker_lidar_.pendingTasks());
+}
+
 void LidarOdometry::sendLidarScanToProcessQueue(const CObservation::ConstPtr & o)
 {
   // Two routes to the single worker thread, depending on whether the pipeline
@@ -118,18 +127,13 @@ void LidarOdometry::sendLidarScanToProcessQueue(const CObservation::ConstPtr & o
   //  - No IMU needed: the scan is ready right away -> hand it to the worker.
   //  - IMU needed:    park it on the wait list until IMU data covering the whole
   //                   scan time span has arrived (see onIMUImpl), then submit.
-  // In both cases the worker applies a "drop stale, keep freshest" policy
-  // (submitReadyLidarScanToWorker), so under overload old scans are skipped and
-  // only the newest ready one is processed, keeping latency low.
+  // In both cases the worker pool (POLICY_DROP_OLD) applies a "drop stale, keep
+  // freshest" policy, so under overload old scans are skipped and only the
+  // newest ready one is processed, keeping latency low.
 
   if (!isPipelineUsingIMU()) {
-    // Report an instantaneous queue length for the GUI / stats:
-    const int queued = [this]() {
-      auto lck = mrpt::lockHelper(worker_lidar_pending_fresh_scan_mtx_);
-      return (worker_lidar_busy_ ? 1 : 0) + (worker_lidar_pending_fresh_scan_ ? 1 : 0);
-    }();
     profiler_.registerUserMeasure(
-      "onNewObservation.lidar_queue_length", static_cast<double>(queued));
+      "onNewObservation.lidar_queue_length", static_cast<double>(pendingLidarScanCount()));
 
     submitReadyLidarScanToWorker(o);
     return;
@@ -152,93 +156,63 @@ void LidarOdometry::sendLidarScanToProcessQueue(const CObservation::ConstPtr & o
     waitListSize = worker_lidar_wait_for_imu_list_.size();
   }
 
-  const int queued = [this]() {
-    auto lck = mrpt::lockHelper(worker_lidar_pending_fresh_scan_mtx_);
-    return (worker_lidar_busy_ ? 1 : 0) + (worker_lidar_pending_fresh_scan_ ? 1 : 0);
-  }() + static_cast<int>(waitListSize);
+  const int queued = pendingLidarScanCount() + static_cast<int>(waitListSize);
   profiler_.registerUserMeasure("onNewObservation.lidar_queue_length", static_cast<double>(queued));
 }
 
 void LidarOdometry::submitReadyLidarScanToWorker(const CObservation::ConstPtr & o)
 {
-  CObservation::ConstPtr supersededScan;
-  bool dispatchNow = false;
-  {
-    auto lck = mrpt::lockHelper(worker_lidar_pending_fresh_scan_mtx_);
-    if (!worker_lidar_busy_) {
-      // Worker is idle: dispatch this scan right away. Mark busy (both flags)
-      // while still holding the slot mutex so isBusy() cannot observe a false
-      // "idle" gap during shutdown draining.
-      worker_lidar_busy_ = true;
-      auto lck2 = mrpt::lockHelper(is_busy_mtx_);
-      state_.worker_tasks_lidar = 1;
-      dispatchNow = true;
-    } else {
-      // Worker is busy: keep only the freshest scan. Any scan already waiting in
-      // the slot is superseded (dropped) by this newer one.
-      supersededScan = std::move(worker_lidar_pending_fresh_scan_);
-      worker_lidar_pending_fresh_scan_ = o;
-    }
-  }
-
-  if (dispatchNow) {
-    profiler_.enter("delay_onNewObs_to_process");
-    auto fut = worker_lidar_.enqueue(&LidarOdometry::onLidar, this, o);
-    (void)fut;
-  } else if (supersededScan) {
-    // We just dropped an older, not-yet-processed scan in favor of a fresher one:
+  // worker_lidar_ uses POLICY_DROP_OLD: with a single worker thread, enqueue()
+  // itself discards any older, not-yet-started scan once one is already queued
+  // behind the one currently running. The pool gives no callback for that
+  // eviction, so detect it here (before enqueueing) purely for the drop-stats
+  // accounting; running scans are never aborted, only queued ones can be
+  // dropped this way.
+  if (worker_lidar_.pendingTasks() > 0) {
     addDropStats(true);
     profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
     MRPT_LOG_THROTTLE_WARN_FMT(
       1.0, "Dropping LiDAR scan (worker busy: keeping only the freshest); dropped frames: %.02f%%",
       getDropStats() * 100.0);
   }
+
+  auto fut = worker_lidar_.enqueue(&LidarOdometry::onLidar, this, o, mrpt::Clock::nowDouble());
+  (void)fut;
 }
 
-void LidarOdometry::onLidar(const CObservation::ConstPtr & o)
+void LidarOdometry::onLidar(const CObservation::ConstPtr & o, const double readyTimestamp)
 {
-  // This worker invocation processes the given scan and then keeps draining the
-  // single pending slot: any fresher scan that arrived while we were busy is
-  // picked up here (older ones having already been dropped by the submitter),
-  // so we always advance to the newest available data.
-  CObservation::ConstPtr cur = o;
-  for (;;) {
-    const bool abort_running = [this]() {
-      auto lck = mrpt::lockHelper(is_busy_mtx_);
-      return destructor_called_;
-    }();
+  const bool abort_running = [this]() {
+    auto lck = mrpt::lockHelper(is_busy_mtx_);
+    return destructor_called_;
+  }();
 
-    // All methods that are enqueued into a thread pool should have its own
-    // top-level try-catch:
-    if (!abort_running) {
-      try {
-        addDropStats(false);
-        processLidarScan(cur);
-      } catch (const std::exception & e) {
-        MRPT_LOG_ERROR_STREAM("Exception:\n" << mrpt::exception_to_str(e));
-        auto lckStateFlags = mrpt::lockHelper(state_flags_mtx_);
-        state_.fatal_error = true;
-      }
-    }
+  if (abort_running) {
+    return;
+  }
 
-    // Pick up the freshest pending scan, if any arrived while we were busy:
-    auto lck = mrpt::lockHelper(worker_lidar_pending_fresh_scan_mtx_);
-    if (worker_lidar_pending_fresh_scan_ && !abort_running) {
-      cur = std::move(worker_lidar_pending_fresh_scan_);
-      worker_lidar_pending_fresh_scan_.reset();
-      // Re-open the delay stopwatch for the scan we are about to process:
-      profiler_.enter("delay_onNewObs_to_process");
-      continue;
-    }
+  {
+    auto lck = mrpt::lockHelper(is_busy_mtx_);
+    state_.worker_tasks_lidar = 1;
+  }
 
-    // Nothing (more) pending: mark the worker idle and finish this invocation.
-    worker_lidar_pending_fresh_scan_.reset();
-    worker_lidar_busy_ = false;
-    {
-      auto lck2 = mrpt::lockHelper(is_busy_mtx_);
-      state_.worker_tasks_lidar = 0;
-    }
-    break;
+  profiler_.registerUserMeasure(
+    "delay_onNewObs_to_process", mrpt::Clock::nowDouble() - readyTimestamp);
+
+  // All methods that are enqueued into a thread pool should have its own
+  // top-level try-catch:
+  try {
+    addDropStats(false);
+    processLidarScan(o);
+  } catch (const std::exception & e) {
+    MRPT_LOG_ERROR_STREAM("Exception:\n" << mrpt::exception_to_str(e));
+    auto lckStateFlags = mrpt::lockHelper(state_flags_mtx_);
+    state_.fatal_error = true;
+  }
+
+  {
+    auto lck = mrpt::lockHelper(is_busy_mtx_);
+    state_.worker_tasks_lidar = 0;
   }
 }
 
@@ -344,11 +318,16 @@ void LidarOdometry::onIMUImpl(const CObservation::ConstPtr & o)
       }
     }
 
-    // Submit oldest -> newest: if the worker cannot keep up, the "keep freshest"
-    // policy inside submitReadyLidarScanToWorker() ensures only the newest of
-    // these is actually processed and the older ones are dropped.
-    for (const auto & lidarObs : readyScans) {
-      submitReadyLidarScanToWorker(lidarObs);
+    // On an IMU catch-up burst, several scans can become ready at once, but
+    // only the newest one matters ("keep freshest"): drop-account the older
+    // ones directly instead of submitting each in turn only to have it
+    // superseded by the next.
+    if (!readyScans.empty()) {
+      for (std::size_t i = 0; i + 1 < readyScans.size(); i++) {
+        addDropStats(true);
+        profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
+      }
+      submitReadyLidarScanToWorker(readyScans.back());
     }
   }
 }

--- a/scripts/mola-lo-gui-mulran
+++ b/scripts/mola-lo-gui-mulran
@@ -20,6 +20,7 @@ shift 1
 
 MOLA_ODOMETRY_PIPELINE_YAML="${PIPELINE_YAML:-$MOLA_LAUNCHS_DIR/../pipelines/lidar3d-default.yaml}" \
 MULRAN_SEQ=$SEQ \
+MOLA_DESKEW_METHOD="${MOLA_DESKEW_METHOD:-MotionCompensationMethod::IMU}" \
   mola-cli \
     $MOLA_LAUNCHS_DIR/lidar_odometry_from_mulran.yaml \
     $@


### PR DESCRIPTION
## Problem

When LiDAR scans (and IMU for LIO) arrive faster than they can be processed
(e.g. 10 Hz input with `onLidar` > 100 ms), the drop-when-overloaded feature was
broken. The single worker thread used a FIFO queue bounded only by
`max_lidar_queue_before_drop=15` and always processed the **oldest** buffered
scan, so it built a deep backlog.

Measured end-to-end staleness (newest arrived scan vs. currently processed scan)
was **~1.8 s** for both LO and LIO, i.e. the odometry ran ~1.8 s behind real
time and queried the state estimator far in the *past*. The enqueue counter also
double-counted pending tasks (`worker_tasks_lidar` already includes
`pendingTasks()`).

## Fix

Replace the deep FIFO with a **"drop stale, keep freshest"** policy:

- A single pending slot (`worker_lidar_pending_fresh_scan_`) holds the newest
  ready scan. When the worker is busy, a newer scan *replaces* (drops) any older
  one waiting there.
- `onLidar` processes its scan and then drains the slot in a loop, so the worker
  always advances to the **newest** available scan instead of grinding through a
  stale backlog.

This keeps latency near a single processing period, so the state-estimator
prediction is queried only slightly into the future. Works for both LO and LIO
(the IMU wait list feeds the same `submitReadyLidarScanToWorker()` path).
`max_lidar_queue_before_drop` now only bounds the IMU wait list.

## Validation

Reproduced with a controlled `onLidar` delay at real-time input rate:

| scenario | staleness before | staleness after | ICP quality |
|---|---|---|---|
| LO KITTI, 150 ms `onLidar` | ~1.8 s | ~0.1-0.3 s | 0.88, 0 bad |
| LIO Mulran (IMU de-skew), 150 ms | ~1.7 s | ~0.3-0.4 s | 0.95, 0 bad |
| LIO, 300 / 600 ms `onLidar` | ~1.8 s (pinned) | ~0.7 / ~1.3 s (= processing time) | 0.94 / 0.82, 0 bad |
| Normal load (no overload) | - | 0 drops, unchanged | healthy |

Staleness now scales with actual processing time (optimal for a single worker)
instead of a fixed deep backlog. Full-sequence completion and clean shutdown
(drain loop) verified. `clang-format-14` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified LiDAR scan enqueue/dispatch under overload, including LO (immediate dispatch) vs. LIO (IMU-covered waiting).
  * Documented the “drop stale, keep freshest” behavior and clarified how the queue limit applies only to IMU waiting.

* **Bug Fixes**
  * Updated LiDAR worker scheduling to prevent deep FIFO backlog by keeping only the newest ready scan when overloaded.
  * Improved drop statistics/thread-safety around queue dropping and added clearer busy vs. pending reporting.
  * Added a post-relocalization safeguard to reduce spurious early ICP effects.

* **Chores**
  * Updated the GUI/mulran script to set the deske w method environment variable for the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->