### PR TITLE
feat: map freeze after relocalization

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -524,6 +524,15 @@ public:
       // Right after a re-localization, do not update the pose state estimator for a few iterations
       uint32_t additional_uncertainty_after_reloc_how_many_timesteps = 5;
 
+      // Right after a re-localization (or initial localization), also do not
+      // update the local map nor the simplemap for this many timesteps.
+      // 0 (default) disables this and preserves pre-existing behavior:
+      // map updates are independent of the re-localization recovery window.
+      // Shares the same recovery-window counter as
+      // additional_uncertainty_after_reloc_how_many_timesteps (the window
+      // becomes the max of the two when both are set).
+      uint32_t additional_map_freeze_after_reloc_how_many_timesteps = 0;
+
       /// Number of IMU (accelerometer) samples to accumulate while stationary to estimate Pitch & Roll:
       uint32_t imu_initial_calibration_sample_count = 50;
 

--- a/module/src/LidarOdometry_InitialLocalization.cpp
+++ b/module/src/LidarOdometry_InitialLocalization.cpp
@@ -49,8 +49,9 @@ void LidarOdometry::handleInitialLocalizationDoInitFromPose(
     // from the fake evolution above, so dividing its position delta by that
     // dt can produce a huge, spurious velocity. Skipping a few steps lets ICP
     // re-converge on a stable pose before velocity is derived again.
-    state_.step_counter_post_relocalization =
-      params_.initial_localization.additional_uncertainty_after_reloc_how_many_timesteps;
+    state_.step_counter_post_relocalization = std::max(
+      params_.initial_localization.additional_uncertainty_after_reloc_how_many_timesteps,
+      params_.initial_localization.additional_map_freeze_after_reloc_how_many_timesteps);
   }
 
   // also, keep it as the last pose for subsequent ICP runs:

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -261,6 +261,7 @@ void LidarOdometry::Parameters::InitialLocalizationOptions::initialize(const Yam
   MCP_LOAD_OPT(cfg, method);
 
   YAML_LOAD_OPT(additional_uncertainty_after_reloc_how_many_timesteps, uint32_t);
+  YAML_LOAD_OPT(additional_map_freeze_after_reloc_how_many_timesteps, uint32_t);
   YAML_LOAD_OPT(imu_initial_calibration_sample_count, uint32_t);
   YAML_LOAD_OPT(imu_initial_calibration_max_age, double);
   YAML_LOAD_OPT(use_imu_orientation, bool);

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -691,6 +691,10 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     }
 
     // Update velocity model:
+    // Snapshot before it gets decremented below, so the map-freeze check
+    // further down still sees this step as part of the recovery window.
+    const uint32_t stepCounterPostRelocalization = state_.step_counter_post_relocalization;
+
     if (icpIsGood) {
       // Good ICP, update state estimation filter with new data from ICP:
 
@@ -828,6 +832,17 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     // Older mola_pose_list: countNearby() unavailable; min_nearby_poses_occupied has no effect.
 #endif
 
+    // Reuse the post-relocalization recovery window/counter (see
+    // additional_map_freeze_after_reloc_how_many_timesteps): only actually
+    // freezes anything when that parameter is >0, so leaving it at its
+    // default of 0 is a no-op regardless of
+    // additional_uncertainty_after_reloc_how_many_timesteps's own value.
+    // Use the pre-decrement snapshot so the last step of the recovery window
+    // (where pose fusion was still suppressed above) also freezes the map.
+    const bool mapFrozenPostReloc =
+      params_.initial_localization.additional_map_freeze_after_reloc_how_many_timesteps > 0 &&
+      stepCounterPostRelocalization > 0;
+
     // clang-format off
     updateLocalMap =
       (icpIsGood &&
@@ -835,7 +850,8 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
        params_.local_map_updates.enabled &&
        // skip map update for the special ICP alignment without motion model
        hasMotionModel &&
-       distFarEnoughLocal
+       distFarEnoughLocal &&
+       !mapFrozenPostReloc
        );
     // clang-format on
 
@@ -889,7 +905,8 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     updateSimpleMap =
       params_.simplemap.generate &&
       (icpIsGood &&
-       (distance_enough_sm || params_.simplemap.add_non_keyframes_too)
+       (distance_enough_sm || params_.simplemap.add_non_keyframes_too) &&
+       !mapFrozenPostReloc
        );
     // clang-format on
 

--- a/module/src/LidarOdometry_Relocalization.cpp
+++ b/module/src/LidarOdometry_Relocalization.cpp
@@ -61,8 +61,9 @@ void LidarOdometry::relocalize_near_pose_pdf_impl(const mrpt::poses::CPose3DPDFG
   state_.adapt_thres_sigma = std::sqrt(p.cov.asEigen().block<2, 2>(0, 0).trace());
 
   // Handle uncertainty in next steps:
-  state_.step_counter_post_relocalization =
-    il.additional_uncertainty_after_reloc_how_many_timesteps;
+  state_.step_counter_post_relocalization = std::max(
+    il.additional_uncertainty_after_reloc_how_many_timesteps,
+    il.additional_map_freeze_after_reloc_how_many_timesteps);
 
   MRPT_LOG_INFO_STREAM(
     "relocalize_near_pose_pdf(): Using thres_sigma=" << state_.adapt_thres_sigma
@@ -85,8 +86,9 @@ void LidarOdometry::relocalize_from_gnss_impl()
   state_.adapt_thres_sigma = params_.adaptive_threshold.initial_sigma;
 
   // Handle uncertainty in next steps:
-  state_.step_counter_post_relocalization =
-    il.additional_uncertainty_after_reloc_how_many_timesteps;
+  state_.step_counter_post_relocalization = std::max(
+    il.additional_uncertainty_after_reloc_how_many_timesteps,
+    il.additional_map_freeze_after_reloc_how_many_timesteps);
 }
 
 }  // namespace mola

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -211,6 +211,14 @@ initial_localization:
   imu_initial_calibration_sample_count: "${MOLA_LO_INITIAL_IMU_SAMPLES|400}"
   imu_initial_calibration_max_age: 5.0
   use_imu_orientation: "${MOLA_LO_INITIAL_IMU_USE_ORIENTATION|true}"
+  # Right after a re-localization (or initial localization), also hold off
+  # local map / simplemap updates for this many timesteps (shares the same
+  # recovery-window counter as additional_uncertainty_after_reloc_how_many_
+  # timesteps above). 0 (default) disables this and is a no-op: this fires
+  # on every initial-localization convergence too, not just explicit
+  # relocalizations, so a nonzero default here would drop early keyframes
+  # on any dataset where the vehicle is already moving at t=0.
+  additional_map_freeze_after_reloc_how_many_timesteps: "${MOLA_LO_INIT_MAP_FREEZE_STEPS|0}"
 
   # Parameters for InitLocalization::FromStateEstimator:
   from_state_estimator_max_position_sigma: "${MOLA_LO_INIT_SE_MAX_POS_SIGMA|0.5}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `initial_localization` option to temporarily freeze map updates after initial localization or re-localization.
  * When enabled, it suppresses both local map updates and simple map keyframe insertion for a configurable number of timesteps (`0` disables the freeze).

* **Improvements**
  * The post-relocalization recovery window now uses the longer of the uncertainty and map-freeze settings when both are configured.
  * Updated pipeline configuration documentation to include and describe the new parameter and its default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->