### PR TITLE
Add mola-lo-gui-oxford-spires helper for the Oxford Spires dataset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ install(
     scripts/mola-lo-gui-rosbag1
     scripts/mola-lo-gui-ouster
     scripts/mola-lo-gui-conslam
+    scripts/mola-lo-gui-oxford-spires
   DESTINATION
     bin
 )

--- a/mola-cli-launchs/lidar_odometry_from_oxford_spires.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_oxford_spires.yaml
@@ -1,0 +1,148 @@
+# -----------------------------------------------------------------------------
+#                        SLAM system definition for MOLA
+# This file defines:
+# LiDAR odometry from the Oxford Spires Dataset, read directly from its
+# ROS 2 bag(s) via mola::Rosbag2Dataset.
+#
+# Dataset: Oxford Spires (https://dynamic.robots.ox.ac.uk/datasets/oxford-spires)
+# Sensor inventory (confirmed with a bag's metadata.yaml):
+#   /hesai/pandar                                       sensor_msgs/PointCloud2   Hesai Pandar, ~10 Hz
+#   /alphasense_driver_ros/imu                           sensor_msgs/Imu           Alphasense IMU, ~400 Hz
+#   /alphasense_driver_ros/cam0/debayered/image/compressed  sensor_msgs/CompressedImage
+#   /alphasense_driver_ros/cam1/debayered/image/compressed  sensor_msgs/CompressedImage
+#   /alphasense_driver_ros/cam2/debayered/image/compressed  sensor_msgs/CompressedImage
+# NO /tf or /tf_static in these bags, so use_fixed_sensor_pose is mandatory
+# for every sensor.
+#
+# Extrinsics: taken from data/calibration/cam-lidar-imu.yaml (Kalibr
+# "C_q_CL"/"C_r_CL" cam-to-lidar, and "C_q_CI"/"C_r_CI" cam0-to-imu),
+# with the Hesai LiDAR as base_link (identity pose) and every other sensor's
+# pose obtained by inverting/composing those transforms into the LiDAR frame.
+#
+# Some sequences are split across several ros2bag directories (a multipart
+# recording); mola::Rosbag2Dataset accepts a YAML sequence for
+# 'rosbag_filename' and replays them back-to-back as a single continuous
+# dataset, so this file exposes OXFORD_SPIRES_BAG_0..5 (unused slots resolve
+# to an empty string and are silently skipped). Use the mola-lo-gui-oxford-spires
+# wrapper script to fill these in automatically from a sequence directory.
+#
+# Usage (normally invoked through scripts/mola-lo-gui-oxford-spires instead):
+#   OXFORD_SPIRES_BAG_0=$SEQ/raw/ros2bag/<part0>/ \
+#   OXFORD_SPIRES_BAG_1=$SEQ/raw/ros2bag/<part1>/ \
+#     mola-cli $(ros2 pkg prefix mola_lidar_odometry)/share/mola_lidar_odometry/mola-cli-launchs/lidar_odometry_from_oxford_spires.yaml
+#
+# Optional overrides:
+#   MOLA_WITH_GUI=false        -- headless mode
+#   MOLA_TIME_WARP=1.0         -- playback speed factor
+#   MOLA_QUIT_ON_DATASET_END=true  -- exit when the bag(s) end
+# -----------------------------------------------------------------------------
+
+modules:
+  # =====================
+  # MolaViz / MolaVizImGui
+  # =====================
+  - name: viz
+    type: ${MOLA_GUI_MODULE|mola::MolaVizImGui}
+    enabled: ${MOLA_WITH_GUI|true}
+    verbosity_level: "${MOLA_VERBOSITY_MOLA_VIZ|INFO}"
+    params:
+      imgui_app_name: lo_oxford_spires
+
+  # =====================
+  # Rosbag2Dataset (Oxford Spires)
+  # =====================
+  - name: dataset_input
+    type: mola::Rosbag2Dataset
+    verbosity_level: "${MOLA_VERBOSITY_ROSBAG2|INFO}"
+    execution_rate: 50 # Hz
+    quit_mola_app_on_dataset_end: ${MOLA_QUIT_ON_DATASET_END|false}
+
+    gui_preview_sensors:
+      - raw_sensor_label: "${MOLA_LIDAR_NAME|lidar}"
+        decimation: 1
+        enabled: ${MOLA_WITH_GUI|true}
+        win_pos: 5 5 400 400
+      - raw_sensor_label: "${MOLA_CAMERA_SENSOR_NAME|camera}"
+        decimation: 1
+        enabled: ${MOLA_WITH_GUI|true}
+        win_pos: 5 420 400 300
+
+    params:
+      # Filled in by the mola-lo-gui-oxford-spires wrapper script, one entry
+      # per ros2bag directory of a (possibly multipart) sequence. Empty
+      # slots are silently skipped:
+      rosbag_filename:
+        - ${OXFORD_SPIRES_BAG_0}
+        - ${OXFORD_SPIRES_BAG_1|}
+        - ${OXFORD_SPIRES_BAG_2|}
+        - ${OXFORD_SPIRES_BAG_3|}
+        - ${OXFORD_SPIRES_BAG_4|}
+        - ${OXFORD_SPIRES_BAG_5|}
+
+      base_link_frame_id: "${MOLA_TF_BASE_LINK|hesai_lidar}"
+      time_warp_scale: ${MOLA_TIME_WARP|1.0}
+      start_paused: ${MOLA_DATASET_START_PAUSED|false}
+      # 0 (default): replay the whole sequence. Set e.g. to quickly validate
+      # a long sequence without waiting for it to finish:
+      max_duration_sec: ${MOLA_MAX_DURATION_SEC|0}
+
+      sensors:
+        - topic: "${MOLA_LIDAR_TOPIC|/hesai/pandar}"
+          type: CObservationPointCloud
+          sensorLabel: "${MOLA_LIDAR_NAME|lidar}"
+          # Hesai LiDAR is used as the reference (base_link) frame here:
+          fixed_sensor_pose: "0 0 0 0 0 0"
+          use_fixed_sensor_pose: true
+
+        - topic: "${MOLA_IMU_TOPIC|/alphasense_driver_ros/imu}"
+          type: CObservationIMU
+          sensorLabel: imu
+          # T_lidar_imu, derived from cam0's C_q_CI/C_r_CI (cam0-to-imu) and
+          # C_q_CL/C_r_CL (cam0-to-lidar):
+          fixed_sensor_pose: "0.018771 -0.008218 -0.070474 -90.6263 -0.1665 -0.1287"
+          use_fixed_sensor_pose: true
+
+        # cam2 is the forward-facing camera (yaw ~ 0 wrt the LiDAR), enabled
+        # by default for the GUI preview. cam0/cam1 (below, commented out)
+        # point sideways; uncomment to also feed them in (e.g. for mapping).
+        - topic: "${MOLA_CAMERA_TOPIC|/alphasense_driver_ros/cam2/debayered/image/compressed}"
+          type: CObservationImage
+          sensorLabel: "${MOLA_CAMERA_SENSOR_NAME|camera}"
+          is_optional: true
+          # T_lidar_cam2:
+          fixed_sensor_pose: "0.002228 0.050377 -0.073378 -0.1092 0.0896 -89.9231"
+          use_fixed_sensor_pose: true
+
+        #- topic: /alphasense_driver_ros/cam0/debayered/image/compressed
+        #  type: CObservationImage
+        #  sensorLabel: camera0
+        #  is_optional: true
+        #  # T_lidar_cam0:
+        #  fixed_sensor_pose: "-0.054541 -0.002683 -0.073943 89.5878 -0.1301 -90.2621"
+        #  use_fixed_sensor_pose: true
+
+        #- topic: /alphasense_driver_ros/cam1/debayered/image/compressed
+        #  type: CObservationImage
+        #  sensorLabel: camera1
+        #  is_optional: true
+        #  # T_lidar_cam1:
+        #  fixed_sensor_pose: "0.001823 -0.057626 -0.073524 179.5324 -0.1189 -89.8271"
+        #  use_fixed_sensor_pose: true
+
+  # =====================
+  # LidarOdometry
+  # =====================
+  - name: lidar_odom
+    type: mola::LidarOdometry
+    verbosity_level: "${MOLA_VERBOSITY_MOLA_LO|INFO}"
+    raw_data_source: "dataset_input"
+    params: "${MOLA_ODOMETRY_PIPELINE_YAML|../pipelines/lidar3d-default.yaml}"
+
+  # =====================
+  # State Estimation
+  # =====================
+  - name: state_estimation
+    type: "${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}"
+    verbosity_level: "${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}"
+    raw_data_source: "dataset_input"
+    params: "${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}"

