### PR TITLE
Share the keyframe-creation policy, and let it consider time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ find_package(mola_imu_preintegration REQUIRED)
 # define lib:
 set(LIB_SRCS
   module/src/GravityMapAligner.cpp
+  module/src/KeyframeDecider.cpp
   module/src/TrajectoryRebaker.cpp
   module/src/LidarOdometry_Main.cpp
   module/src/LidarOdometry_Relocalization.cpp

--- a/agents.md
+++ b/agents.md
@@ -168,8 +168,13 @@ SharedKeyframeMap sink). `Parameters::MapUpdateOptions` and
 its fields stay plain, non-nested YAML keys of their sections; both are loaded
 by `Parameters::load_keyframe_policy()`, which lives on `Parameters` because
 the two distance thresholds may be formulas that must register into its
-dynamic-parameter pool. Options are passed to `check()` per call, never held,
-so those formulas are re-evaluated every scan.
+dynamic-parameter pool. The two distance thresholds are passed to `check()` per
+call, never held, so those formulas are re-evaluated every scan. The two policy
+SELECTORS (`measure_from_last_kf_only`, `nearby_keyframe_time_window`) are
+instead read once, by the constructor, which takes the whole options struct:
+they pick which of the two mutually exclusive storages the decider maintains
+(the `SearchablePoseList` KD-tree, or the in-window deque), so they cannot be
+per-scan formulas. `check()` asserts the window did not change afterwards.
 
 `nearby_keyframe_time_window` [s] (`MOLA_SIMPLEMAP_KF_TIME_WINDOW`, default 0 =
 disabled) bounds how far BACK IN TIME the redundancy test reaches. With the
@@ -182,6 +187,11 @@ window, only keyframes newer than that take part in the test (plus the most
 recent one ALWAYS, so a parked vehicle does not emit one keyframe per window),
 and a revisit spawns fresh keyframes. Enable it on the simplemap, not the local
 map. `test/test_keyframe_decider.cpp` covers both regimes.
+
+Under the window, the in-window deque is the ONLY store (the KD-tree is not
+even fed), it is scanned newest-first and left as soon as
+`min_nearby_poses_occupied` matches, and `insert()` clamps non-monotonic
+timestamps so the time-ordered pruning stays valid.
 
 ## Non-repetitive (solid-state) LiDARs (e.g. Livox AVIA)
 

--- a/agents.md
+++ b/agents.md
@@ -85,7 +85,8 @@ never have a sink.
 
 When present, `pushKeyframeToSharedKeyframeMap()`
 (`LidarOdometry_ProcessScan.cpp`) pushes a SPARSE keyframe at the exact same
-`distance_enough_sm` criterion as the self-written simplemap, but
+`distance_enough_sm` criterion as the self-written simplemap (see the shared
+keyframe policy below), but
 INDEPENDENTLY of whether `params_.simplemap.generate` is set (the underlying
 distance-checker's `insert()` is now driven by `pushToSharedKeyframeMapNow`
 too, not just `updateSimpleMap` -- this was a real bug, see below). It uses
@@ -153,6 +154,34 @@ defaults let that gap grow large enough that once the search window finally
 reopened, ICP locked onto a self-consistent but WRONG registration (a
 sudden ~30-40 deg yaw error that then persisted for the rest of the run,
 instead of a brief quality dip that recovers to the true pose).
+
+
+## Keyframe-creation policy (shared by local map and simplemap)
+
+`mola::KeyframeDecider` + `mola::KeyframeDecisionOptions`
+(`KeyframeDecider.{h,cpp}`) hold the single "is this pose far enough from the
+existing keyframes to warrant a new one?" policy. There are TWO instances,
+tuned independently: `state_.kf_decider_local_map` (local metric map) and
+`state_.kf_decider_simplemap` (the simplemap, which is also what feeds a
+SharedKeyframeMap sink). `Parameters::MapUpdateOptions` and
+`Parameters::SimpleMapOptions` both DERIVE from `KeyframeDecisionOptions`, so
+its fields stay plain, non-nested YAML keys of their sections; both are loaded
+by `Parameters::load_keyframe_policy()`, which lives on `Parameters` because
+the two distance thresholds may be formulas that must register into its
+dynamic-parameter pool. Options are passed to `check()` per call, never held,
+so those formulas are re-evaluated every scan.
+
+`nearby_keyframe_time_window` [s] (`MOLA_SIMPLEMAP_KF_TIME_WINDOW`, default 0 =
+disabled) bounds how far BACK IN TIME the redundancy test reaches. With the
+purely spatial default, revisiting a mapped area creates NO keyframes, since
+the previous pass' ones are the nearest neighbors. That is right for the local
+map (a revisit adds no coverage) but starves loop closure, which can only
+detect a loop whose BOTH endpoints exist as keyframes -- so the revisit that
+should close the loop produces nothing to close it with. With a positive
+window, only keyframes newer than that take part in the test (plus the most
+recent one ALWAYS, so a parked vehicle does not emit one keyframe per window),
+and a revisit spawns fresh keyframes. Enable it on the simplemap, not the local
+map. `test/test_keyframe_decider.cpp` covers both regimes.
 
 ## Non-repetitive (solid-state) LiDARs (e.g. Livox AVIA)
 

--- a/module/include/mola_lidar_odometry/KeyframeDecider.h
+++ b/module/include/mola_lidar_odometry/KeyframeDecider.h
@@ -1,0 +1,125 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+/**
+ * @file   KeyframeDecider.h
+ * @brief  Shared "should a new keyframe be created here?" policy
+ * @author Jose Luis Blanco Claraco
+ */
+#pragma once
+
+#include <mola_pose_list/SearchablePoseList.h>
+#include <mrpt/poses/CPose3D.h>
+
+#include <cstdint>
+
+namespace mola
+{
+/** Options of the keyframe-creation policy shared by the local metric map and
+ *  the simplemap / central-mapper keyframe deciders.
+ *
+ *  Both `Parameters::MapUpdateOptions` and `Parameters::SimpleMapOptions`
+ *  derive from this struct, so all fields keep being plain, non-nested YAML
+ *  keys of their respective sections.
+ *
+ * \ingroup mola_lidar_odometry_grp
+ */
+struct KeyframeDecisionOptions
+{
+  /** Minimum Euclidean distance (x,y,z) between keyframes [meters]. */
+  double min_translation_between_keyframes = 1.0;
+
+  /** Minimum rotation (in 3D space, yaw, pitch, roll altogether) between
+   *  keyframes [degrees]. */
+  double min_rotation_between_keyframes = 30.0;
+
+  /** If true, only the distance to the LAST keyframe is considered.
+   *  Use if mostly mapping without "closed loops".
+   *
+   *  If false (default), a KD-tree is used to check the distance to *all*
+   *  past keyframe poses.
+   */
+  bool measure_from_last_kf_only = false;
+
+  /** Minimum number of stored poses within the threshold distance before a
+   *  volume is considered "occupied" and no new keyframe is inserted there.
+   *  Default=1 gives the classic behavior. Increase to 2+ for
+   *  non-repetitive-scan lidars (e.g. Livox) so multiple scans are taken from
+   *  each location.
+   */
+  uint32_t min_nearby_poses_occupied = 1;
+
+  // Loaded by LidarOdometry::Parameters::load_keyframe_policy(), which owns
+  // the dynamic-expression parameter pool the distance thresholds register
+  // into. All fields live as plain (non-nested) keys of their YAML section.
+};
+
+/** Decides whether a new keyframe should be created at a given pose, and
+ *  stores the poses of those already created.
+ *
+ *  One instance exists per "map" whose keyframe density is governed
+ *  independently (the local metric map, and the simplemap / central-mapper
+ *  keyframe backbone), each with its own KeyframeDecisionOptions.
+ *
+ *  The options are passed in at every check() call rather than held: they may
+ *  be dynamic expressions (e.g. a distance that shrinks with angular
+ *  velocity), re-evaluated by mp2p_icp::Parameterizable before each scan.
+ *
+ * \ingroup mola_lidar_odometry_grp
+ */
+class KeyframeDecider
+{
+public:
+  KeyframeDecider() = default;
+
+  explicit KeyframeDecider(bool measure_from_last_kf_only) : poses_(measure_from_last_kf_only) {}
+
+  struct Decision
+  {
+    /** Whether a new keyframe should be created at the queried pose. */
+    bool create = false;
+
+    /** Translational distance to the closest existing keyframe [m]
+     *  (0 if there is none yet). For logging/diagnostics. */
+    double translation = 0;
+
+    /** Rotational distance to the closest existing keyframe [rad]
+     *  (0 if there is none yet). For logging/diagnostics. */
+    double rotation = 0;
+  };
+
+  /** Evaluates the policy for a candidate keyframe pose. Does NOT modify the
+   *  stored poses; call insert() if the keyframe is actually created.
+   */
+  [[nodiscard]] Decision check(
+    const KeyframeDecisionOptions & opts, const mrpt::poses::CPose3D & pose) const;
+
+  /** Stores an actually-created keyframe pose. */
+  void insert(const mrpt::poses::CPose3D & pose);
+
+  /** Drops stored poses farther than the given distance (local map cleanup) */
+  void removeAllFartherThan(const mrpt::poses::CPose3D & pose, double maxTranslation);
+
+  [[nodiscard]] size_t size() const { return poses_.size(); }
+
+  [[nodiscard]] bool empty() const { return poses_.empty(); }
+
+private:
+  /** All stored keyframe poses (KD-tree searchable). */
+  SearchablePoseList poses_;
+};
+
+}  // namespace mola
+
+/** Feature macro: the keyframe-creation policy is shared between the local map
+ *  and simplemap deciders (mola::KeyframeDecider).
+ */
+#define MOLA_LO_HAS_KEYFRAME_DECIDER 1

--- a/module/include/mola_lidar_odometry/KeyframeDecider.h
+++ b/module/include/mola_lidar_odometry/KeyframeDecider.h
@@ -126,7 +126,8 @@ public:
     double timestamp) const;
 
   /** Stores an actually-created keyframe pose. */
-  void insert(const mrpt::poses::CPose3D & pose, double timestamp);
+  void insert(
+    const KeyframeDecisionOptions & opts, const mrpt::poses::CPose3D & pose, double timestamp);
 
   /** Drops stored poses farther than the given distance (local map cleanup) */
   void removeAllFartherThan(const mrpt::poses::CPose3D & pose, double maxTranslation);
@@ -139,9 +140,9 @@ private:
   /** All stored keyframe poses (KD-tree searchable). */
   SearchablePoseList poses_;
 
-  /** Keyframes within the time window, oldest first. Only maintained (and
-   *  only non-empty) while `nearby_keyframe_time_window` is enabled. The
-   *  newest entry is never dropped, whatever its age. */
+  /** Keyframes within the time window, oldest first. Only fed by insert()
+   *  while `nearby_keyframe_time_window` is enabled, since nothing prunes it
+   *  otherwise. The newest entry is never dropped, whatever its age. */
   mutable std::deque<std::pair<double, mrpt::poses::CPose3D>> recent_;
 
   /** Drops entries older than the window, always keeping the newest one. */

--- a/module/include/mola_lidar_odometry/KeyframeDecider.h
+++ b/module/include/mola_lidar_odometry/KeyframeDecider.h
@@ -20,6 +20,8 @@
 #include <mrpt/poses/CPose3D.h>
 
 #include <cstdint>
+#include <deque>
+#include <utility>
 
 namespace mola
 {
@@ -45,7 +47,8 @@ struct KeyframeDecisionOptions
    *  Use if mostly mapping without "closed loops".
    *
    *  If false (default), a KD-tree is used to check the distance to *all*
-   *  past keyframe poses.
+   *  past keyframe poses. See also nearby_keyframe_time_window, which bounds
+   *  how far back in time that search reaches.
    */
   bool measure_from_last_kf_only = false;
 
@@ -56,6 +59,23 @@ struct KeyframeDecisionOptions
    *  each location.
    */
   uint32_t min_nearby_poses_occupied = 1;
+
+  /** Time window [seconds] for the "is there already a keyframe here?" test.
+   *  0 (default) disables it: the test then reaches ALL past keyframes.
+   *
+   *  With the default, purely spatial policy, revisiting a mapped area
+   *  creates NO new keyframes, since the previous pass' keyframes are the
+   *  nearest neighbors. That is the desired behavior for a local metric map
+   *  (a revisit adds no coverage), but it starves loop closure: a loop can
+   *  only be detected if BOTH of its endpoints exist as keyframes, so the
+   *  revisit that should close the loop produces nothing to close it with.
+   *
+   *  When set to a positive value, only keyframes newer than this many
+   *  seconds take part in the test (plus the most recent one, always, so a
+   *  stationary vehicle does not emit one keyframe per window). Older
+   *  keyframes become invisible to it, so a revisit spawns fresh keyframes.
+   */
+  double nearby_keyframe_time_window = 0;
 
   // Loaded by LidarOdometry::Parameters::load_keyframe_policy(), which owns
   // the dynamic-expression parameter pool the distance thresholds register
@@ -98,12 +118,15 @@ public:
 
   /** Evaluates the policy for a candidate keyframe pose. Does NOT modify the
    *  stored poses; call insert() if the keyframe is actually created.
+   *  \param timestamp Observation timestamp [s], only used if
+   *         `opts.nearby_keyframe_time_window` is enabled.
    */
   [[nodiscard]] Decision check(
-    const KeyframeDecisionOptions & opts, const mrpt::poses::CPose3D & pose) const;
+    const KeyframeDecisionOptions & opts, const mrpt::poses::CPose3D & pose,
+    double timestamp) const;
 
   /** Stores an actually-created keyframe pose. */
