### PR TITLE
fix: two bugs blocking GNSS+IMU relocalization (FromStateEstimator)

### DIFF
--- a/pipelines/extras/lidar3d-dual-map.yaml
+++ b/pipelines/extras/lidar3d-dual-map.yaml
@@ -27,7 +27,7 @@ params:
     enabled: true
     initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
     min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
-    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
+    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|2.00} # [m]
     max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
     icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
     kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
@@ -42,7 +42,12 @@ params:
     # push ICP into failure, and with sigma frozen the correspondence search
     # window never reopens, so the pipeline stalls indefinitely
     # (estimated_trajectory never grows again). Set to false to restore the
-    # old behavior.
+    # old behavior. `maximum_sigma` must be set strictly above
+    # `initial_sigma`, or this mechanism is a no-op: sigma always starts
+    # each run AT initial_sigma, so a bad ICP on frame 1 (e.g. a slightly
+    # imprecise localization-only seed pose against a prebuilt map) has no
+    # room to grow into and can never recover (observed in testing as ICP
+    # goodness stuck just under min_icp_goodness for an entire run).
     #
     # recover_after_n_bad/recover_growth_factor default to a fast reaction
     # (2 bad frames, x2.0 growth) rather than a slow one (5 bad frames,

--- a/pipelines/extras/lidar3d-edges.yaml
+++ b/pipelines/extras/lidar3d-edges.yaml
@@ -31,7 +31,7 @@ params:
     enabled: true
     initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
     min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
-    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
+    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|2.00} # [m]
     max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
     icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
     kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
@@ -46,7 +46,12 @@ params:
     # push ICP into failure, and with sigma frozen the correspondence search
     # window never reopens, so the pipeline stalls indefinitely
     # (estimated_trajectory never grows again). Set to false to restore the
-    # old behavior.
+    # old behavior. `maximum_sigma` must be set strictly above
+    # `initial_sigma`, or this mechanism is a no-op: sigma always starts
+    # each run AT initial_sigma, so a bad ICP on frame 1 (e.g. a slightly
+    # imprecise localization-only seed pose against a prebuilt map) has no
+    # room to grow into and can never recover (observed in testing as ICP
+    # goodness stuck just under min_icp_goodness for an entire run).
     #
     # recover_after_n_bad/recover_growth_factor default to a fast reaction
     # (2 bad frames, x2.0 growth) rather than a slow one (5 bad frames,

--- a/pipelines/extras/rgbd.yaml
+++ b/pipelines/extras/rgbd.yaml
@@ -49,7 +49,7 @@ params:
     enabled: true
     initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
     min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
-    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
+    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|2.00} # [m]
     max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
     icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
     kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
@@ -64,7 +64,12 @@ params:
     # push ICP into failure, and with sigma frozen the correspondence search
     # window never reopens, so the pipeline stalls indefinitely
     # (estimated_trajectory never grows again). Set to false to restore the
-    # old behavior.
+    # old behavior. `maximum_sigma` must be set strictly above
+    # `initial_sigma`, or this mechanism is a no-op: sigma always starts
+    # each run AT initial_sigma, so a bad ICP on frame 1 (e.g. a slightly
+    # imprecise localization-only seed pose against a prebuilt map) has no
+    # room to grow into and can never recover (observed in testing as ICP
+    # goodness stuck just under min_icp_goodness for an entire run).
     #
     # recover_after_n_bad/recover_growth_factor default to a fast reaction
     # (2 bad frames, x2.0 growth) rather than a slow one (5 bad frames,

--- a/pipelines/lidar2d.yaml
+++ b/pipelines/lidar2d.yaml
@@ -58,7 +58,7 @@ params:
     enabled: true
     initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
     min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
-    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
+    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|2.00} # [m]
     max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
     icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
     kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
@@ -73,7 +73,12 @@ params:
     # push ICP into failure, and with sigma frozen the correspondence search
     # window never reopens, so the pipeline stalls indefinitely
     # (estimated_trajectory never grows again). Set to false to restore the
-    # old behavior.
+    # old behavior. `maximum_sigma` must be set strictly above
+    # `initial_sigma`, or this mechanism is a no-op: sigma always starts
+    # each run AT initial_sigma, so a bad ICP on frame 1 (e.g. a slightly
+    # imprecise localization-only seed pose against a prebuilt map) has no
+    # room to grow into and can never recover (observed in testing as ICP
+    # goodness stuck just under min_icp_goodness for an entire run).
     #
     # recover_after_n_bad/recover_growth_factor default to a fast reaction
     # (2 bad frames, x2.0 growth) rather than a slow one (5 bad frames,

