### PR TITLE
Stop the ICP debug-file functor shadowing MP2P_ICP_GENERATE_DEBUG_FILES

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -243,6 +243,20 @@ pipeline YAML, not read directly in C++.)
 | `LO_TEST_LIDAR_TOPIC` | string | (unset) | `test/test_lidar_odometry_rosbag2.cpp` | LiDAR topic name to read from the rosbag2 |
 | `LO_TEST_GT_TUM` | string | (unset) | both tests above | Path to the ground-truth trajectory (TUM format) |
 
+`functor_should_generate_debug_file` (the callback backing the two
+`MOLA_DEBUG_DUMP_ICP_LOG_*` vars above) is only installed on `icp_params`
+when one of them (or `write_debug_icp_log_if_quality_under`) is actually
+configured: `mp2p_icp::ICP::align()` gives an installed functor unconditional
+priority over its own `generateDebugFiles` / `MP2P_ICP_GENERATE_DEBUG_FILES`
+(and that path's `decimationDebugFiles` support), so an always-installed
+functor would silently shadow the global flag even when none of its own
+triggers fire. To dump every ICP call unconditionally, use
+`MP2P_ICP_GENERATE_DEBUG_FILES=1` with neither `MOLA_DEBUG_DUMP_ICP_LOG_*` var
+set. Each dumped `.icplog` embeds the full local-map snapshot for that call
+(tens of MB), so a wide from/to range or an unbounded `MP2P_ICP_GENERATE_DEBUG_FILES`
+run over a long dataset can reach tens of GB quickly; keep the range narrow
+(a few seconds) or rely on `decimationDebugFiles`.
+
 Plain `getenv()` calls remain only in `module/src/libcfgpath/cfgpath.h`
 (vendored third-party code resolving standard XDG base directories:
 `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_CACHE_HOME`, `HOME`) — these are OS

--- a/docs/mola_lo_pipelines.rst
+++ b/docs/mola_lo_pipelines.rst
@@ -699,6 +699,12 @@ ICP log files
   are saved whenever ICP quality drops below that threshold, independently of ``MP2P_ICP_GENERATE_DEBUG_FILES``.
   Useful for targeted debugging of bad frames without enabling full logging.
 
+- ``MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP`` / ``MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP`` (Default: ``0``, disabled):
+  A valid, non-empty window (both set, with ``TO >= FROM``) saves ``.icplog`` files for all ICP runs whose timestamp
+  falls within the ``[FROM, TO]`` range (in seconds, as Unix epoch or dataset time), independently of
+  ``MP2P_ICP_GENERATE_DEBUG_FILES``. Useful to capture a specific time window without enabling full logging. Each
+  ``.icplog`` embeds the full local-map snapshot for that call (tens of MB), so keep the range narrow.
+
 .. note::
 
    Enabling ICP log files is the most powerful tool to **debug mapping or localization** issues or to understand what
@@ -712,12 +718,6 @@ If ``MP2P_ICP_GENERATE_DEBUG_FILES`` is not enabled, the rest of parameters that
   optimization steps are also stored in the ICP logs. Great to learn how ICP actually works, but increases log file sizes.
 - ``MP2P_ICP_LOG_FILES_SAVE_DETAILS_DECIMATION`` (Default: ``3``): If ``MP2P_ICP_LOG_FILES_SAVE_DETAILS`` is enabled,
   how many ICP internal iterations to drop for each saved one.
-- ``MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP`` (Default: ``0``, disabled): If set to a non-zero value together with
-  ``MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP``, ICP log files are saved for all ICP runs whose timestamp falls within
-  the ``[FROM, TO]`` range (in seconds, as Unix epoch or dataset time). Useful to capture a specific time window
-  without enabling full logging.
-- ``MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP`` (Default: ``0``, disabled): Upper bound of the timestamp range for
-  selective ICP log dumping. Must be set together with ``MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP``.
 
 
 Trace debug files

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -572,17 +572,21 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     thread_local auto MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP =
       mrpt::get_env<double>("MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP", 0);
 
-    if (
-      params_.write_debug_icp_log_if_quality_under.has_value() ||
-      MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP > 0) {
+    // A half-open or reversed window (TO unset/zero, or earlier than FROM) can never match, so
+    // it must not install the functor either: doing so would shadow the native switch without
+    // ever dumping anything.
+    const bool hasTimestampWindow = MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP > 0 &&
+      MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP >= MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP;
+
+    if (params_.write_debug_icp_log_if_quality_under.has_value() || hasTimestampWindow) {
       icp_params.functor_should_generate_debug_file =
-        [this](const mp2p_icp::LogRecord & log) -> bool {
+        [this, hasTimestampWindow](const mp2p_icp::LogRecord & log) -> bool {
         const bool cond_1 =
           params_.write_debug_icp_log_if_quality_under.has_value() &&
           log.icpResult.quality < params_.write_debug_icp_log_if_quality_under.value();
 
         const bool cond_2 =
-          (MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP > 0 && state_.last_icp_timestamp.has_value() &&
+          (hasTimestampWindow && state_.last_icp_timestamp.has_value() &&
            mrpt::Clock::toDouble(*state_.last_icp_timestamp) >=
              MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP &&
            mrpt::Clock::toDouble(*state_.last_icp_timestamp) <=

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -575,7 +575,8 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     // A half-open or reversed window (TO unset/zero, or earlier than FROM) can never match, so
     // it must not install the functor either: doing so would shadow the native switch without
     // ever dumping anything.
-    const bool hasTimestampWindow = MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP > 0 &&
+    const bool hasTimestampWindow =
+      MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP > 0 &&
       MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP >= MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP;
 
     if (params_.write_debug_icp_log_if_quality_under.has_value() || hasTimestampWindow) {

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -585,7 +585,8 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
           (MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP > 0 && state_.last_icp_timestamp.has_value() &&
            mrpt::Clock::toDouble(*state_.last_icp_timestamp) >=
              MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP &&
-           mrpt::Clock::toDouble(*state_.last_icp_timestamp) <= MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP);
+           mrpt::Clock::toDouble(*state_.last_icp_timestamp) <=
+             MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP);
 
         return cond_1 || cond_2;
       };

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -561,27 +561,35 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     auto icp_params = in.icp_params;
     size_t remainingIcpIters = icp_params.maxIterations;
 
-    // Debug helper: dump ICP logs to file if quality is under a threshold, or if the timestamp is within a range:
-    icp_params.functor_should_generate_debug_file =
-      [this](const mp2p_icp::LogRecord & log) -> bool {
-      // Debug helper: dump icp logs for from-to timestamps only:
-      thread_local auto MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP =
-        mrpt::get_env<double>("MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP", 0);
-      thread_local auto MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP =
-        mrpt::get_env<double>("MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP", 0);
+    // Debug helper: dump ICP logs to file if quality is under a threshold, or if the timestamp is
+    // within a range. Only install the predicate when one of those two triggers is actually
+    // configured: mp2p_icp::ICP::align() gives an installed functor unconditional priority over its
+    // own `generateDebugFiles`/`MP2P_ICP_GENERATE_DEBUG_FILES` (and that path's `decimationDebugFiles`
+    // support), so always installing it here silently shadowed that global switch (see
+    // functor_should_generate_debug_file's use in mp2p_icp/src/ICP.cpp).
+    thread_local auto MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP =
+      mrpt::get_env<double>("MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP", 0);
+    thread_local auto MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP =
+      mrpt::get_env<double>("MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP", 0);
 
-      const bool cond_1 =
-        params_.write_debug_icp_log_if_quality_under.has_value() &&
-        log.icpResult.quality < params_.write_debug_icp_log_if_quality_under.value();
+    if (
+      params_.write_debug_icp_log_if_quality_under.has_value() ||
+      MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP > 0) {
+      icp_params.functor_should_generate_debug_file =
+        [this](const mp2p_icp::LogRecord & log) -> bool {
+        const bool cond_1 =
+          params_.write_debug_icp_log_if_quality_under.has_value() &&
+          log.icpResult.quality < params_.write_debug_icp_log_if_quality_under.value();
 
-      const bool cond_2 =
-        (MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP > 0 && state_.last_icp_timestamp.has_value() &&
-         mrpt::Clock::toDouble(*state_.last_icp_timestamp) >=
-           MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP &&
-         mrpt::Clock::toDouble(*state_.last_icp_timestamp) <= MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP);
+        const bool cond_2 =
+          (MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP > 0 && state_.last_icp_timestamp.has_value() &&
+           mrpt::Clock::toDouble(*state_.last_icp_timestamp) >=
+             MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP &&
+           mrpt::Clock::toDouble(*state_.last_icp_timestamp) <= MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP);
 
-      return cond_1 || cond_2;
-    };
+        return cond_1 || cond_2;
+      };
+    }
 
     do {
       icp_params.maxIterations = remainingIcpIters;


### PR DESCRIPTION
## Problem

`MP2P_ICP_GENERATE_DEBUG_FILES=1` silently did nothing — no `icp-logs` directory was ever created.

Cause: `processLidarScan()` installed `icp_params.functor_should_generate_debug_file` on **every** ICP call, and `mp2p_icp::ICP::align()` gives an installed functor unconditional priority over its own `generateDebugFiles` / `MP2P_ICP_GENERATE_DEBUG_FILES` switch — along with that path's `decimationDebugFiles` support. So the always-installed functor shadowed the global flag even when none of the functor's own triggers were configured.

## Change

Only install the predicate when one of its own triggers is actually set: `write_debug_icp_log_if_quality_under`, or the `MOLA_DEBUG_DUMP_ICP_LOG_FROM/TO_TIMESTAMP` range. Otherwise the native mp2p_icp path stays in charge, including decimation.

The `thread_local` env reads are hoisted out of the lambda so the `if` can test them.

## Docs

`agents.md` now records how the two mechanisms interact, and warns that each dumped `.icplog` embeds a full local-map snapshot (tens of MB each), so a wide from/to range — or an unbounded `MP2P_ICP_GENERATE_DEBUG_FILES` run over a long dataset — reaches tens of GB quickly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for selective ICP `.icplog` dumping via `MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP` / `MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP`, including valid-window rules, independence from debug-file generation, and large file/data-size cautions (each dump includes a full local-map snapshot).
  * Clarified how debug-file generation can affect other ICP dump behaviors when enabled.

* **Bug Fixes**
  * ICP debug-log capture is now enabled only when relevant dump settings are configured (quality threshold and/or a valid timestamp window).
  * Preserves the existing quality-threshold and inclusive `[FROM, TO]` filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->