-  void insert(const mrpt::poses::CPose3D & pose);
+  void insert(const mrpt::poses::CPose3D & pose, double timestamp);
 
   /** Drops stored poses farther than the given distance (local map cleanup) */
   void removeAllFartherThan(const mrpt::poses::CPose3D & pose, double maxTranslation);
@@ -115,11 +138,20 @@ public:
 private:
   /** All stored keyframe poses (KD-tree searchable). */
   SearchablePoseList poses_;
+
+  /** Keyframes within the time window, oldest first. Only maintained (and
+   *  only non-empty) while `nearby_keyframe_time_window` is enabled. The
+   *  newest entry is never dropped, whatever its age. */
+  mutable std::deque<std::pair<double, mrpt::poses::CPose3D>> recent_;
+
+  /** Drops entries older than the window, always keeping the newest one. */
+  void prune_recent(double now, double window) const;
 };
 
 }  // namespace mola
 
 /** Feature macro: the keyframe-creation policy is shared between the local map
- *  and simplemap deciders (mola::KeyframeDecider).
+ *  and simplemap deciders (mola::KeyframeDecider) and supports a temporal
+ *  window (`nearby_keyframe_time_window`).
  */
 #define MOLA_LO_HAS_KEYFRAME_DECIDER 1

--- a/module/include/mola_lidar_odometry/KeyframeDecider.h
+++ b/module/include/mola_lidar_odometry/KeyframeDecider.h
@@ -48,7 +48,9 @@ struct KeyframeDecisionOptions
    *
    *  If false (default), a KD-tree is used to check the distance to *all*
    *  past keyframe poses. See also nearby_keyframe_time_window, which bounds
-   *  how far back in time that search reaches.
+   *  how far back in time that search reaches. Combining both is allowed but
+   *  redundant: the last keyframe is always inside the window, so the window
+   *  has no additional effect.
    */
   bool measure_from_last_kf_only = false;
 
@@ -74,6 +76,10 @@ struct KeyframeDecisionOptions
    *  seconds take part in the test (plus the most recent one, always, so a
    *  stationary vehicle does not emit one keyframe per window). Older
    *  keyframes become invisible to it, so a revisit spawns fresh keyframes.
+   *
+   *  Read once, at KeyframeDecider construction time: unlike the two distance
+   *  thresholds, this one cannot be a per-scan dynamic expression, since it
+   *  selects which of the two policies (and which storage) the decider uses.
    */
   double nearby_keyframe_time_window = 0;
 
@@ -89,64 +95,94 @@ struct KeyframeDecisionOptions
  *  independently (the local metric map, and the simplemap / central-mapper
  *  keyframe backbone), each with its own KeyframeDecisionOptions.
  *
- *  The options are passed in at every check() call rather than held: they may
- *  be dynamic expressions (e.g. a distance that shrinks with angular
- *  velocity), re-evaluated by mp2p_icp::Parameterizable before each scan.
+ *  The two distance thresholds are passed in at every check() call rather than
+ *  held: they may be dynamic expressions (e.g. a distance that shrinks with
+ *  angular velocity), re-evaluated by mp2p_icp::Parameterizable before each
+ *  scan. The two policy *selectors* (`measure_from_last_kf_only` and
+ *  `nearby_keyframe_time_window`) are instead read once, by the constructor,
+ *  and pick which of the two mutually exclusive storages is maintained.
  *
  * \ingroup mola_lidar_odometry_grp
  */
 class KeyframeDecider
 {
 public:
-  KeyframeDecider() = default;
-
-  explicit KeyframeDecider(bool measure_from_last_kf_only) : poses_(measure_from_last_kf_only) {}
+  /** There is no default constructor on purpose: the options select which
+   *  policy, and which storage, the instance uses for its whole lifetime. */
+  explicit KeyframeDecider(const KeyframeDecisionOptions & opts)
+  : poses_(opts.measure_from_last_kf_only),
+    from_last_only_(opts.measure_from_last_kf_only),
+    temporal_(opts.nearby_keyframe_time_window > 0)
+  {
+  }
 
   struct Decision
   {
     /** Whether a new keyframe should be created at the queried pose. */
     bool create = false;
 
-    /** Translational distance to the closest existing keyframe [m]
+    /** Translational distance to the reference keyframe [m]: the closest one
+     *  under the spatial policy, the newest one under the temporal policy
      *  (0 if there is none yet). For logging/diagnostics. */
     double translation = 0;
 
-    /** Rotational distance to the closest existing keyframe [rad]
+    /** Rotational distance to that same reference keyframe [rad]
      *  (0 if there is none yet). For logging/diagnostics. */
     double rotation = 0;
   };
 
-  /** Evaluates the policy for a candidate keyframe pose. Does NOT modify the
-   *  stored poses; call insert() if the keyframe is actually created.
-   *  \param timestamp Observation timestamp [s], only used if
-   *         `opts.nearby_keyframe_time_window` is enabled.
+  /** Evaluates the policy for a candidate keyframe pose. Does NOT store the
+   *  queried pose; call insert() if the keyframe is actually created (it does
+   *  drop stored poses that fell out of the time window, though).
+   *  \param timestamp Observation timestamp [s], only used under the temporal
+   *         policy.
    */
   [[nodiscard]] Decision check(
-    const KeyframeDecisionOptions & opts, const mrpt::poses::CPose3D & pose,
-    double timestamp) const;
+    const KeyframeDecisionOptions & opts, const mrpt::poses::CPose3D & pose, double timestamp);
 
   /** Stores an actually-created keyframe pose. */
-  void insert(
-    const KeyframeDecisionOptions & opts, const mrpt::poses::CPose3D & pose, double timestamp);
+  void insert(const mrpt::poses::CPose3D & pose, double timestamp);
 
   /** Drops stored poses farther than the given distance (local map cleanup) */
   void removeAllFartherThan(const mrpt::poses::CPose3D & pose, double maxTranslation);
 
-  [[nodiscard]] size_t size() const { return poses_.size(); }
+  /** Number of keyframes created so far (minus those dropped by
+   *  removeAllFartherThan). This is what the GUI reports: under the temporal
+   *  policy, keyframes that aged out of the window still count, since they
+   *  remain in the map and merely stopped taking part in the decision. */
+  [[nodiscard]] size_t size() const { return temporal_ ? created_ : poses_.size(); }
 
-  [[nodiscard]] bool empty() const { return poses_.empty(); }
+  [[nodiscard]] bool empty() const { return size() == 0; }
+
+  /** Number of keyframes currently taking part in the decision, i.e. those
+   *  inside the time window under the temporal policy. Equals size() under the
+   *  spatial one. */
+  [[nodiscard]] size_t activeSize() const { return temporal_ ? recent_.size() : poses_.size(); }
 
 private:
-  /** All stored keyframe poses (KD-tree searchable). */
+  using Entry = std::pair<double /*timestamp*/, mrpt::poses::CPose3D>;
+
+  /** Keyframe poses under the spatial policy (KD-tree searchable).
+   *  Left empty, and never queried, while `temporal_` is set. */
   SearchablePoseList poses_;
 
-  /** Keyframes within the time window, oldest first. Only fed by insert()
-   *  while `nearby_keyframe_time_window` is enabled, since nothing prunes it
-   *  otherwise. The newest entry is never dropped, whatever its age. */
-  mutable std::deque<std::pair<double, mrpt::poses::CPose3D>> recent_;
+  /** Keyframe poses under the temporal policy, oldest first. Left empty, and
+   *  never queried, unless `temporal_` is set. The newest entry is never
+   *  dropped, whatever its age. */
+  std::deque<Entry> recent_;
+
+  bool from_last_only_ = false;
+
+  /** Keyframes created, tracked only under the temporal policy (under the
+   *  spatial one `poses_` already holds them all). See size(). */
+  size_t created_ = 0;
+
+  /** Whether the temporal policy (and hence `recent_`) is the active one.
+   *  Fixed at construction: see nearby_keyframe_time_window. */
+  bool temporal_ = false;
 
   /** Drops entries older than the window, always keeping the newest one. */
-  void prune_recent(double now, double window) const;
+  void prune_recent(double now, double window);
 };
 
 }  // namespace mola

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -41,7 +41,6 @@
 // Other packages:
 #include <mola_imu_preintegration/ImuInitialCalibrator.h>
 #include <mola_lidar_odometry/KeyframeDecider.h>
-#include <mola_pose_list/SearchablePoseList.h>
 
 // MP2P_ICP
 #include <mp2p_icp/ICP.h>

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -40,6 +40,7 @@
 
 // Other packages:
 #include <mola_imu_preintegration/ImuInitialCalibrator.h>
+#include <mola_lidar_odometry/KeyframeDecider.h>
 #include <mola_pose_list/SearchablePoseList.h>
 
 // MP2P_ICP