--- a/pipelines/lidar3d-gicp-optimize-twist.yaml
+++ b/pipelines/lidar3d-gicp-optimize-twist.yaml
@@ -74,7 +74,7 @@ params:
     enabled: true
     initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
     min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
-    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
+    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|2.00} # [m]
     max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
     icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
     kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
@@ -89,7 +89,12 @@ params:
     # push ICP into failure, and with sigma frozen the correspondence search
     # window never reopens, so the pipeline stalls indefinitely
     # (estimated_trajectory never grows again). Set to false to restore the
-    # old behavior.
+    # old behavior. `maximum_sigma` must be set strictly above
+    # `initial_sigma`, or this mechanism is a no-op: sigma always starts
+    # each run AT initial_sigma, so a bad ICP on frame 1 (e.g. a slightly
+    # imprecise localization-only seed pose against a prebuilt map) has no
+    # room to grow into and can never recover (observed in testing as ICP
+    # goodness stuck just under min_icp_goodness for an entire run).
     #
     # recover_after_n_bad/recover_growth_factor default to a fast reaction
     # (2 bad frames, x2.0 growth) rather than a slow one (5 bad frames,

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -85,7 +85,7 @@ params:
     enabled: true
     initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
     min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
-    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
+    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|2.00} # [m]
     max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
     icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
     kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
@@ -100,7 +100,12 @@ params:
     # push ICP into failure, and with sigma frozen the correspondence search
     # window never reopens, so the pipeline stalls indefinitely
     # (estimated_trajectory never grows again). Set to false to restore the
-    # old behavior.
+    # old behavior. `maximum_sigma` must be set strictly above
+    # `initial_sigma`, or this mechanism is a no-op: sigma always starts
+    # each run AT initial_sigma, so a bad ICP on frame 1 (e.g. a slightly
+    # imprecise localization-only seed pose against a prebuilt map) has no
+    # room to grow into and can never recover (observed in testing as ICP
+    # goodness stuck just under min_icp_goodness for an entire run).
     #
     # recover_after_n_bad/recover_growth_factor default to a fast reaction
     # (2 bad frames, x2.0 growth) rather than a slow one (5 bad frames,

--- a/pipelines/lidar3d-icp.yaml
+++ b/pipelines/lidar3d-icp.yaml
@@ -74,7 +74,7 @@ params:
     enabled: true
     initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
     min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
-    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
+    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|2.00} # [m]
     max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
     icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
     kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
@@ -89,7 +89,12 @@ params:
     # push ICP into failure, and with sigma frozen the correspondence search
     # window never reopens, so the pipeline stalls indefinitely
     # (estimated_trajectory never grows again). Set to false to restore the
-    # old behavior.
+    # old behavior. `maximum_sigma` must be set strictly above
+    # `initial_sigma`, or this mechanism is a no-op: sigma always starts
+    # each run AT initial_sigma, so a bad ICP on frame 1 (e.g. a slightly
+    # imprecise localization-only seed pose against a prebuilt map) has no
+    # room to grow into and can never recover (observed in testing as ICP
+    # goodness stuck just under min_icp_goodness for an entire run).
     #
     # recover_after_n_bad/recover_growth_factor default to a fast reaction
     # (2 bad frames, x2.0 growth) rather than a slow one (5 bad frames,

--- a/pipelines/lidar3d-ndt.yaml
+++ b/pipelines/lidar3d-ndt.yaml
@@ -68,7 +68,7 @@ params:
     enabled: true
     initial_sigma: ${MOLA_SIGMA_INITIAL|0.50} # [m]
     min_motion: ${MOLA_SIGMA_MIN_MOTION|0.04} # [m]
-    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|0.50} # [m]
+    maximum_sigma: ${MOLA_SIGMA_MAX_MOTION|2.00} # [m]
     max_sigma_step: ${MOLA_SIGMA_MAX_STEP|0.05} # [m]
     icp_quality_controller_setpoint: ${MOLA_SIGMA_CONTROLLER_QUALITY_SETPOINT|0.85}
     kp: ${MOLA_SIGMA_CONTROLLER_GAIN|2.0}
@@ -83,7 +83,12 @@ params:
     # push ICP into failure, and with sigma frozen the correspondence search
     # window never reopens, so the pipeline stalls indefinitely
     # (estimated_trajectory never grows again). Set to false to restore the