--- a/scripts/mola-lo-gui-oxford-spires
+++ b/scripts/mola-lo-gui-oxford-spires
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# For usage instructions, see: https://docs.mola-slam.org/latest/
+#
+# Convenience wrapper around mola-cli for the Oxford Spires Dataset
+# (https://dynamic.robots.ox.ac.uk/datasets/oxford-spires):
+# presets its LiDAR/IMU/camera topic names and fixed sensor poses (see
+# mola-cli-launchs/lidar_odometry_from_oxford_spires.yaml for the details
+# and the calibration source), and transparently stitches together
+# multipart sequences (some sequences are split across several ros2bag
+# directories) into a single continuous replay.
+#
+# Usage:
+#   mola-lo-gui-oxford-spires /path/to/data/sequences/<sequence-name>/ [additional flags for mola-cli]
+#
+# Example:
+#   mola-lo-gui-oxford-spires /mnt/storage/oxford-spires/data/sequences/2024-03-12-keble-college-01/
+
+import os
+import re
+import sys
+from pathlib import Path
+
+# Number of "OXFORD_SPIRES_BAG_N" slots defined in the launch YAML:
+MAX_BAG_PARTS = 6
+
+
+def die(msg: str) -> None:
+    print(f"Error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def find_bag_parts(seq_dir: Path) -> list[Path]:
+    bag_root = seq_dir / "raw" / "ros2bag"
+    if not bag_root.is_dir():
+        die(
+            f"'{bag_root}' does not exist. Expected argument to be a sequence "
+            f"directory such as '.../data/sequences/2024-03-12-keble-college-01/', "
+            f"containing a 'raw/ros2bag/' subdirectory."
+        )
+
+    parts = [d for d in bag_root.iterdir() if d.is_dir() and (d / "metadata.yaml").is_file()]
+    if not parts:
+        die(f"No ros2bag directories (with a 'metadata.yaml') found under '{bag_root}'.")
+
+    # Directory names end in "..._<part_index>" (e.g.
+    # "1710252275_2024-03-12-14-04-36_0", "..._1", "..._2", ...): sort
+    # numerically on that suffix so multipart sequences replay in order.
+    def part_index(d: Path) -> int:
+        m = re.search(r"_(\d+)$", d.name)
+        return int(m.group(1)) if m else 0
+
+    parts.sort(key=part_index)
+
+    if len(parts) > MAX_BAG_PARTS:
+        die(
+            f"Sequence '{seq_dir.name}' has {len(parts)} ros2bag parts, but this "
+            f"script/launch file only supports up to {MAX_BAG_PARTS}. Add more "
+            f"OXFORD_SPIRES_BAG_N slots to lidar_odometry_from_oxford_spires.yaml."
+        )
+
+    return parts
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} /path/to/data/sequences/<sequence-name>/ [additional flags for mola-cli]")
+        sys.exit(1)
+
+    seq_dir = Path(sys.argv[1]).expanduser().resolve()
+    extra_args = sys.argv[2:]
+
+    if not seq_dir.is_dir():
+        die(f"'{seq_dir}' is not a directory.")
+
+    parts = find_bag_parts(seq_dir)
+    print(f"Sequence '{seq_dir.name}': found {len(parts)} ros2bag part(s):", file=sys.stderr)
+    for p in parts:
+        print(f"  - {p}", file=sys.stderr)
+
+    script_dir = Path(__file__).resolve().parent
+
+    launchs_dir = script_dir.parent / "mola-cli-launchs"
+    installed_launchs_dir = script_dir.parent / "share" / "mola_lidar_odometry" / "mola-cli-launchs"
+    if installed_launchs_dir.is_dir():
+        launchs_dir = installed_launchs_dir
+
+    launch_yaml = launchs_dir / "lidar_odometry_from_oxford_spires.yaml"
+    if not launch_yaml.is_file():
+        die(f"Launch file not found: '{launch_yaml}'")
+
+    env = os.environ.copy()
+    for i, part in enumerate(parts):
+        env[f"OXFORD_SPIRES_BAG_{i}"] = str(part)
+
+    # Handheld/backpack platform (VILENS): lean on the IMU for the initial
+    # pitch/roll estimate and for deskewing, same as the ConSLAM wrapper.
+    # The Alphasense IMU does not publish an onboard-fused orientation (its
+    # Imu messages carry an all-zero quaternion), so the pitch/roll
+    # initializer automatically falls back to leveling from raw accelerometer
+    # readings (see mola_imu_preintegration's ImuInitialCalibrator).
+    env.setdefault("MOLA_LO_INITIAL_LOCALIZATION_METHOD", "InitLocalization::PitchAndRollFromIMU")
+    env.setdefault("MOLA_DESKEW_METHOD", "MotionCompensationMethod::IMU")
+
+    os.execvpe("mola-cli", ["mola-cli", str(launch_yaml), *extra_args], env)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mola-lo-gui-oxford-spires
+++ b/scripts/mola-lo-gui-oxford-spires
@@ -89,8 +89,11 @@ def main() -> None:
         die(f"Launch file not found: '{launch_yaml}'")
 
     env = os.environ.copy()