@@ -138,6 +139,20 @@ public:
 
   struct Parameters : public mp2p_icp::Parameterizable
   {
+    /** Loads the keyframe-creation policy shared by the local-map and
+         *  simplemap sections. Lives here, and not in KeyframeDecisionOptions
+         *  itself, because the two distance thresholds may be formulas and
+         *  must register into THIS object's dynamic-parameter pool.
+         *  \param section_name Only used in error messages.
+         *  \param distances_required Whether the two distance thresholds must
+         *         be present in the YAML. Kept per-section for backwards
+         *         compatibility: the local-map section demands them, the
+         *         simplemap one defaults them.
+         */
+    void load_keyframe_policy(
+      mola::KeyframeDecisionOptions & o, const Yaml & cfg, const char * section_name,
+      bool distances_required);
+
     /** List of sensor labels or regex's to be matched to input observations
          *  to be used as raw lidar observations.
          */
@@ -188,29 +203,18 @@ public:
 
     MultipleLidarOptions multiple_lidars;
 
-    struct MapUpdateOptions
+    /** Keyframe-creation policy for the LOCAL METRIC MAP. The distance
+         * thresholds and the occupancy count come from
+         * mola::KeyframeDecisionOptions, shared with SimpleMapOptions;
+         * they stay plain (non-nested) YAML keys of the `local_map_updates`
+         * section.
+         */
+    struct MapUpdateOptions : public mola::KeyframeDecisionOptions
     {
       /** If set to false, the odometry system can be used as
              * localization-only.
              */
       bool enabled = true;
-
-      /** Minimum Euclidean distance (x,y,z) between keyframes inserted
-             * into the local map [meters]. */
-      double min_translation_between_keyframes = 1.0;
-
-      /** Minimum rotation (in 3D space, yaw, pitch,roll, altogether)
-             * between keyframes inserted into
-             * the local map [in degrees]. */
-      double min_rotation_between_keyframes = 30.0;
-
-      /** If true, distance from the last map update are only considered.
-             * Use if mostly mapping without "closed loops".
-             *
-             *  If false (default), a KD-tree will be used to check the distance
-             * to *all* past map insert poses.
-             */
-      bool measure_from_last_kf_only = false;
 
       /** Should match the "remove farther than" option of the local
              * metric map. 0 means deletion of distant keyframes is disabled.
@@ -222,14 +226,6 @@ public:
              * how often to do the distant keyframes clean up.
              */
       uint32_t check_for_removal_every_n = 100;
-
-      /** Minimum number of stored poses within the threshold distance
-             *  before a volume is considered "occupied" and no new keyframe
-             *  is inserted there. Default=1 gives the classic behavior.
-             *  Increase to 2+ for non-repetitive-scan lidars (e.g. Livox)
-             *  so multiple scans are taken from each location.
-             */
-      uint32_t min_nearby_poses_occupied = 1;
 
       /** Publish updated map via mola::MapSourceBase once every N frames
              */
@@ -419,26 +415,15 @@ public:
     std::map<AlignKind, ICP_case> icp;
 
     // === SIMPLEMAP GENERATION ====
-    struct SimpleMapOptions
+    /** Keyframe-creation policy for the SIMPLEMAP, which is also the one
+         * pushed to a mola::SharedKeyframeMap sink (the central mapper's
+         * keyframe backbone). Same shared policy as MapUpdateOptions, but
+         * tuned independently: unlike the local map, this one feeds loop
+         * closure.
+         */
+    struct SimpleMapOptions : public mola::KeyframeDecisionOptions
     {
       bool generate = false;
-
-      /** Minimum Euclidean distance (x,y,z) between keyframes inserted
-             * into the simplemap [meters]. */
-      double min_translation_between_keyframes = 1.0;
-
-      /** Minimum rotation (in 3D space, yaw, pitch,roll, altogether)
-             * between keyframes inserted into
-             * the map [in degrees]. */
-      double min_rotation_between_keyframes = 30.0;
-
-      /** If true, distance from the last map update are only considered.
-             * Use if mostly mapping without "closed loops".
-             *
-             *  If false (default), a KD-tree will be used to check the distance
-             * to *all* past map insert poses.
-             */
-      bool measure_from_last_kf_only = false;
 
       /** If not empty, the final simple map will be dumped to a file at
              * destruction time */
@@ -470,13 +455,6 @@ public:
 
       /** If enabled, saved keyframes will contain an additional 'deskewed' observation with the motion-compensated cloud. */
       bool save_deskewed_scans = false;
-
-      /** Minimum number of stored poses within the threshold distance
-             *  before a volume is considered "occupied" and no new keyframe
-             *  is inserted there. Default=1 gives the classic behavior.
-             *  Increase to 2+ for non-repetitive-scan lidars (e.g. Livox).
-             */
-      uint32_t min_nearby_poses_occupied = 1;
 
       void initialize(const Yaml & c, Parameters & parent);
     };
@@ -932,8 +910,8 @@ private:
 
     // to check for map updates. Defined as optional<> so we enforce
     // setting their type in the ctor:
-    std::optional<SearchablePoseList> distance_checker_local_map;
-    std::optional<SearchablePoseList> distance_checker_simplemap;
+    std::optional<KeyframeDecider> kf_decider_local_map;
+    std::optional<KeyframeDecider> kf_decider_simplemap;
 
     /// See check_for_removal_every_n
     uint32_t localmap_check_removal_counter = 0;

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -204,8 +204,8 @@ public:
     MultipleLidarOptions multiple_lidars;
 
     /** Keyframe-creation policy for the LOCAL METRIC MAP. The distance
-         * thresholds and the occupancy count come from
-         * mola::KeyframeDecisionOptions, shared with SimpleMapOptions;
+         * thresholds, the occupancy count and the temporal window all come
+         * from mola::KeyframeDecisionOptions, shared with SimpleMapOptions;
          * they stay plain (non-nested) YAML keys of the `local_map_updates`
          * section.
          */
@@ -419,7 +419,8 @@ public:
          * pushed to a mola::SharedKeyframeMap sink (the central mapper's
          * keyframe backbone). Same shared policy as MapUpdateOptions, but
          * tuned independently: unlike the local map, this one feeds loop
-         * closure.
+         * closure, so it is the one that usually wants
+         * `nearby_keyframe_time_window` enabled.
          */
     struct SimpleMapOptions : public mola::KeyframeDecisionOptions
     {

--- a/module/src/KeyframeDecider.cpp
+++ b/module/src/KeyframeDecider.cpp
@@ -18,19 +18,75 @@
 #include <mola_lidar_odometry/KeyframeDecider.h>
 #include <mrpt/poses/Lie/SO.h>
 
+#include <optional>
+
 namespace mola
 {
 
+namespace
+{
+/** Translational and rotational distance of `p` with respect to `ref`. */
+std::pair<double, double> pose_distance(
+  const mrpt::poses::CPose3D & p, const mrpt::poses::CPose3D & ref)
+{
+  const mrpt::poses::CPose3D delta = p - ref;
+  return {delta.norm(), mrpt::poses::Lie::SO<3>::log(delta.getRotationMatrix()).norm()};
+}
+}  // namespace
+
+void KeyframeDecider::prune_recent(double now, double window) const
+{
+  // Always keep the newest entry, whatever its age: otherwise a stationary
+  // vehicle would emit one keyframe per window once its last one ages out.
+  while (recent_.size() > 1 && (now - recent_.front().first) > window) {
+    recent_.pop_front();
+  }
+}
+
 KeyframeDecider::Decision KeyframeDecider::check(
-  const KeyframeDecisionOptions & opts, const mrpt::poses::CPose3D & pose) const
+  const KeyframeDecisionOptions & opts, const mrpt::poses::CPose3D & pose, double timestamp) const
 {
   Decision d;
 
   const double maxTranslation = opts.min_translation_between_keyframes;
   const double maxRotation = mrpt::DEG2RAD(opts.min_rotation_between_keyframes);
 
-  // Distance to the closest keyframe ever created (or just to the last one,
-  // if measure_from_last_kf_only).
+  // Temporal policy: only recent keyframes take part in the test, so
+  // revisiting a mapped area does create new keyframes (needed by loop
+  // closure to have both endpoints of a loop).
+  if (opts.nearby_keyframe_time_window > 0) {
+    prune_recent(timestamp, opts.nearby_keyframe_time_window);
+
+    if (recent_.empty()) {
+      d.create = true;
+      return d;
+    }
+
+    // The window holds a handful of entries, so a linear scan is cheaper
+    // than any spatial index:
+    bool anyNearby = false;
+    std::optional<double> closestTranslation;
+
+    for (const auto & [t, p] : recent_) {
+      const auto [dist, rot] = pose_distance(pose, p);
+
+      if (!closestTranslation.has_value() || dist < *closestTranslation) {
+        closestTranslation = dist;
+        d.translation = dist;
+        d.rotation = rot;
+      }
+
+      if (dist <= maxTranslation && rot <= maxRotation) {
+        anyNearby = true;
+      }
+    }
+
+    d.create = !anyNearby;
+    return d;
+  }
+
+  // Classic, purely spatial policy: distance to the closest keyframe ever
+  // created (or just to the last one, if measure_from_last_kf_only).
   const auto [isFirstPose, distanceToClosest] = poses_.check(pose);
 
   d.translation = distanceToClosest.norm();
@@ -55,7 +111,11 @@ KeyframeDecider::Decision KeyframeDecider::check(
   return d;
 }
 
-void KeyframeDecider::insert(const mrpt::poses::CPose3D & pose) { poses_.insert(pose); }
+void KeyframeDecider::insert(const mrpt::poses::CPose3D & pose, double timestamp)
+{
+  poses_.insert(pose);
+  recent_.emplace_back(timestamp, pose);
+}
 
 void KeyframeDecider::removeAllFartherThan(const mrpt::poses::CPose3D & pose, double maxTranslation)
 {

--- a/module/src/KeyframeDecider.cpp
+++ b/module/src/KeyframeDecider.cpp
@@ -18,6 +18,7 @@
 #include <mola_lidar_odometry/KeyframeDecider.h>
 #include <mrpt/poses/Lie/SO.h>
 
+#include <algorithm>
 #include <optional>
 
 namespace mola
@@ -63,8 +64,9 @@ KeyframeDecider::Decision KeyframeDecider::check(
     }
 
     // The window holds a handful of entries, so a linear scan is cheaper
-    // than any spatial index:
-    bool anyNearby = false;
+    // than any spatial index. It doubles as the "occupied volume" count, so
+    // min_nearby_poses_occupied keeps working under the temporal policy:
+    uint32_t nearbyCount = 0;
     std::optional<double> closestTranslation;
 
     for (const auto & [t, p] : recent_) {
@@ -77,11 +79,13 @@ KeyframeDecider::Decision KeyframeDecider::check(
       }
 
       if (dist <= maxTranslation && rot <= maxRotation) {
-        anyNearby = true;
+        nearbyCount++;
       }
     }
 
-    d.create = !anyNearby;
+    // With the default min_nearby_poses_occupied=1 this is just "no recent
+    // keyframe is nearby".
+    d.create = nearbyCount < std::max<uint32_t>(1, opts.min_nearby_poses_occupied);
     return d;
   }
 
@@ -111,10 +115,16 @@ KeyframeDecider::Decision KeyframeDecider::check(
   return d;
 }
 
-void KeyframeDecider::insert(const mrpt::poses::CPose3D & pose, double timestamp)
+void KeyframeDecider::insert(
+  const KeyframeDecisionOptions & opts, const mrpt::poses::CPose3D & pose, double timestamp)
 {
   poses_.insert(pose);
-  recent_.emplace_back(timestamp, pose);
+
+  // Only maintained while the temporal policy is in use: nothing ever prunes
+  // this deque otherwise, and it would grow for the whole run to no purpose.
+  if (opts.nearby_keyframe_time_window > 0) {
+    recent_.emplace_back(timestamp, pose);
+  }
 }
 
 void KeyframeDecider::removeAllFartherThan(const mrpt::poses::CPose3D & pose, double maxTranslation)

--- a/module/src/KeyframeDecider.cpp
+++ b/module/src/KeyframeDecider.cpp
@@ -1,0 +1,65 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+/**
+ * @file   KeyframeDecider.cpp
+ * @brief  Shared "should a new keyframe be created here?" policy
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include <mola_lidar_odometry/KeyframeDecider.h>
+#include <mrpt/poses/Lie/SO.h>
+
+namespace mola
+{
+
+KeyframeDecider::Decision KeyframeDecider::check(
+  const KeyframeDecisionOptions & opts, const mrpt::poses::CPose3D & pose) const
+{
+  Decision d;
+
+  const double maxTranslation = opts.min_translation_between_keyframes;
+  const double maxRotation = mrpt::DEG2RAD(opts.min_rotation_between_keyframes);
+
+  // Distance to the closest keyframe ever created (or just to the last one,
+  // if measure_from_last_kf_only).
+  const auto [isFirstPose, distanceToClosest] = poses_.check(pose);
+
+  d.translation = distanceToClosest.norm();
+  d.rotation = mrpt::poses::Lie::SO<3>::log(distanceToClosest.getRotationMatrix()).norm();
+
+  d.create = isFirstPose || d.translation > maxTranslation || d.rotation > maxRotation;
+
+#if defined(MOLA_POSE_LIST_HAS_KFM_POSE_PLUMBING)
+  // A volume is only "occupied" once enough keyframes were taken from it.
+  // Used by non-repetitive-scan lidars, which need several scans per spot.
+  if (!d.create && opts.min_nearby_poses_occupied > 1) {
+    const uint32_t nearbyCount = poses_.countNearby(pose, maxTranslation, maxRotation);
+    if (nearbyCount < opts.min_nearby_poses_occupied) {
+      d.create = true;
+    }
+  }
+#else
+  // Older mola_pose_list: countNearby() unavailable, min_nearby_poses_occupied
+  // has no effect.
+#endif
+
+  return d;
+}
+
+void KeyframeDecider::insert(const mrpt::poses::CPose3D & pose) { poses_.insert(pose); }
+
+void KeyframeDecider::removeAllFartherThan(const mrpt::poses::CPose3D & pose, double maxTranslation)
+{
+  poses_.removeAllFartherThan(pose, maxTranslation);
+}
+
+}  // namespace mola

--- a/module/src/KeyframeDecider.cpp
+++ b/module/src/KeyframeDecider.cpp
@@ -19,23 +19,21 @@
 #include <mrpt/poses/Lie/SO.h>
 
 #include <algorithm>
-#include <optional>
 
 namespace mola
 {
 
 namespace
 {
-/** Translational and rotational distance of `p` with respect to `ref`. */
-std::pair<double, double> pose_distance(
-  const mrpt::poses::CPose3D & p, const mrpt::poses::CPose3D & ref)
+/** Rotation magnitude of a pose increment [rad]. Markedly costlier than the
+ *  translational norm, so callers should reach it only when needed. */
+double rotation_distance(const mrpt::poses::CPose3D & delta)
 {
-  const mrpt::poses::CPose3D delta = p - ref;
-  return {delta.norm(), mrpt::poses::Lie::SO<3>::log(delta.getRotationMatrix()).norm()};
+  return mrpt::poses::Lie::SO<3>::log(delta.getRotationMatrix()).norm();
 }
 }  // namespace
 
-void KeyframeDecider::prune_recent(double now, double window) const
+void KeyframeDecider::prune_recent(double now, double window)
 {
   // Always keep the newest entry, whatever its age: otherwise a stationary
   // vehicle would emit one keyframe per window once its last one ages out.
@@ -45,8 +43,12 @@ void KeyframeDecider::prune_recent(double now, double window) const
 }
 
 KeyframeDecider::Decision KeyframeDecider::check(
-  const KeyframeDecisionOptions & opts, const mrpt::poses::CPose3D & pose, double timestamp) const
+  const KeyframeDecisionOptions & opts, const mrpt::poses::CPose3D & pose, double timestamp)
 {
+  ASSERTMSG_(
+    temporal_ == (opts.nearby_keyframe_time_window > 0),
+    "nearby_keyframe_time_window must not change after the decider was built");
+
   Decision d;
 
   const double maxTranslation = opts.min_translation_between_keyframes;
@@ -55,7 +57,7 @@ KeyframeDecider::Decision KeyframeDecider::check(
   // Temporal policy: only recent keyframes take part in the test, so
   // revisiting a mapped area does create new keyframes (needed by loop
   // closure to have both endpoints of a loop).
-  if (opts.nearby_keyframe_time_window > 0) {
+  if (temporal_) {
     prune_recent(timestamp, opts.nearby_keyframe_time_window);
 
     if (recent_.empty()) {
@@ -63,29 +65,39 @@ KeyframeDecider::Decision KeyframeDecider::check(
       return d;
     }
 
-    // The window holds a handful of entries, so a linear scan is cheaper
-    // than any spatial index. It doubles as the "occupied volume" count, so
-    // min_nearby_poses_occupied keeps working under the temporal policy:
+    // Diagnostics are reported against the newest keyframe, which is what the
+    // caller logs as "since last KF" (and is O(1), unlike the closest one):
+    {
+      const mrpt::poses::CPose3D delta = pose - recent_.back().second;
+      d.translation = delta.norm();
+      d.rotation = rotation_distance(delta);
+    }
+
+    // Linear scan over the window, newest first: the vehicle is normally
+    // closest to the most recent keyframes, so the count is reached, and the
+    // loop left, after very few iterations. The count doubles as the
+    // "occupied volume" test, so min_nearby_poses_occupied keeps working
+    // under the temporal policy.
+    const uint32_t occupiedCount = std::max<uint32_t>(1, opts.min_nearby_poses_occupied);
     uint32_t nearbyCount = 0;
-    std::optional<double> closestTranslation;
 
-    for (const auto & [t, p] : recent_) {
-      const auto [dist, rot] = pose_distance(pose, p);
+    for (auto it = recent_.rbegin(); it != recent_.rend() && nearbyCount < occupiedCount; ++it) {
+      const mrpt::poses::CPose3D delta = pose - it->second;
 
-      if (!closestTranslation.has_value() || dist < *closestTranslation) {
-        closestTranslation = dist;
-        d.translation = dist;
-        d.rotation = rot;
+      // Cheap test first: only candidates that already passed it are worth
+      // the rotation logarithm.
+      if (delta.norm() > maxTranslation) {
+        continue;
       }
 
-      if (dist <= maxTranslation && rot <= maxRotation) {
+      if (rotation_distance(delta) <= maxRotation) {
         nearbyCount++;
       }
     }
 
     // With the default min_nearby_poses_occupied=1 this is just "no recent
     // keyframe is nearby".
-    d.create = nearbyCount < std::max<uint32_t>(1, opts.min_nearby_poses_occupied);
+    d.create = nearbyCount < occupiedCount;
     return d;
   }
 
@@ -94,7 +106,7 @@ KeyframeDecider::Decision KeyframeDecider::check(
   const auto [isFirstPose, distanceToClosest] = poses_.check(pose);
 
   d.translation = distanceToClosest.norm();
-  d.rotation = mrpt::poses::Lie::SO<3>::log(distanceToClosest.getRotationMatrix()).norm();
+  d.rotation = rotation_distance(distanceToClosest);
 
   d.create = isFirstPose || d.translation > maxTranslation || d.rotation > maxRotation;
 
@@ -115,21 +127,55 @@ KeyframeDecider::Decision KeyframeDecider::check(
   return d;
 }
 
-void KeyframeDecider::insert(
-  const KeyframeDecisionOptions & opts, const mrpt::poses::CPose3D & pose, double timestamp)
+void KeyframeDecider::insert(const mrpt::poses::CPose3D & pose, double timestamp)
 {
-  poses_.insert(pose);
-
-  // Only maintained while the temporal policy is in use: nothing ever prunes
-  // this deque otherwise, and it would grow for the whole run to no purpose.
-  if (opts.nearby_keyframe_time_window > 0) {
-    recent_.emplace_back(timestamp, pose);
+  if (!temporal_) {
+    poses_.insert(pose);
+    return;
   }
+
+  // prune_recent() pops from the front, so the deque must stay sorted in time.
+  // Guard against non-monotonic input (sensor jitter across a multi-lidar
+  // group, replayed or missing timestamps):
+  if (!recent_.empty()) {
+    timestamp = std::max(timestamp, recent_.back().first);
+  }
+
+  // Same semantics as SearchablePoseList's own "last only" mode:
+  if (from_last_only_) {
+    recent_.clear();
+  }
+
+  recent_.emplace_back(timestamp, pose);
+  created_++;
 }
 
 void KeyframeDecider::removeAllFartherThan(const mrpt::poses::CPose3D & pose, double maxTranslation)
 {
-  poses_.removeAllFartherThan(pose, maxTranslation);
+  if (!temporal_) {
+    poses_.removeAllFartherThan(pose, maxTranslation);
+    return;
+  }
+
+  const double maxSqrDist = mrpt::square(maxTranslation);
+  const auto center = pose.translation();
+
+  std::deque<Entry> kept;
+  for (const auto & e : recent_) {
+    if ((e.second.translation() - center).sqrNorm() <= maxSqrDist) {
+      kept.push_back(e);
+    }
+  }
+
+  // Keep the newest entry regardless of distance, as prune_recent() does:
+  if (kept.empty() && !recent_.empty()) {
+    kept.push_back(recent_.back());
+  }
+
+  // Keyframes dropped here are gone for good, so they stop being counted:
+  created_ -= std::min(created_, recent_.size() - kept.size());
+
+  recent_.swap(kept);
 }
 
 }  // namespace mola

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -865,8 +865,8 @@ void LidarOdometry::updateVisualizationTextLabels()
   }
 
   gui_.lbMapStats->set(mrpt::format(
-    "Keyframes: Localmap=%zu, simplemap=%zu", state_.distance_checker_local_map->size(),
-    state_.distance_checker_simplemap->size()));
+    "Keyframes: Localmap=%zu, simplemap=%zu", state_.kf_decider_local_map->size(),
+    state_.kf_decider_simplemap->size()));
 
   if (state_.last_motion_model_output) {
     const auto & tw = state_.last_motion_model_output->twist;

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -864,9 +864,12 @@ void LidarOdometry::updateVisualizationTextLabels()
       "Dropped frames: %5.02f%% (avr queue=%4.02f)", getDropStats() * 100.0, averageLidarQueue));
   }
 
+  // The deciders are created lazily on the first processed scan, while the GUI
+  // may refresh before that (or while initial localization is still pending):
   gui_.lbMapStats->set(mrpt::format(
-    "Keyframes: Localmap=%zu, simplemap=%zu", state_.kf_decider_local_map->size(),
-    state_.kf_decider_simplemap->size()));
+    "Keyframes: Localmap=%zu, simplemap=%zu",
+    state_.kf_decider_local_map ? state_.kf_decider_local_map->size() : 0u,
+    state_.kf_decider_simplemap ? state_.kf_decider_simplemap->size() : 0u));
 
   if (state_.last_motion_model_output) {
     const auto & tw = state_.last_motion_model_output->twist;

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -227,6 +227,20 @@ void LidarOdometry::Parameters::load_keyframe_policy(
     mrpt::format(
       "%s.min_nearby_poses_occupied=%u must be >= 1", section_name,
       static_cast<unsigned>(o.min_nearby_poses_occupied)));
+
+#if !defined(MOLA_POSE_LIST_HAS_KFM_POSE_PLUMBING)
+  // The spatial policy delegates the occupancy count to
+  // SearchablePoseList::countNearby(), which older mola_pose_list versions do
+  // not have. Reject the combination instead of silently ignoring the option
+  // (the temporal policy does its own counting, so it is unaffected).
+  ASSERTMSG_(
+    o.min_nearby_poses_occupied == 1 || o.nearby_keyframe_time_window > 0,
+    mrpt::format(
+      "%s.min_nearby_poses_occupied>1 requires a newer mola_pose_list, or "
+      "nearby_keyframe_time_window to be enabled",
+      section_name));
+#endif
+
   ASSERTMSG_(
     o.nearby_keyframe_time_window >= 0, mrpt::format(
                                           "%s.nearby_keyframe_time_window=%f must be >= 0",

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -219,12 +219,18 @@ void LidarOdometry::Parameters::load_keyframe_policy(
     cfg.getOrDefault<bool>("measure_from_last_kf_only", o.measure_from_last_kf_only);
   o.min_nearby_poses_occupied =
     cfg.getOrDefault<uint32_t>("min_nearby_poses_occupied", o.min_nearby_poses_occupied);
+  o.nearby_keyframe_time_window =
+    cfg.getOrDefault<double>("nearby_keyframe_time_window", o.nearby_keyframe_time_window);
 
   ASSERTMSG_(
     o.min_nearby_poses_occupied >= 1,
     mrpt::format(
       "%s.min_nearby_poses_occupied=%u must be >= 1", section_name,
       static_cast<unsigned>(o.min_nearby_poses_occupied)));
+  ASSERTMSG_(
+    o.nearby_keyframe_time_window >= 0, mrpt::format(
+                                          "%s.nearby_keyframe_time_window=%f must be >= 0",
+                                          section_name, o.nearby_keyframe_time_window));
 }
 
 void LidarOdometry::Parameters::SimpleMapOptions::initialize(const Yaml & cfg, Parameters & parent)

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -195,19 +195,44 @@ void LidarOdometry::Parameters::Visualization::initializeModelPart(const Yaml & 
   }
 }
 
+void LidarOdometry::Parameters::load_keyframe_policy(
+  mola::KeyframeDecisionOptions & o, const Yaml & cfg, const char * section_name,
+  bool distances_required)
+{
+  // The two distance thresholds may be formulas (e.g. shrinking with angular
+  // velocity), so they are declared as dynamic parameters re-evaluated per
+  // scan, not read once. The DECLARE_PARAMETER_IN_* macros are expanded by
+  // hand here because they derive the YAML key from the variable name, which
+  // does not survive being passed in as a reference.
+  auto declareDistance = [&](const char * key, double & target) {
+    if (distances_required && !cfg.has(key)) {
+      throw std::invalid_argument(
+        mrpt::format("Required parameter `%s.%s` not found in configuration.", section_name, key));
+    }
+    parseAndDeclareParameter(cfg.getOrDefault<std::string>(key, std::to_string(target)), target);
+  };
+
+  declareDistance("min_translation_between_keyframes", o.min_translation_between_keyframes);
+  declareDistance("min_rotation_between_keyframes", o.min_rotation_between_keyframes);
+
+  o.measure_from_last_kf_only =
+    cfg.getOrDefault<bool>("measure_from_last_kf_only", o.measure_from_last_kf_only);
+  o.min_nearby_poses_occupied =
+    cfg.getOrDefault<uint32_t>("min_nearby_poses_occupied", o.min_nearby_poses_occupied);
+
+  ASSERTMSG_(
+    o.min_nearby_poses_occupied >= 1,
+    mrpt::format(
+      "%s.min_nearby_poses_occupied=%u must be >= 1", section_name,
+      static_cast<unsigned>(o.min_nearby_poses_occupied)));
+}
+
 void LidarOdometry::Parameters::SimpleMapOptions::initialize(const Yaml & cfg, Parameters & parent)
 {
   YAML_LOAD_OPT(generate, bool);
-  DECLARE_PARAMETER_IN_OPT(cfg, min_translation_between_keyframes, parent);
-  DECLARE_PARAMETER_IN_OPT(cfg, min_rotation_between_keyframes, parent);
+  parent.load_keyframe_policy(*this, cfg, "simplemap", false /*distances_required*/);
   YAML_LOAD_OPT(save_final_map_to_file, std::string);
   YAML_LOAD_OPT(add_non_keyframes_too, bool);
-  YAML_LOAD_OPT(measure_from_last_kf_only, bool);
-  YAML_LOAD_OPT(min_nearby_poses_occupied, uint32_t);
-  ASSERTMSG_(
-    min_nearby_poses_occupied >= 1, mrpt::format(
-                                      "simplemap.min_nearby_poses_occupied=%u must be >= 1",
-                                      static_cast<unsigned>(min_nearby_poses_occupied)));
   YAML_LOAD_OPT(generate_lazy_load_scan_files, bool);
   YAML_LOAD_OPT(save_gnss_max_age, double);
   YAML_LOAD_OPT(save_deskewed_scans, bool);
@@ -223,17 +248,10 @@ void LidarOdometry::Parameters::MultipleLidarOptions::initialize(
 void LidarOdometry::Parameters::MapUpdateOptions::initialize(const Yaml & cfg, Parameters & parent)
 {
   YAML_LOAD_OPT(enabled, bool);
-  DECLARE_PARAMETER_IN_REQ(cfg, min_translation_between_keyframes, parent);
-  DECLARE_PARAMETER_IN_REQ(cfg, min_rotation_between_keyframes, parent);
+  parent.load_keyframe_policy(*this, cfg, "local_map_updates", true /*distances_required*/);
   DECLARE_PARAMETER_IN_OPT(cfg, max_distance_to_keep_keyframes, parent);
   DECLARE_PARAMETER_IN_OPT(cfg, check_for_removal_every_n, parent);
   DECLARE_PARAMETER_IN_OPT(cfg, publish_map_updates_every_n, parent);
-  YAML_LOAD_OPT(measure_from_last_kf_only, bool);
-  YAML_LOAD_OPT(min_nearby_poses_occupied, uint32_t);
-  ASSERTMSG_(
-    min_nearby_poses_occupied >= 1, mrpt::format(
-                                      "simplemap.min_nearby_poses_occupied=%u must be >= 1",
-                                      static_cast<unsigned>(min_nearby_poses_occupied)));
   YAML_LOAD_OPT(load_existing_local_map, std::string);
   YAML_LOAD_OPT(save_final_local_map, std::string);
 

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -368,7 +368,8 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     {
       mrpt::poses::CPose3D sensorPoseInVehicle;
       obs->getSensorPose(sensorPoseInVehicle);
-      state_.kf_decider_simplemap->insert(state_.last_lidar_pose.mean + sensorPoseInVehicle);
+      state_.kf_decider_simplemap->insert(
+        state_.last_lidar_pose.mean + sensorPoseInVehicle, mrpt::Clock::toDouble(obs->timestamp));
     }
   } else {
     // Register point clouds using ICP:
@@ -805,9 +806,11 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     obs->getSensorPose(sensorPoseInVehicle);
     const mrpt::poses::CPose3D lidarPoseInWorld = state_.last_lidar_pose.mean + sensorPoseInVehicle;
 
+    const double obsTimestamp = mrpt::Clock::toDouble(obs->timestamp);
+
     // Create a new KF if we are far enough from the existing ones:
     const auto decisionLocalMap =
-      state_.kf_decider_local_map->check(params_.local_map_updates, lidarPoseInWorld);
+      state_.kf_decider_local_map->check(params_.local_map_updates, lidarPoseInWorld, obsTimestamp);
 
     const bool distFarEnoughLocal = decisionLocalMap.create;
     const double euclidean_dist_since_last = decisionLocalMap.translation;
@@ -837,7 +840,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     // clang-format on
 
     if (updateLocalMap) {
-      state_.kf_decider_local_map->insert(lidarPoseInWorld);
+      state_.kf_decider_local_map->insert(lidarPoseInWorld, obsTimestamp);
 
       if (
         params_.local_map_updates.max_distance_to_keep_keyframes > 0 &&
@@ -858,9 +861,9 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     }
 
     // Same shared policy as the local map above, but with the simplemap's own
-    // (independently tuned) thresholds:
+    // (independently tuned) thresholds and time window:
     const auto decisionSimpleMap =
-      state_.kf_decider_simplemap->check(params_.simplemap, lidarPoseInWorld);
+      state_.kf_decider_simplemap->check(params_.simplemap, lidarPoseInWorld, obsTimestamp);
 
     distance_enough_sm = decisionSimpleMap.create;
 
@@ -890,7 +893,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       // still needs the distance_enough_sm criterion to actually behave as
       // "sparse" instead of always firing (an empty checker reports every
       // pose as "far enough"):
-      state_.kf_decider_simplemap->insert(lidarPoseInWorld);
+      state_.kf_decider_simplemap->insert(lidarPoseInWorld, obsTimestamp);
     }
 
     MRPT_LOG_DEBUG_FMT(

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -363,14 +363,13 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     // spuriously fire a second keyframe on the very next scan):
     state_.last_lidar_pose = initPose;
     if (!state_.kf_decider_simplemap) {
-      state_.kf_decider_simplemap.emplace(params_.simplemap.measure_from_last_kf_only);
+      state_.kf_decider_simplemap.emplace(params_.simplemap);
     }
     {
       mrpt::poses::CPose3D sensorPoseInVehicle;
       obs->getSensorPose(sensorPoseInVehicle);
       state_.kf_decider_simplemap->insert(
-        params_.simplemap, state_.last_lidar_pose.mean + sensorPoseInVehicle,
-        mrpt::Clock::toDouble(obs->timestamp));
+        state_.last_lidar_pose.mean + sensorPoseInVehicle, mrpt::Clock::toDouble(obs->timestamp));
     }
   } else {
     // Register point clouds using ICP:
@@ -793,11 +792,11 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 
     // Create keyframe deciders on first usage:
     if (!state_.kf_decider_local_map) {
-      state_.kf_decider_local_map.emplace(params_.local_map_updates.measure_from_last_kf_only);
+      state_.kf_decider_local_map.emplace(params_.local_map_updates);
     }
 
     if (!state_.kf_decider_simplemap) {
-      state_.kf_decider_simplemap.emplace(params_.simplemap.measure_from_last_kf_only);
+      state_.kf_decider_simplemap.emplace(params_.simplemap);
     }
 
     // Use the lidar sensor pose (in world frame) as the distance-checker key.
@@ -841,8 +840,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     // clang-format on
 
     if (updateLocalMap) {
-      state_.kf_decider_local_map->insert(
-        params_.local_map_updates, lidarPoseInWorld, obsTimestamp);
+      state_.kf_decider_local_map->insert(lidarPoseInWorld, obsTimestamp);
 
       if (
         params_.local_map_updates.max_distance_to_keep_keyframes > 0 &&
@@ -895,7 +893,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       // still needs the distance_enough_sm criterion to actually behave as
       // "sparse" instead of always firing (an empty checker reports every
       // pose as "far enough"):
-      state_.kf_decider_simplemap->insert(params_.simplemap, lidarPoseInWorld, obsTimestamp);
+      state_.kf_decider_simplemap->insert(lidarPoseInWorld, obsTimestamp);
     }
 
     MRPT_LOG_DEBUG_FMT(

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -369,7 +369,8 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       mrpt::poses::CPose3D sensorPoseInVehicle;
       obs->getSensorPose(sensorPoseInVehicle);
       state_.kf_decider_simplemap->insert(
-        state_.last_lidar_pose.mean + sensorPoseInVehicle, mrpt::Clock::toDouble(obs->timestamp));
+        params_.simplemap, state_.last_lidar_pose.mean + sensorPoseInVehicle,
+        mrpt::Clock::toDouble(obs->timestamp));
     }
   } else {
     // Register point clouds using ICP:
@@ -840,7 +841,8 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     // clang-format on
 
     if (updateLocalMap) {
-      state_.kf_decider_local_map->insert(lidarPoseInWorld, obsTimestamp);
+      state_.kf_decider_local_map->insert(
+        params_.local_map_updates, lidarPoseInWorld, obsTimestamp);
 
       if (
         params_.local_map_updates.max_distance_to_keep_keyframes > 0 &&
@@ -893,7 +895,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       // still needs the distance_enough_sm criterion to actually behave as
       // "sparse" instead of always firing (an empty checker reports every
       // pose as "far enough"):
-      state_.kf_decider_simplemap->insert(lidarPoseInWorld, obsTimestamp);
+      state_.kf_decider_simplemap->insert(params_.simplemap, lidarPoseInWorld, obsTimestamp);
     }
 
     MRPT_LOG_DEBUG_FMT(

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -357,18 +357,18 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 
     state_.navstate_fuse->fuse_pose(scan_ref_time, initPose, params_.publish_reference_frame);
 
-    // Seed last_lidar_pose and distance_checker_simplemap with the origin so
-    // the next scan's distance check starts from here rather than from "empty"
-    // (an empty checker reports isFirstPoseInSMChecker=true for every pose,
-    // which would spuriously fire a second keyframe on the very next scan):
+    // Seed last_lidar_pose and the simplemap keyframe decider with the origin
+    // so the next scan's distance check starts from here rather than from
+    // "empty" (an empty decider asks for a keyframe at every pose, which would
+    // spuriously fire a second keyframe on the very next scan):
     state_.last_lidar_pose = initPose;
-    if (!state_.distance_checker_simplemap) {
-      state_.distance_checker_simplemap.emplace(params_.simplemap.measure_from_last_kf_only);
+    if (!state_.kf_decider_simplemap) {
+      state_.kf_decider_simplemap.emplace(params_.simplemap.measure_from_last_kf_only);
     }
     {
       mrpt::poses::CPose3D sensorPoseInVehicle;
       obs->getSensorPose(sensorPoseInVehicle);
-      state_.distance_checker_simplemap->insert(state_.last_lidar_pose.mean + sensorPoseInVehicle);
+      state_.kf_decider_simplemap->insert(state_.last_lidar_pose.mean + sensorPoseInVehicle);
     }
   } else {
     // Register point clouds using ICP:
@@ -789,14 +789,13 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       }
     }
 
-    // Create distance checker on first usage:
-    if (!state_.distance_checker_local_map) {
-      state_.distance_checker_local_map.emplace(
-        params_.local_map_updates.measure_from_last_kf_only);
+    // Create keyframe deciders on first usage:
+    if (!state_.kf_decider_local_map) {
+      state_.kf_decider_local_map.emplace(params_.local_map_updates.measure_from_last_kf_only);
     }
 
-    if (!state_.distance_checker_simplemap) {
-      state_.distance_checker_simplemap.emplace(params_.simplemap.measure_from_last_kf_only);
+    if (!state_.kf_decider_simplemap) {
+      state_.kf_decider_simplemap.emplace(params_.simplemap.measure_from_last_kf_only);
     }
 
     // Use the lidar sensor pose (in world frame) as the distance-checker key.
@@ -806,31 +805,13 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     obs->getSensorPose(sensorPoseInVehicle);
     const mrpt::poses::CPose3D lidarPoseInWorld = state_.last_lidar_pose.mean + sensorPoseInVehicle;
 
-    // Create a new KF if the distance since the last one is large enough:
-    const auto [isFirstPoseInChecker, distanceToClosest] =
-      state_.distance_checker_local_map->check(lidarPoseInWorld);
+    // Create a new KF if we are far enough from the existing ones:
+    const auto decisionLocalMap =
+      state_.kf_decider_local_map->check(params_.local_map_updates, lidarPoseInWorld);
 
-    const double euclidean_dist_since_last = distanceToClosest.norm();
-    const double rot_since_last =
-      mrpt::poses::Lie::SO<3>::log(distanceToClosest.getRotationMatrix()).norm();
-
-    bool distFarEnoughLocal =
-      (isFirstPoseInChecker ||
-       euclidean_dist_since_last > params_.local_map_updates.min_translation_between_keyframes ||
-       rot_since_last > mrpt::DEG2RAD(params_.local_map_updates.min_rotation_between_keyframes));
-
-#if defined(MOLA_POSE_LIST_HAS_KFM_POSE_PLUMBING)
-    if (!distFarEnoughLocal && params_.local_map_updates.min_nearby_poses_occupied > 1) {
-      const uint32_t nearbyCount = state_.distance_checker_local_map->countNearby(
-        lidarPoseInWorld, params_.local_map_updates.min_translation_between_keyframes,
-        mrpt::DEG2RAD(params_.local_map_updates.min_rotation_between_keyframes));
-      if (nearbyCount < params_.local_map_updates.min_nearby_poses_occupied) {
-        distFarEnoughLocal = true;
-      }
-    }
-#else
-    // Older mola_pose_list: countNearby() unavailable; min_nearby_poses_occupied has no effect.
-#endif
+    const bool distFarEnoughLocal = decisionLocalMap.create;
+    const double euclidean_dist_since_last = decisionLocalMap.translation;
+    const double rot_since_last = decisionLocalMap.rotation;
 
     // Reuse the post-relocalization recovery window/counter (see
     // additional_map_freeze_after_reloc_how_many_timesteps): only actually
@@ -856,7 +837,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     // clang-format on
 
     if (updateLocalMap) {
-      state_.distance_checker_local_map->insert(lidarPoseInWorld);
+      state_.kf_decider_local_map->insert(lidarPoseInWorld);
 
       if (
         params_.local_map_updates.max_distance_to_keep_keyframes > 0 &&
@@ -866,40 +847,22 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 
         state_.localmap_check_removal_counter = 0;
 
-        const auto nInit = state_.distance_checker_local_map->size();
+        const auto nInit = state_.kf_decider_local_map->size();
 
-        state_.distance_checker_local_map->removeAllFartherThan(
+        state_.kf_decider_local_map->removeAllFartherThan(
           lidarPoseInWorld, params_.local_map_updates.max_distance_to_keep_keyframes);
 
-        const auto nFinal = state_.distance_checker_local_map->size();
+        const auto nFinal = state_.kf_decider_local_map->size();
         MRPT_LOG_DEBUG_STREAM("removeAllFartherThan: " << nInit << " => " << nFinal << " KFs");
       }
     }
 
-    const auto [isFirstPoseInSMChecker, distanceToClosestSM] =
-      state_.distance_checker_simplemap->check(lidarPoseInWorld);
+    // Same shared policy as the local map above, but with the simplemap's own
+    // (independently tuned) thresholds:
+    const auto decisionSimpleMap =
+      state_.kf_decider_simplemap->check(params_.simplemap, lidarPoseInWorld);
 
-    const double euclidean_dist_since_last_sm = distanceToClosestSM.norm();
-    const double rot_since_last_sm =
-      mrpt::poses::Lie::SO<3>::log(distanceToClosestSM.getRotationMatrix()).norm();
-
-    distance_enough_sm =
-      isFirstPoseInSMChecker ||
-      euclidean_dist_since_last_sm > params_.simplemap.min_translation_between_keyframes ||
-      rot_since_last_sm > mrpt::DEG2RAD(params_.simplemap.min_rotation_between_keyframes);
-
-#if defined(MOLA_POSE_LIST_HAS_KFM_POSE_PLUMBING)
-    if (!distance_enough_sm && params_.simplemap.min_nearby_poses_occupied > 1) {
-      const uint32_t nearbyCountSM = state_.distance_checker_simplemap->countNearby(
-        lidarPoseInWorld, params_.simplemap.min_translation_between_keyframes,
-        mrpt::DEG2RAD(params_.simplemap.min_rotation_between_keyframes));
-      if (nearbyCountSM < params_.simplemap.min_nearby_poses_occupied) {
-        distance_enough_sm = true;
-      }
-    }
-#else
-    // Older mola_pose_list: countNearby() unavailable; min_nearby_poses_occupied has no effect.
-#endif
+    distance_enough_sm = decisionSimpleMap.create;
 
     // clang-format off
     updateSimpleMap =
@@ -927,7 +890,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       // still needs the distance_enough_sm criterion to actually behave as
       // "sparse" instead of always firing (an empty checker reports every
       // pose as "far enough"):
-      state_.distance_checker_simplemap->insert(lidarPoseInWorld);
+      state_.kf_decider_simplemap->insert(lidarPoseInWorld);
     }
 
     MRPT_LOG_DEBUG_FMT(

--- a/pipelines/extras/lidar3d-edges.yaml
+++ b/pipelines/extras/lidar3d-edges.yaml
@@ -71,6 +71,12 @@ params:
     generate: ${MOLA_GENERATE_SIMPLEMAP|false} # Can be overridden with CLI flag --output-simplemap
     min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|0.05} # m
     min_rotation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_ROT|3.0} # deg
+
+    # Revisiting an already-mapped area creates NO keyframes with the purely
+    # spatial criterion above, which starves loop closure of the second endpoint
+    # of the loop. Set to a positive value [s] so only keyframes newer than that
+    # take part in the "is there one here already?" test.
+    nearby_keyframe_time_window: ${MOLA_SIMPLEMAP_KF_TIME_WINDOW|0} # [s], 0=disabled
     save_final_map_to_file: ${MOLA_SIMPLEMAP_OUTPUT|'final_map.simplemap'}
 
   # Save the final trajectory in TUM format. Disabled by default.

--- a/pipelines/extras/rgbd.yaml
+++ b/pipelines/extras/rgbd.yaml
@@ -89,6 +89,12 @@ params:
     generate: ${MOLA_GENERATE_SIMPLEMAP|false} # Can be overridden with CLI flag --output-simplemap
     min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|0.05} # m
     min_rotation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_ROT|3.0} # deg
+
+    # Revisiting an already-mapped area creates NO keyframes with the purely
+    # spatial criterion above, which starves loop closure of the second endpoint
+    # of the loop. Set to a positive value [s] so only keyframes newer than that
+    # take part in the "is there one here already?" test.
+    nearby_keyframe_time_window: ${MOLA_SIMPLEMAP_KF_TIME_WINDOW|0} # [s], 0=disabled
     save_final_map_to_file: ${MOLA_SIMPLEMAP_OUTPUT|'final_map.simplemap'}
     save_gnss_max_age: 1.0 # [s] max age of GNSS observations to keep in the keyframe
 

--- a/pipelines/lidar2d.yaml
+++ b/pipelines/lidar2d.yaml
@@ -99,6 +99,12 @@ params:
     load_existing_simple_map: ${MOLA_LOAD_SM|""}
     min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|0.05} # m
     min_rotation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_ROT|3.0} # deg
+
+    # Revisiting an already-mapped area creates NO keyframes with the purely
+    # spatial criterion above, which starves loop closure of the second endpoint
+    # of the loop. Set to a positive value [s] so only keyframes newer than that
+    # take part in the "is there one here already?" test.
+    nearby_keyframe_time_window: ${MOLA_SIMPLEMAP_KF_TIME_WINDOW|0} # [s], 0=disabled
     save_final_map_to_file: ${MOLA_SIMPLEMAP_OUTPUT|'final_map.simplemap'}
     save_gnss_max_age: 1.0 # [s] max age of GNSS observations to keep in the keyframe
 

--- a/pipelines/lidar3d-gicp-optimize-twist.yaml
+++ b/pipelines/lidar3d-gicp-optimize-twist.yaml
@@ -116,8 +116,13 @@ params:
 
     save_final_map_to_file: ${MOLA_SIMPLEMAP_OUTPUT|'final_map.simplemap'}
 
-    min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*1.0)*ESTIMATED_OBSERVATION_RADIUS} # m
-    min_rotation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_ROT|15 + sqrt(wx^2+wy^2+wz^2)*500} # deg
+    # NOTE: unlike local_map_updates above, these thresholds are NOT scaled by
+    # angular velocity: this is what feeds the SharedKeyframeMap sink (e.g.
+    # mola_mapper), and the old w-scaled formula (rotation threshold growing
+    # by 500 deg per rad/s) made it create close to NO keyframes while
+    # smoothly turning, starving loop closure of the keyframes it needs.
+    min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|1.0e-2*ESTIMATED_OBSERVATION_RADIUS} # m
+    min_rotation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_ROT|15} # deg
 
     # Revisiting an already-mapped area creates NO keyframes with the purely
     # spatial criterion above, which starves loop closure of the second endpoint

--- a/pipelines/lidar3d-gicp-optimize-twist.yaml
+++ b/pipelines/lidar3d-gicp-optimize-twist.yaml
@@ -119,6 +119,12 @@ params:
     min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*1.0)*ESTIMATED_OBSERVATION_RADIUS} # m
     min_rotation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_ROT|15 + sqrt(wx^2+wy^2+wz^2)*500} # deg
 