-    # old behavior.
+    # old behavior. `maximum_sigma` must be set strictly above
+    # `initial_sigma`, or this mechanism is a no-op: sigma always starts
+    # each run AT initial_sigma, so a bad ICP on frame 1 (e.g. a slightly
+    # imprecise localization-only seed pose against a prebuilt map) has no
+    # room to grow into and can never recover (observed in testing as ICP
+    # goodness stuck just under min_icp_goodness for an entire run).
     #
     # recover_after_n_bad/recover_growth_factor default to a fast reaction
     # (2 bad frames, x2.0 growth) rather than a slow one (5 bad frames,

--- a/ros2-launchs/ros2-lidar-odometry.launch.py
+++ b/ros2-launchs/ros2-lidar-odometry.launch.py
@@ -474,17 +474,27 @@ def generate_launch_description():
             " else 'mola::state_estimation_simple::StateEstimationSimple'"
         ]))
 
+    # NOTE: 'state_estimation' (not 'state_estimator') must match the
+    # module *instance name* the state estimator is registered under in
+    # mola-cli-launchs/lidar_odometry_ros2.yaml ("- name: state_estimation"),
+    # since that's what ends up in each LocalizationUpdate/MapUpdate's
+    # `.method` field (StateEstimationSmoother::spinOnce() and
+    # ::publish_georef(), via getModuleInstanceName()'s colon-suffix) and is
+    # therefore what publish_tf_from_slam_source/
+    # publish_odometry_msgs_from_slam_source filter against. A mismatch here
+    # silently discards every update from the state estimator: no /tf, no
+    # odometry topic, ever, regardless of how well localization converged.
     localization_publish_tf_source_env_var = SetEnvironmentVariable(
         name='MOLA_LOCALIZATION_PUBLISH_TF_SOURCE',
         value=PythonExpression([
-            "'state_estimator' if ", LaunchConfiguration(
+            "'state_estimation' if ", LaunchConfiguration(
                 'use_state_estimator'), " else 'lidar_odometry'"
         ])
     )
     localization_publish_odom_source_env_var = SetEnvironmentVariable(
         name='MOLA_LOCALIZATION_PUBLISH_ODOM_MSGS_SOURCE',
         value=PythonExpression([
-            "'state_estimator' if ", LaunchConfiguration(
+            "'state_estimation' if ", LaunchConfiguration(
                 'use_state_estimator'), " else 'lidar_odometry'"
         ])
     )


### PR DESCRIPTION
## Summary
Found via end-to-end MOLA + MVSIM simulation testing of geo-referencing-based initial pose estimation (GNSS position + IMU global attitude, fused by `mola_state_estimation_smoother`, seeding `mola_lidar_odometry`'s ICP via `InitLocalization::FromStateEstimator`). Both bugs independently and completely block that scenario; each is described in detail in its own commit.

- **`maximum_sigma` defaulted equal to `initial_sigma`** in all 8 pipeline YAMLs, silently making the sustained-failure-recovery mechanism (added earlier for a different bug) a no-op whenever a run starts with marginal ICP quality on scan 1 — exactly what happens in localization-only mode (`start_mapping_enabled:=false`) against a prebuilt map. Confirmed via reproduction: ICP goodness pinned at 33-42% and the estimated pose frozen near the initial seed for a full run despite real vehicle motion; fixed by raising the default to 2.00m, confirmed goodness then reaches ~100% within a handful of frames.
- **`MOLA_LOCALIZATION_PUBLISH_TF_SOURCE`/`..._ODOM_MSGS_SOURCE` had a module-name string typo** (`'state_estimator'` vs the actual instance name `'state_estimation'`), so with `use_state_estimator:=true` BridgeROS2 silently discarded every localization update from the state estimator — no `/tf`, ever, no error — even after convergence was correctly detected and logged.

## Test plan
- [x] All 8 modified pipeline YAMLs are still valid (loaded successfully in live testing)
- [x] `colcon test --packages-select mola_lidar_odometry`: 6/6 passed
- [x] End-to-end MOLA + MVSIM simulation: `InitLocalization::FromStateEstimator` relocalization main scenario passes 5/5 repeated runs, plus two adversarial variants (reversed heading, degraded GNSS) 5/5 each, after these two fixes (previously failed/crashed/never-published before either fix)
- [x] `agents.md` updated with both findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ROS 2 localization output publishing so TF and odometry updates are delivered correctly when the state estimator is enabled.
  * Improved recovery from sustained poor scan registration, reducing pose freezes after an initially bad match.

* **Configuration**
  * Increased the default adaptive threshold recovery limit from 0.50 to 2.00, allowing greater recovery flexibility across supported lidar and RGB-D configurations.

* **Documentation**
  * Added guidance explaining recovery threshold requirements and the localization publishing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->