-    for i, part in enumerate(parts):
-        env[f"OXFORD_SPIRES_BAG_{i}"] = str(part)
+    # Set every slot (not just the ones we have parts for): otherwise a
+    # OXFORD_SPIRES_BAG_N the user left exported from a previous run would
+    # leak through os.environ.copy() and get appended as a stale extra part.
+    for i in range(MAX_BAG_PARTS):
+        env[f"OXFORD_SPIRES_BAG_{i}"] = str(parts[i]) if i < len(parts) else ""
 
     # Handheld/backpack platform (VILENS): lean on the IMU for the initial
     # pitch/roll estimate and for deskewing, same as the ConSLAM wrapper.


### PR DESCRIPTION
## Summary
- Adds `mola-cli-launchs/lidar_odometry_from_oxford_spires.yaml`: LiDAR/IMU/camera topics and fixed extrinsics for the [Oxford Spires dataset](https://dynamic.robots.ox.ac.uk/datasets/oxford-spires), derived from the dataset's own `cam-lidar-imu.yaml` calibration (verified bit-exact against its explicit `T_cam_lidar` matrices). Hesai LiDAR is used as the reference frame; the forward-facing camera (cam2) is enabled by default for GUI preview, with cam0/cam1 present but commented out.
- Adds `scripts/mola-lo-gui-oxford-spires`, a Python wrapper taking a single sequence directory (e.g. `.../data/sequences/2024-03-12-keble-college-01/`) and auto-discovering/stitching multipart ros2bag recordings, using `Rosbag2Dataset`'s existing multi-file `rosbag_filename` support (no changes needed there).

## Dependencies
This dataset's cameras publish `sensor_msgs/msg/CompressedImage`, and its IMU ships an orientation-less (all-zero quaternion) message. Both are needed for a full, error-free run:
- MOLAorg/mola#178 (CompressedImage decoding in `mola_input_rosbag2`)
- MOLAorg/mola_imu_preintegration#11 (drop all-zero orientation quaternions instead of aborting)

## Test plan
- [x] `colcon build --packages-select mola_lidar_odometry` (Release)
- [x] Headless smoke test on a 3-part multipart sequence (`2024-03-12-keble-college-01`): all parts stitched in order, LiDAR/IMU/camera streaming, ICP + local-map updates running, zero errors
- [x] Headless smoke test on a single-part sequence (`2024-07-09-new-college-01`): zero errors
- [x] Verified script error handling for a missing/invalid sequence path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a convenient launcher for replaying Oxford Spires LiDAR datasets with GUI visualization.
  * Added support for multipart rosbag datasets, automatic segment discovery, and configurable playback and localization settings.
  * Added LiDAR odometry and state estimation configuration for the Oxford Spires sequence.

* **Chores**
  * Included the Oxford Spires launcher in installed GUI demo tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->