+    # Revisiting an already-mapped area creates NO keyframes with the purely
+    # spatial criterion above, which starves loop closure of the second endpoint
+    # of the loop. Set to a positive value [s] so only keyframes newer than that
+    # take part in the "is there one here already?" test.
+    nearby_keyframe_time_window: ${MOLA_SIMPLEMAP_KF_TIME_WINDOW|0} # [s], 0=disabled
+
     generate_lazy_load_scan_files: ${MOLA_SIMPLEMAP_GENERATE_LAZY_LOAD|false} # If enabled, a directory will be create alongside the .simplemap and pointclouds will be externally serialized there.
     add_non_keyframes_too: ${MOLA_SIMPLEMAP_ALSO_NON_KEYFRAMES|false} # If enabled, all frames are stored in the simplemap, but non-keyframes will be without associated observations.
     save_gnss_max_age: 1.0 # [s] max age of GNSS observations to keep in the keyframe

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -65,7 +65,7 @@ params:
 
     # Idea: don't integrate scans with a high rotational speed since they are probably not correctly deskewed:
     min_translation_between_keyframes: "${MOLA_MIN_XYZ_BETWEEN_MAP_UPDATES|(0.1e-2 + sqrt(wx^2+wy^2+wz^2)*0.1)*ESTIMATED_OBSERVATION_RADIUS}" # [m]
