### PR TITLE
Make the localization /tf source overridable (enables routing map->odom)

### DIFF
--- a/ros2-launchs/ros2-lidar-odometry.launch.py
+++ b/ros2-launchs/ros2-lidar-odometry.launch.py
@@ -484,11 +484,25 @@ def generate_launch_description():
     # publish_odometry_msgs_from_slam_source filter against. A mismatch here
     # silently discards every update from the state estimator: no /tf, no
     # odometry topic, ever, regardless of how well localization converged.
+    # By default the bridge publishes /tf from the active estimator's primary
+    # localization method ('state_estimation' or 'lidar_odometry'). This arg
+    # lets a caller override that source, e.g. to route /tf from the smoother's
+    # 'state_estimation/map_odom' method so map->odom is taken straight from the
+    # estimator's own T_map_to_odom (publish_map_to_odom_tf) instead of being
+    # composed by the bridge from a mismatched-timestamp odom lookup. Empty
+    # keeps the default behavior.
+    localization_publish_tf_source_arg = DeclareLaunchArgument(
+        "localization_publish_tf_source", default_value="",
+        description="Override the bridge's publish_tf_from_slam_source (the "
+                    "localization `method` whose /tf is published). Empty = the "
+                    "default ('state_estimation' if use_state_estimator else "
+                    "'lidar_odometry').")
     localization_publish_tf_source_env_var = SetEnvironmentVariable(
         name='MOLA_LOCALIZATION_PUBLISH_TF_SOURCE',
         value=PythonExpression([
-            "'state_estimation' if ", LaunchConfiguration(
-                'use_state_estimator'), " else 'lidar_odometry'"
+            "'", LaunchConfiguration('localization_publish_tf_source'),
+            "' or ('state_estimation' if ", LaunchConfiguration(
+                'use_state_estimator'), " else 'lidar_odometry')"
         ])
     )
     localization_publish_odom_source_env_var = SetEnvironmentVariable(
@@ -776,6 +790,7 @@ def generate_launch_description():
         state_estimator_config_yaml_arg,
         OpaqueFunction(function=resolve_state_estimator_config),
 
+        localization_publish_tf_source_arg,
         localization_publish_tf_source_env_var,
         localization_publish_odom_source_env_var,
         # group


### PR DESCRIPTION
## Motivation

`MOLA_LOCALIZATION_PUBLISH_TF_SOURCE` (the bridge's `publish_tf_from_slam_source` — which localization `method`'s /tf is published) was computed unconditionally from `use_state_estimator`. A launch that **includes** `ros2-lidar-odometry.launch.py` therefore could not override it (the child's `SetEnvironmentVariable` wins over any value the parent set first).

## What changed

Add a `localization_publish_tf_source` launch argument (default empty = unchanged behavior). When set, it takes precedence over the computed default.

This enables routing /tf from the state estimator's `state_estimation/map_odom` method, so `map->odom` is taken straight from the smoother's own `T_map_to_odom` (`StateEstimationSmoother`'s new `publish_map_to_odom_tf`) and forwarded by the bridge verbatim, instead of being composed from a mismatched-timestamp `odom->base_link` lookup (that composition injects motion-correlated `map->odom` jitter).

## Compatibility

Empty default → the emitted env var is byte-for-byte identical to before, so every existing launch is unchanged. Verified `--show-args` exposes the new argument and the launch parses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional launch setting to select the localization source used for publishing the `/tf` stream.
  * Preserved the existing default behavior when no override is provided.
  * The setting can be supplied through the command line when starting the launch configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->