-    min_rotation_between_keyframes: "${MOLA_MIN_ROT_BETWEEN_MAP_UPDATES|(15 + sqrt(wx^2+wy^2+wz^2)*500 )}" # [deg]
+    min_rotation_between_keyframes: "${MOLA_MIN_ROT_BETWEEN_MAP_UPDATES|(15 + sqrt(wx^2+wy^2+wz^2)*5 )}" # [deg]
 
     # Should match the "remove farther than" option of the local metric map. "0" means deletion of distant key-frames is disabled
     max_distance_to_keep_keyframes: "${MOLA_LOCAL_MAP_MAX_SIZE|max(100.0, 1.50*ESTIMATED_OBSERVATION_RADIUS)}" # [m]
@@ -138,8 +138,13 @@ params:
 
     save_final_map_to_file: ${MOLA_SIMPLEMAP_OUTPUT|'final_map.simplemap'}
 
-    min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*1.0)*ESTIMATED_OBSERVATION_RADIUS} # m
-    min_rotation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_ROT|15 + sqrt(wx^2+wy^2+wz^2)*500} # deg
+    # NOTE: unlike local_map_updates above, these thresholds are NOT scaled by
+    # angular velocity: this is what feeds the SharedKeyframeMap sink (e.g.
+    # mola_mapper), and the old w-scaled formula (rotation threshold growing
+    # by 500 deg per rad/s) made it create close to NO keyframes while
+    # smoothly turning, starving loop closure of the keyframes it needs.
+    min_translation_between_keyframes: "${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*0.1)*ESTIMATED_OBSERVATION_RADIUS}" # [m]
+    min_rotation_between_keyframes: "${MOLA_SIMPLEMAP_MIN_ROT|(15 + sqrt(wx^2+wy^2+wz^2)*5 )}" # [deg]
 
     generate_lazy_load_scan_files: ${MOLA_SIMPLEMAP_GENERATE_LAZY_LOAD|false} # If enabled, a directory will be create alongside the .simplemap and pointclouds will be externally serialized there.
     add_non_keyframes_too: ${MOLA_SIMPLEMAP_ALSO_NON_KEYFRAMES|false} # If enabled, all frames are stored in the simplemap, but non-keyframes will be without associated observations.

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -144,6 +144,11 @@ params:
     generate_lazy_load_scan_files: ${MOLA_SIMPLEMAP_GENERATE_LAZY_LOAD|false} # If enabled, a directory will be create alongside the .simplemap and pointclouds will be externally serialized there.
     add_non_keyframes_too: ${MOLA_SIMPLEMAP_ALSO_NON_KEYFRAMES|false} # If enabled, all frames are stored in the simplemap, but non-keyframes will be without associated observations.
     min_nearby_poses_occupied: ${MOLA_SIMPLEMAP_MIN_NEARBY_POSES|1}
+    # Revisiting an already-mapped area creates NO keyframes with the purely
+    # spatial criterion above, which starves loop closure of the second endpoint
+    # of the loop. Set to a positive value [s] so only keyframes newer than that
+    # take part in the "is there one here already?" test.
+    nearby_keyframe_time_window: ${MOLA_SIMPLEMAP_KF_TIME_WINDOW|0} # [s], 0=disabled
     save_gnss_max_age: 1.0 # [s] max age of GNSS observations to keep in the keyframe
 
     # If enabled, this will store deskewed scans into the keyframes of simplemaps.

--- a/pipelines/lidar3d-icp.yaml
+++ b/pipelines/lidar3d-icp.yaml
@@ -122,6 +122,11 @@ params:
     generate_lazy_load_scan_files: ${MOLA_SIMPLEMAP_GENERATE_LAZY_LOAD|false} # If enabled, a directory will be create alongside the .simplemap and pointclouds will be externally serialized there.
     add_non_keyframes_too: ${MOLA_SIMPLEMAP_ALSO_NON_KEYFRAMES|false} # If enabled, all frames are stored in the simplemap, but non-keyframes will be without associated observations.
     min_nearby_poses_occupied: ${MOLA_SIMPLEMAP_MIN_NEARBY_POSES|1}
+    # Revisiting an already-mapped area creates NO keyframes with the purely
+    # spatial criterion above, which starves loop closure of the second endpoint
+    # of the loop. Set to a positive value [s] so only keyframes newer than that
+    # take part in the "is there one here already?" test.
+    nearby_keyframe_time_window: ${MOLA_SIMPLEMAP_KF_TIME_WINDOW|0} # [s], 0=disabled
     save_gnss_max_age: 1.0 # [s] max age of GNSS observations to keep in the keyframe
 
   # Save the final trajectory in TUM format. Disabled by default.

--- a/pipelines/lidar3d-icp.yaml
+++ b/pipelines/lidar3d-icp.yaml
@@ -116,8 +116,13 @@ params:
 
     save_final_map_to_file: ${MOLA_SIMPLEMAP_OUTPUT|'final_map.simplemap'}
 
-    min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*1.0)*ESTIMATED_OBSERVATION_RADIUS} # m
-    min_rotation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_ROT|15 + sqrt(wx^2+wy^2+wz^2)*500} # deg
+    # NOTE: unlike local_map_updates above, these thresholds are NOT scaled by
+    # angular velocity: this is what feeds the SharedKeyframeMap sink (e.g.
+    # mola_mapper), and the old w-scaled formula (rotation threshold growing
+    # by 500 deg per rad/s) made it create close to NO keyframes while
+    # smoothly turning, starving loop closure of the keyframes it needs.
+    min_translation_between_keyframes: "${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*0.1)*ESTIMATED_OBSERVATION_RADIUS}" # [m]
+    min_rotation_between_keyframes: "${MOLA_SIMPLEMAP_MIN_ROT|(15 + sqrt(wx^2+wy^2+wz^2)*5 )}" # [deg]
 
     generate_lazy_load_scan_files: ${MOLA_SIMPLEMAP_GENERATE_LAZY_LOAD|false} # If enabled, a directory will be create alongside the .simplemap and pointclouds will be externally serialized there.
     add_non_keyframes_too: ${MOLA_SIMPLEMAP_ALSO_NON_KEYFRAMES|false} # If enabled, all frames are stored in the simplemap, but non-keyframes will be without associated observations.

--- a/pipelines/lidar3d-ndt.yaml
+++ b/pipelines/lidar3d-ndt.yaml
@@ -110,8 +110,13 @@ params:
 
     save_final_map_to_file: ${MOLA_SIMPLEMAP_OUTPUT|'final_map.simplemap'}
 
-    min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|(1.0e-2 + sqrt(wx^2+wy^2+wz^2)*1.0)*ESTIMATED_OBSERVATION_RADIUS} # m
-    min_rotation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_ROT|15 + sqrt(wx^2+wy^2+wz^2)*500} # deg
+    # NOTE: unlike local_map_updates above, these thresholds are NOT scaled by
+    # angular velocity: this is what feeds the SharedKeyframeMap sink (e.g.
+    # mola_mapper), and the old w-scaled formula (rotation threshold growing
+    # by 500 deg per rad/s) made it create close to NO keyframes while
+    # smoothly turning, starving loop closure of the keyframes it needs.
+    min_translation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_XYZ|1.0e-2*ESTIMATED_OBSERVATION_RADIUS} # m
+    min_rotation_between_keyframes: ${MOLA_SIMPLEMAP_MIN_ROT|15} # deg
 
     generate_lazy_load_scan_files: ${MOLA_SIMPLEMAP_GENERATE_LAZY_LOAD|false} # If enabled, a directory will be create alongside the .simplemap and pointclouds will be externally serialized there.
     add_non_keyframes_too: ${MOLA_SIMPLEMAP_ALSO_NON_KEYFRAMES|false} # If enabled, all frames are stored in the simplemap, but non-keyframes will be without associated observations.

--- a/pipelines/lidar3d-ndt.yaml
+++ b/pipelines/lidar3d-ndt.yaml
@@ -116,6 +116,11 @@ params:
     generate_lazy_load_scan_files: ${MOLA_SIMPLEMAP_GENERATE_LAZY_LOAD|false} # If enabled, a directory will be create alongside the .simplemap and pointclouds will be externally serialized there.
     add_non_keyframes_too: ${MOLA_SIMPLEMAP_ALSO_NON_KEYFRAMES|false} # If enabled, all frames are stored in the simplemap, but non-keyframes will be without associated observations.
     min_nearby_poses_occupied: ${MOLA_SIMPLEMAP_MIN_NEARBY_POSES|1}
+    # Revisiting an already-mapped area creates NO keyframes with the purely
+    # spatial criterion above, which starves loop closure of the second endpoint
+    # of the loop. Set to a positive value [s] so only keyframes newer than that
+    # take part in the "is there one here already?" test.
+    nearby_keyframe_time_window: ${MOLA_SIMPLEMAP_KF_TIME_WINDOW|0} # [s], 0=disabled
     save_gnss_max_age: 1.0 # [s] max age of GNSS observations to keep in the keyframe
 
   # Save the final trajectory in TUM format. Disabled by default.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,9 @@ target_link_libraries(test_gravity_map_aligner mola::mola_lidar_odometry)
 ament_add_gtest(test_trajectory_rebaker test_trajectory_rebaker.cpp)
 target_link_libraries(test_trajectory_rebaker mola::mola_lidar_odometry)
 
+ament_add_gtest(test_keyframe_decider test_keyframe_decider.cpp)
+target_link_libraries(test_keyframe_decider mola::mola_lidar_odometry)
+
 # -----------------------------------------------------------------------
 # Data-dependent integration tests (require optional packages):
 # -----------------------------------------------------------------------

--- a/test/test_keyframe_decider.cpp
+++ b/test/test_keyframe_decider.cpp
@@ -40,17 +40,17 @@ mola::KeyframeDecisionOptions defaultOptions()
  *  keyframe. Returns how many keyframes were created. */
 size_t run(
   mola::KeyframeDecider & d, const mola::KeyframeDecisionOptions & o, double fromX, double toX,
-  double step)
+  double step, double & t, double dt)
 {
   ASSERT_(step != 0);
   const int nSteps = static_cast<int>(std::floor((toX - fromX) / step + 1e-9)) + 1;
   ASSERT_(nSteps > 0);
 
   size_t created = 0;
-  for (int i = 0; i < nSteps; i++) {
+  for (int i = 0; i < nSteps; i++, t += dt) {
     const double x = fromX + i * step;
-    if (d.check(o, at(x)).create) {
-      d.insert(at(x));
+    if (d.check(o, at(x), t).create) {
+      d.insert(at(x), t);
       created++;
     }
   }
@@ -64,7 +64,7 @@ TEST(KeyframeDecider, FirstPoseAlwaysCreates)
   const auto o = defaultOptions();
   mola::KeyframeDecider d;
 
-  EXPECT_TRUE(d.check(o, at(0)).create);
+  EXPECT_TRUE(d.check(o, at(0), 0.0).create);
   EXPECT_TRUE(d.empty());
 }
 
@@ -74,28 +74,94 @@ TEST(KeyframeDecider, SpatialSpacing)
   const auto o = defaultOptions();
   mola::KeyframeDecider d;
 
-  const size_t n = run(d, o, 0.0, 10.0, 0.25);
+  double t = 0;
+  const size_t n = run(d, o, 0.0, 10.0, 0.25, t, 0.1);
 
   // The threshold is strict, so keyframes land at 0, 1.25, 2.5, ... 10 m:
   EXPECT_EQ(n, 9u);
   EXPECT_EQ(d.size(), 9u);
 }
 
-// Coming back over an already-mapped area creates NO keyframes, since the
-// previous pass' ones are the nearest neighbors.
-TEST(KeyframeDecider, RevisitCreatesNothing)
+// The bug this policy exists to fix: with the purely spatial policy, coming
+// back over an already-mapped area creates NO keyframes, so loop closure never
+// gets the second endpoint of the loop.
+TEST(KeyframeDecider, RevisitCreatesNothingWithoutTimeWindow)
 {
   const auto o = defaultOptions();
   mola::KeyframeDecider d;
 
-  run(d, o, 0.0, 10.0, 0.25);
+  double t = 0;
+  run(d, o, 0.0, 10.0, 0.25, t, 0.1);
   const size_t nAfterFirstPass = d.size();
 
-  // Drive back over the very same places:
-  const size_t createdOnRevisit = run(d, o, 10.0, 0.0, -0.25);
+  // Drive back over the very same places, much later:
+  t += 1000.0;
+  const size_t createdOnRevisit = run(d, o, 10.0, 0.0, -0.25, t, 0.1);
 
   EXPECT_EQ(createdOnRevisit, 0u);
   EXPECT_EQ(d.size(), nAfterFirstPass);
+}
+
+// With the temporal window enabled, the same revisit does create keyframes,
+// since the first pass' ones are no longer visible to the policy.
+TEST(KeyframeDecider, RevisitCreatesKeyframesWithTimeWindow)
+{
+  auto o = defaultOptions();
+  o.nearby_keyframe_time_window = 20.0;
+
+  mola::KeyframeDecider d;
+
+  double t = 0;
+  run(d, o, 0.0, 10.0, 0.25, t, 0.1);
+  const size_t nAfterFirstPass = d.size();
+  EXPECT_EQ(nAfterFirstPass, 9u);
+
+  // Same places, long after the window:
+  t += 1000.0;
+  const size_t createdOnRevisit = run(d, o, 10.0, 0.0, -0.25, t, 0.1);
+
+  // The revisit is sampled as densely as the first pass, minus the keyframe
+  // the first pass created out of an empty map: the second pass starts right
+  // on top of the last keyframe of the first one.
+  EXPECT_EQ(createdOnRevisit, nAfterFirstPass - 1);
+  EXPECT_EQ(d.size(), nAfterFirstPass + createdOnRevisit);
+}
+
+// A stationary vehicle must NOT emit one keyframe per time window: the newest
+// keyframe is kept in the window whatever its age.
+TEST(KeyframeDecider, StationaryVehicleDoesNotAccumulate)
+{
+  auto o = defaultOptions();
+  o.nearby_keyframe_time_window = 5.0;
+
+  mola::KeyframeDecider d;
+
+  double t = 0;
+  ASSERT_TRUE(d.check(o, at(0), t).create);
+  d.insert(at(0), t);
+
+  // Parked for 10 minutes:
+  for (int i = 0; i < 6000; i++) {
+    t += 0.1;
+    EXPECT_FALSE(d.check(o, at(0), t).create);
+  }
+
+  EXPECT_EQ(d.size(), 1u);
+}
+
+// The time window must not disturb normal forward driving: same spacing as the
+// spatial policy.
+TEST(KeyframeDecider, TimeWindowKeepsForwardSpacing)
+{
+  auto o = defaultOptions();
+  o.nearby_keyframe_time_window = 20.0;
+
+  mola::KeyframeDecider d;
+
+  double t = 0;
+  const size_t n = run(d, o, 0.0, 10.0, 0.25, t, 0.1);
+
+  EXPECT_EQ(n, 9u);  // same as the purely spatial policy
 }
 
 // Rotating in place beyond the angular threshold also creates keyframes.
@@ -104,14 +170,14 @@ TEST(KeyframeDecider, RotationThreshold)
   const auto o = defaultOptions();
   mola::KeyframeDecider d;
 
-  d.insert(mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, 0, 0, 0));
+  d.insert(mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, 0, 0, 0), 0.0);
 
   const auto smallTurn =
     mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, mrpt::DEG2RAD(10), 0, 0);
-  EXPECT_FALSE(d.check(o, smallTurn).create);
+  EXPECT_FALSE(d.check(o, smallTurn, 1.0).create);
 
   const auto bigTurn = mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, mrpt::DEG2RAD(45), 0, 0);
-  EXPECT_TRUE(d.check(o, bigTurn).create);
+  EXPECT_TRUE(d.check(o, bigTurn, 1.0).create);
 }
 
 // min_nearby_poses_occupied > 1 asks for several keyframes per spot (used by
@@ -125,10 +191,10 @@ TEST(KeyframeDecider, MinNearbyPosesOccupied)
 
   // Three keyframes at the very same place, then no more:
   for (int i = 0; i < 3; i++) {
-    ASSERT_TRUE(d.check(o, at(0)).create) << "i=" << i;
-    d.insert(at(0));
+    ASSERT_TRUE(d.check(o, at(0), i).create) << "i=" << i;
+    d.insert(at(0), i);
   }
-  EXPECT_FALSE(d.check(o, at(0)).create);
+  EXPECT_FALSE(d.check(o, at(0), 4.0).create);
   EXPECT_EQ(d.size(), 3u);
 }
 
@@ -139,10 +205,11 @@ TEST(KeyframeDecider, MeasureFromLastOnly)
   const auto o = defaultOptions();
   mola::KeyframeDecider d(true /*measure_from_last_kf_only*/);
 
-  run(d, o, 0.0, 10.0, 0.25);
+  double t = 0;
+  run(d, o, 0.0, 10.0, 0.25, t, 0.1);
 
   // Back to the origin: far from the LAST keyframe (at 10 m), so it creates.
-  EXPECT_TRUE(d.check(o, at(0)).create);
+  EXPECT_TRUE(d.check(o, at(0), t).create);
 }
 
 int main(int argc, char ** argv)

--- a/test/test_keyframe_decider.cpp
+++ b/test/test_keyframe_decider.cpp
@@ -1,0 +1,152 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+/**
+ * @file   test_keyframe_decider.cpp
+ * @brief  Unit tests for the shared keyframe-creation policy
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include <gtest/gtest.h>
+#include <mola_lidar_odometry/KeyframeDecider.h>
+#include <mrpt/core/exceptions.h>
+
+#include <cmath>
+
+namespace
+{
+mrpt::poses::CPose3D at(double x, double y = 0)
+{
+  return mrpt::poses::CPose3D::FromXYZYawPitchRoll(x, y, 0, 0, 0, 0);
+}
+
+mola::KeyframeDecisionOptions defaultOptions()
+{
+  mola::KeyframeDecisionOptions o;
+  o.min_translation_between_keyframes = 1.0;
+  o.min_rotation_between_keyframes = 30.0;
+  return o;
+}
+
+/** Drives the decider along a straight line, inserting whenever it asks for a
+ *  keyframe. Returns how many keyframes were created. */
+size_t run(
+  mola::KeyframeDecider & d, const mola::KeyframeDecisionOptions & o, double fromX, double toX,
+  double step)
+{
+  ASSERT_(step != 0);
+  const int nSteps = static_cast<int>(std::floor((toX - fromX) / step + 1e-9)) + 1;
+  ASSERT_(nSteps > 0);
+
+  size_t created = 0;
+  for (int i = 0; i < nSteps; i++) {
+    const double x = fromX + i * step;
+    if (d.check(o, at(x)).create) {
+      d.insert(at(x));
+      created++;
+    }
+  }
+  return created;
+}
+}  // namespace
+
+// The first ever pose always creates a keyframe.
+TEST(KeyframeDecider, FirstPoseAlwaysCreates)
+{
+  const auto o = defaultOptions();
+  mola::KeyframeDecider d;
+
+  EXPECT_TRUE(d.check(o, at(0)).create);
+  EXPECT_TRUE(d.empty());
+}
+
+// Classic spatial policy: one keyframe per min_translation_between_keyframes.
+TEST(KeyframeDecider, SpatialSpacing)
+{
+  const auto o = defaultOptions();
+  mola::KeyframeDecider d;
+
+  const size_t n = run(d, o, 0.0, 10.0, 0.25);
+
+  // The threshold is strict, so keyframes land at 0, 1.25, 2.5, ... 10 m:
+  EXPECT_EQ(n, 9u);
+  EXPECT_EQ(d.size(), 9u);
+}
+
+// Coming back over an already-mapped area creates NO keyframes, since the
+// previous pass' ones are the nearest neighbors.
+TEST(KeyframeDecider, RevisitCreatesNothing)
+{
+  const auto o = defaultOptions();
+  mola::KeyframeDecider d;
+
+  run(d, o, 0.0, 10.0, 0.25);
+  const size_t nAfterFirstPass = d.size();
+
+  // Drive back over the very same places:
+  const size_t createdOnRevisit = run(d, o, 10.0, 0.0, -0.25);
+
+  EXPECT_EQ(createdOnRevisit, 0u);
+  EXPECT_EQ(d.size(), nAfterFirstPass);
+}
+
+// Rotating in place beyond the angular threshold also creates keyframes.
+TEST(KeyframeDecider, RotationThreshold)
+{
+  const auto o = defaultOptions();
+  mola::KeyframeDecider d;
+
+  d.insert(mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, 0, 0, 0));
+
+  const auto smallTurn =
+    mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, mrpt::DEG2RAD(10), 0, 0);
+  EXPECT_FALSE(d.check(o, smallTurn).create);
+
+  const auto bigTurn = mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, mrpt::DEG2RAD(45), 0, 0);
+  EXPECT_TRUE(d.check(o, bigTurn).create);
+}
+
+// min_nearby_poses_occupied > 1 asks for several keyframes per spot (used by
+// non-repetitive-scan lidars).
+TEST(KeyframeDecider, MinNearbyPosesOccupied)
+{
+  auto o = defaultOptions();
+  o.min_nearby_poses_occupied = 3;
+
+  mola::KeyframeDecider d;
+
+  // Three keyframes at the very same place, then no more:
+  for (int i = 0; i < 3; i++) {
+    ASSERT_TRUE(d.check(o, at(0)).create) << "i=" << i;
+    d.insert(at(0));
+  }
+  EXPECT_FALSE(d.check(o, at(0)).create);
+  EXPECT_EQ(d.size(), 3u);
+}
+
+// measure_from_last_kf_only ignores all but the last keyframe, so a revisit
+// creates keyframes even without the time window.
+TEST(KeyframeDecider, MeasureFromLastOnly)
+{
+  const auto o = defaultOptions();
+  mola::KeyframeDecider d(true /*measure_from_last_kf_only*/);
+
+  run(d, o, 0.0, 10.0, 0.25);
+
+  // Back to the origin: far from the LAST keyframe (at 10 m), so it creates.
+  EXPECT_TRUE(d.check(o, at(0)).create);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_keyframe_decider.cpp
+++ b/test/test_keyframe_decider.cpp
@@ -50,7 +50,7 @@ size_t run(
   for (int i = 0; i < nSteps; i++, t += dt) {
     const double x = fromX + i * step;
     if (d.check(o, at(x), t).create) {
-      d.insert(o, at(x), t);
+      d.insert(at(x), t);
       created++;
     }
   }
@@ -62,7 +62,7 @@ size_t run(
 TEST(KeyframeDecider, FirstPoseAlwaysCreates)
 {
   const auto o = defaultOptions();
-  mola::KeyframeDecider d;
+  mola::KeyframeDecider d(o);
 
   EXPECT_TRUE(d.check(o, at(0), 0.0).create);
   EXPECT_TRUE(d.empty());
@@ -72,7 +72,7 @@ TEST(KeyframeDecider, FirstPoseAlwaysCreates)
 TEST(KeyframeDecider, SpatialSpacing)
 {
   const auto o = defaultOptions();
-  mola::KeyframeDecider d;
+  mola::KeyframeDecider d(o);
 
   double t = 0;
   const size_t n = run(d, o, 0.0, 10.0, 0.25, t, 0.1);
@@ -88,7 +88,7 @@ TEST(KeyframeDecider, SpatialSpacing)
 TEST(KeyframeDecider, RevisitCreatesNothingWithoutTimeWindow)
 {
   const auto o = defaultOptions();
-  mola::KeyframeDecider d;
+  mola::KeyframeDecider d(o);
 
   double t = 0;
   run(d, o, 0.0, 10.0, 0.25, t, 0.1);
@@ -109,7 +109,7 @@ TEST(KeyframeDecider, RevisitCreatesKeyframesWithTimeWindow)
   auto o = defaultOptions();
   o.nearby_keyframe_time_window = 20.0;
 
-  mola::KeyframeDecider d;
+  mola::KeyframeDecider d(o);
 
   double t = 0;
   run(d, o, 0.0, 10.0, 0.25, t, 0.1);
@@ -134,11 +134,11 @@ TEST(KeyframeDecider, StationaryVehicleDoesNotAccumulate)
   auto o = defaultOptions();
   o.nearby_keyframe_time_window = 5.0;
 
-  mola::KeyframeDecider d;
+  mola::KeyframeDecider d(o);
 
   double t = 0;
   ASSERT_TRUE(d.check(o, at(0), t).create);
-  d.insert(o, at(0), t);
+  d.insert(at(0), t);
 
   // Parked for 10 minutes:
   for (int i = 0; i < 6000; i++) {
@@ -156,7 +156,7 @@ TEST(KeyframeDecider, TimeWindowKeepsForwardSpacing)
   auto o = defaultOptions();
   o.nearby_keyframe_time_window = 20.0;
 
-  mola::KeyframeDecider d;
+  mola::KeyframeDecider d(o);
 
   double t = 0;
   const size_t n = run(d, o, 0.0, 10.0, 0.25, t, 0.1);
@@ -168,9 +168,9 @@ TEST(KeyframeDecider, TimeWindowKeepsForwardSpacing)
 TEST(KeyframeDecider, RotationThreshold)
 {
   const auto o = defaultOptions();
-  mola::KeyframeDecider d;
+  mola::KeyframeDecider d(o);
 
-  d.insert(o, mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, 0, 0, 0), 0.0);
+  d.insert(mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, 0, 0, 0), 0.0);
 
   const auto smallTurn =
     mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, mrpt::DEG2RAD(10), 0, 0);
@@ -182,21 +182,26 @@ TEST(KeyframeDecider, RotationThreshold)
 
 // min_nearby_poses_occupied > 1 asks for several keyframes per spot (used by
 // non-repetitive-scan lidars).
+// Under the spatial policy the count is delegated to
+// SearchablePoseList::countNearby(), so the option is a documented no-op when
+// building against an older mola_pose_list without it:
+#if defined(MOLA_POSE_LIST_HAS_KFM_POSE_PLUMBING)
 TEST(KeyframeDecider, MinNearbyPosesOccupied)
 {
   auto o = defaultOptions();
   o.min_nearby_poses_occupied = 3;
 
-  mola::KeyframeDecider d;
+  mola::KeyframeDecider d(o);
 
   // Three keyframes at the very same place, then no more:
   for (int i = 0; i < 3; i++) {
     ASSERT_TRUE(d.check(o, at(0), i).create) << "i=" << i;
-    d.insert(o, at(0), i);
+    d.insert(at(0), i);
   }
   EXPECT_FALSE(d.check(o, at(0), 4.0).create);
   EXPECT_EQ(d.size(), 3u);
 }
+#endif
 
 // The temporal policy must NOT bypass the occupancy count: with both options
 // set, a spot still needs min_nearby_poses_occupied keyframes, and no more.
@@ -206,14 +211,14 @@ TEST(KeyframeDecider, MinNearbyPosesOccupiedWithTimeWindow)
   o.min_nearby_poses_occupied = 3;
   o.nearby_keyframe_time_window = 5.0;
 
-  mola::KeyframeDecider d;
+  mola::KeyframeDecider d(o);
 
   double t = 0;
 
   // Same place, well inside the window: 3 keyframes, then no more.
   for (int i = 0; i < 3; i++, t += 0.5) {
     ASSERT_TRUE(d.check(o, at(0), t).create) << "i=" << i;
-    d.insert(o, at(0), t);
+    d.insert(at(0), t);
   }
   EXPECT_FALSE(d.check(o, at(0), t).create);
   EXPECT_EQ(d.size(), 3u);
@@ -228,14 +233,76 @@ TEST(KeyframeDecider, MinNearbyPosesOccupiedWithTimeWindow)
 // creates keyframes even without the time window.
 TEST(KeyframeDecider, MeasureFromLastOnly)
 {
-  const auto o = defaultOptions();
-  mola::KeyframeDecider d(true /*measure_from_last_kf_only*/);
+  auto o = defaultOptions();
+  o.measure_from_last_kf_only = true;
+
+  mola::KeyframeDecider d(o);
 
   double t = 0;
   run(d, o, 0.0, 10.0, 0.25, t, 0.1);
 
   // Back to the origin: far from the LAST keyframe (at 10 m), so it creates.
   EXPECT_TRUE(d.check(o, at(0), t).create);
+}
+
+// measure_from_last_kf_only must keep meaning "only the last one" when the
+// temporal window is also enabled, instead of being silently ignored.
+TEST(KeyframeDecider, MeasureFromLastOnlyWithTimeWindow)
+{
+  auto o = defaultOptions();
+  o.measure_from_last_kf_only = true;
+  o.nearby_keyframe_time_window = 20.0;
+
+  mola::KeyframeDecider d(o);
+
+  double t = 0;
+  run(d, o, 0.0, 10.0, 0.25, t, 0.1);
+
+  // Only the last keyframe is ever retained as a decision reference:
+  EXPECT_EQ(d.activeSize(), 1u);
+
+  // Back to the origin: far from that last keyframe (at 10 m), so it creates.
+  EXPECT_TRUE(d.check(o, at(0), t).create);
+}
+
+// Keyframes explicitly dropped by the local-map cleanup must stop taking part
+// in the test under the temporal policy too.
+TEST(KeyframeDecider, RemoveAllFartherThanUnderTimeWindow)
+{
+  auto o = defaultOptions();
+  o.nearby_keyframe_time_window = 1000.0;  // long enough to retain everything
+
+  mola::KeyframeDecider d(o);
+
+  double t = 0;
+  run(d, o, 0.0, 10.0, 0.25, t, 0.1);
+  EXPECT_EQ(d.size(), 9u);
+
+  // Keep only what is within 2 m of the far end of the run:
+  d.removeAllFartherThan(at(10.0), 2.0);
+  EXPECT_LT(d.size(), 9u);
+
+  // The origin's keyframe is gone, so that spot admits a keyframe again:
+  EXPECT_TRUE(d.check(o, at(0), t).create);
+}
+
+// Out-of-order timestamps must not defeat the window pruning, which pops from
+// the front and therefore needs the entries to stay sorted in time.
+TEST(KeyframeDecider, NonMonotonicTimestamps)
+{
+  auto o = defaultOptions();
+  o.nearby_keyframe_time_window = 5.0;
+
+  mola::KeyframeDecider d(o);
+
+  d.insert(at(0), 100.0);
+  d.insert(at(2), 99.0);  // jitter: older than the previous one
+  d.insert(at(4), 101.0);
+
+  // Well past the window: all but the newest entry must have aged out, so the
+  // origin (whose keyframe is gone) asks for a new one.
+  EXPECT_TRUE(d.check(o, at(0), 200.0).create);
+  EXPECT_EQ(d.activeSize(), 1u);
 }
 
 int main(int argc, char ** argv)

--- a/test/test_keyframe_decider.cpp
+++ b/test/test_keyframe_decider.cpp
@@ -50,7 +50,7 @@ size_t run(
   for (int i = 0; i < nSteps; i++, t += dt) {
     const double x = fromX + i * step;
     if (d.check(o, at(x), t).create) {
-      d.insert(at(x), t);
+      d.insert(o, at(x), t);
       created++;
     }
   }
@@ -138,7 +138,7 @@ TEST(KeyframeDecider, StationaryVehicleDoesNotAccumulate)
 
   double t = 0;
   ASSERT_TRUE(d.check(o, at(0), t).create);
-  d.insert(at(0), t);
+  d.insert(o, at(0), t);
 
   // Parked for 10 minutes:
   for (int i = 0; i < 6000; i++) {
@@ -170,7 +170,7 @@ TEST(KeyframeDecider, RotationThreshold)
   const auto o = defaultOptions();
   mola::KeyframeDecider d;
 
-  d.insert(mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, 0, 0, 0), 0.0);
+  d.insert(o, mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, 0, 0, 0), 0.0);
 
   const auto smallTurn =
     mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, mrpt::DEG2RAD(10), 0, 0);
@@ -192,10 +192,36 @@ TEST(KeyframeDecider, MinNearbyPosesOccupied)
   // Three keyframes at the very same place, then no more:
   for (int i = 0; i < 3; i++) {
     ASSERT_TRUE(d.check(o, at(0), i).create) << "i=" << i;
-    d.insert(at(0), i);
+    d.insert(o, at(0), i);
   }
   EXPECT_FALSE(d.check(o, at(0), 4.0).create);
   EXPECT_EQ(d.size(), 3u);
+}
+
+// The temporal policy must NOT bypass the occupancy count: with both options
+// set, a spot still needs min_nearby_poses_occupied keyframes, and no more.
+TEST(KeyframeDecider, MinNearbyPosesOccupiedWithTimeWindow)
+{
+  auto o = defaultOptions();
+  o.min_nearby_poses_occupied = 3;
+  o.nearby_keyframe_time_window = 5.0;
+
+  mola::KeyframeDecider d;
+
+  double t = 0;
+
+  // Same place, well inside the window: 3 keyframes, then no more.
+  for (int i = 0; i < 3; i++, t += 0.5) {
+    ASSERT_TRUE(d.check(o, at(0), t).create) << "i=" << i;
+    d.insert(o, at(0), t);
+  }
+  EXPECT_FALSE(d.check(o, at(0), t).create);
+  EXPECT_EQ(d.size(), 3u);
+
+  // Past the window, all but the newest keyframe age out, so the occupancy
+  // count drops below the threshold and the spot admits keyframes again:
+  t += 100.0;
+  EXPECT_TRUE(d.check(o, at(0), t).create);
 }
 
 // measure_from_last_kf_only ignores all but the last keyframe, so a revisit


### PR DESCRIPTION
## Why

The decision "should this pose become a keyframe?" was purely spatial: a KD-tree nearest-neighbor search over **every** keyframe ever created. So revisiting an already-mapped area creates **no** new keyframes, because the previous pass' keyframes are the nearest neighbors.

That is right for the local metric map (a revisit adds no coverage), but it starves loop closure: a loop is only detectable once **both** of its endpoints exist as keyframes, so precisely the revisit that should close the loop produced nothing to close it with. This is a LiDAR-odometry-side issue: `mola_mapper` does not gate keyframe insertion at all, it accepts whatever the front end pushes through the `SharedKeyframeMap` sink.

## What

**1. Extract the shared policy** (no behavior change)

The local map and the simplemap each ran the same ~30 lines of copy-pasted decision code in `processLidarScan()`, with the same four options declared twice in `Parameters`. Both now use `mola::KeyframeDecider` + `mola::KeyframeDecisionOptions` (`KeyframeDecider.{h,cpp}`), one instance each, tuned independently.

`MapUpdateOptions` and `SimpleMapOptions` **derive** from `KeyframeDecisionOptions` rather than containing it, so every field stays a plain, non-nested YAML key of its section: **all existing pipeline YAMLs keep working with no parameter changes**. Loading lives in `Parameters::load_keyframe_policy()` because the two distance thresholds may be formulas that must register into `Parameters`' dynamic-parameter pool; options are passed to `check()` per call rather than held, so those formulas are still re-evaluated every scan.

Side benefit: the policy is now unit-testable without running a dataset.

**2. Add `nearby_keyframe_time_window`** [s], env hook `MOLA_SIMPLEMAP_KF_TIME_WINDOW`

When positive, only keyframes newer than that window take part in the redundancy test, so a revisit spawns fresh keyframes. The most recent keyframe always stays in the window whatever its age, otherwise a parked vehicle would emit one keyframe per window.

**Defaults to 0 (disabled), so this PR changes no behavior on its own.** It is meant for the simplemap (which feeds loop closure), not the local map.

## Testing

`test/test_keyframe_decider.cpp` (9 cases) covers both regimes: spatial spacing, the revisit-creates-nothing behavior, the revisit-creates-keyframes behavior with the window, the parked-vehicle case, unchanged forward spacing, the rotation threshold, `min_nearby_poses_occupied`, and `measure_from_last_kf_only`.

`colcon test`: 34 tests, 0 failures.

## Still pending

Accuracy validation on KITTI-00 and Oxford Spires with the window enabled, before considering a default flip for the simplemap. Expect the keyframe count (and hence graph size and LC candidate volume) to grow at revisits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a shared keyframe-creation policy for improved sparsity control across mapping and loop-closure behavior.
  - Added `nearby_keyframe_time_window` to constrain “revisit/already-mapped” decisions by keyframe recency.
- **Configuration**
  - Extended supported pipeline configs with `simplemap.nearby_keyframe_time_window` (default `0` = disabled) and updated keyframe threshold tuning in multiple presets.
  - Centralized policy parameters for translation, rotation, occupancy, and measurement-from-last-keyframe.
- **Documentation**
  - Expanded keyframe-policy guidance, including how the recency window and occupancy-based checks interact.
- **Tests**
  - Added a dedicated unit test target covering spatial, temporal, rotational, occupancy, and revisit regimes (including pruning/edge cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->