### PR TITLE
Add IMU gravity correction with preintegration method and ICP prior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ set(LIB_SRCS
   module/src/LidarOdometry_AdaptiveVariables.cpp
   module/src/LidarOdometry_MapServer.cpp
   module/src/LidarOdometry_GUI.cpp
+  module/src/LidarOdometry_GravityEstimation.cpp
   module/src/LidarOdometry_SensorCallbacks.cpp
   module/src/LidarOdometry_Publish.cpp
   module/src/LidarOdometry_InitialLocalization.cpp

--- a/agents.md
+++ b/agents.md
@@ -223,6 +223,69 @@ over multiple frames. Two consequences for pipeline tuning:
 See `mola-cli-launchs/lidar_odometry_from_botanicgarden_livox.yaml` for a
 complete example with all three env vars set.
 
+## IMU gravity correction: two methods behind one interface
+
+`Parameters::IMUGravityCorrection::method` selects how the gravity direction
+feeding the ICP prior's pitch/roll is obtained. Both live behind
+`LidarOdometry::estimateGravityPitchRoll()`
+(`module/src/LidarOdometry_GravityEstimation.cpp`), which returns map-frame
+pitch/roll PLUS the sigma to weight them with, so `LidarOdometry_ProcessScan.cpp`
+holds no method-specific logic.
+
+- **`AccelAverage`** (DEFAULT, legacy): averages the last N raw accelerometer
+  samples (`state_.gravity_estimator`). A single sample is gravity PLUS body
+  acceleration, so this is only valid while quasi-static: under sustained
+  motion it is biased, not merely noisy. Uses the fixed `sigma_deg`, and the
+  `gravity_calib_pitch_roll` map-origin offset to re-express absolute IMU tilt
+  in the (possibly non-level) map frame.
+- **`Preintegration`**: drives `mola::imu::MapGravityEstimator`, which
+  estimates the gravity vector IN THE MAP FRAME from preintegrated IMU aided by
+  LO's own attitudes and velocities. Body acceleration cancels out, so it stays
+  valid while moving arbitrarily. Reports its OWN earned sigma. The
+  `gravity_calib_pitch_roll` composition is deliberately NOT applied here: `g_M`
+  is already expressed in the map frame, so composing it would double-count.
+
+Wiring notes:
+- Intervals are closed on a fixed TIME CADENCE (`interval_duration`, default
+  0.5 s), NOT on the keyframe policy: real keyframe spacing reaches many seconds
+  (Oxford: 3.4 s mean / 15.9 s max), too long for the constant-bias assumption,
+  and it would couple this to `simplemap.generate`.
+- Samples are drained from the SHARED de-skew
+  `state_.parameter_source.localVelocityBuffer`, whose retention is widened to
+  `buffer_retention_sec` (default 60 s) at init. Its samples are already
+  body-frame with the lever arm applied (the mp2p_icp `Generator` runs them
+  through `mola::imu::ImuTransformer`). The default retention is 0.5 s; a buffer
+  shorter than the interval silently yields a partial delta attributed to the
+  whole interval, so `Parameters::initialize()` REFUSES such a configuration
+  outright instead of relying on the runtime coverage guard.
+- Only a GOOD ICP feeds the estimator: its attitude and velocity are the
+  inputs, and a failed registration would poison them.
+- `NavState::twist` is in the LOCAL VEHICLE frame, so it is rotated to the map
+  frame; the twist information matrix is inverted and rotated for the real
+  velocity covariance, with a loose default when singular.
+- Fallback is automatic: not converged, sigma above `max_accepted_sigma_deg`,
+  or no estimator yet falls through to `AccelAverage`, which is what works at
+  start-up while still quasi-static.
+
+**Correction scope**: by default the local map and the simplemap are NEVER
+modified; the correction applies to the CURRENT POSE only, through the ICP prior.
+Tilt already baked into the map is therefore not removed. On real drifting
+sequences the prior is a modest net win (MulRan DCC01: APE -14%); where the
+baseline is already gravity-aligned it is neutral.
+
+There is an EXPERIMENTAL, off-by-default map-releveling path
+(`imu_gravity_correction.tilt_rebake`, `LidarOdometry::updateMapReleveling()`):
+it rotates the active local-map keyframes to level, sourcing gravity from the
+preintegration `g_M`, and resets the estimator each rebake to break a feedback
+loop. It DOES drive the reported attitude to vertical, but it injects a
+CONTINUOUS vertical-position leak (net position worse) that is not solved by the
+current-pose pivot, estimator reset, or shrinking the local map. It is kept as a
+research scaffold only; do NOT enable in production. The older
+`GravityMapAligner` + `TrajectoryRebaker` classes remain as reusable primitives.
+
+Design + status: `~/plans/801_lio_imu_preintegration_gravity.md` and
+`~/plans/802_mola_lo_map_level_gravity_rebake.md`.
+
 ## Environment Variables (Debug/Tracing Flags)
 
 Debug/tracing flags in C++ code use `mrpt::get_env<T>(name, default)` (from

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -40,7 +40,19 @@
 
 // Other packages:
 #include <mola_imu_preintegration/ImuInitialCalibrator.h>
+#include <mola_imu_preintegration/ImuTransformer.h>
+#include <mola_imu_preintegration/LocalVelocityBuffer.h>
+#if __has_include(<mola_imu_preintegration/MapGravityEstimator.h>)
+#include <mola_imu_preintegration/MapGravityEstimator.h>
+/// Set when the available mola_imu_preintegration provides the
+/// preintegration-based gravity estimator, i.e. when
+/// IMUGravityCorrection::Method::Preintegration can be built. Older checkouts
+/// only offer the accelerometer-average method.
+#define MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR 1
+#endif
+#include <mola_lidar_odometry/GravityMapAligner.h>
 #include <mola_lidar_odometry/KeyframeDecider.h>
+#include <mola_lidar_odometry/TrajectoryRebaker.h>
 
 // MP2P_ICP
 #include <mp2p_icp/ICP.h>
@@ -551,11 +563,32 @@ public:
 
     struct IMUGravityCorrection
     {
+      /// How the gravity direction is estimated.
+      enum class Method : uint8_t
+      {
+        /// Average the last N raw accelerometer samples. Only valid while the
+        /// vehicle is quasi-static: a single sample is gravity PLUS body
+        /// acceleration, so under sustained motion this is biased, not merely
+        /// noisy.
+        AccelAverage = 0,
+
+        /// Estimate the gravity vector in the map frame from preintegrated IMU
+        /// measurements aided by the odometry's own poses and velocities
+        /// (mola::imu::MapGravityEstimator). Body acceleration cancels out, so
+        /// this stays valid while moving arbitrarily.
+        Preintegration,
+      };
+
       /// Enable accelerometer-based pitch/roll correction in ICP prior.
       bool enabled = true;
 
+      /// Which estimator to use. Defaults to the legacy accelerometer average.
+      Method method = Method::AccelAverage;
+
       /// Sigma [degrees] for the gravity-derived pitch/roll prior.
-      /// Lower values = more trust in IMU. Typical: 1–5 deg.
+      /// Lower values = more trust in IMU. Typical: 1-5 deg.
+      /// Only used by Method::AccelAverage: the preintegration method reports
+      /// its own "earned" sigma, propagated from its information matrix.
       double sigma_deg = 2.0;
 
       /// Number of recent accelerometer samples to average for gravity estimation.
@@ -564,6 +597,96 @@ public:
       /// Maximum age [seconds] for accelerometer samples used in averaging.
       /// Samples older than this are discarded. 0 = no age limit.
       double max_age_seconds = 2.0;
+
+      /** \name Method::Preintegration only
+       *  @{ */
+
+      /// Nominal duration [s] of one preintegration interval. Intervals are
+      /// closed on this time cadence rather than on the keyframe policy: real
+      /// keyframe spacing can reach many seconds, which is too long for the
+      /// constant-bias assumption and yields too few intervals per window.
+      double interval_duration = 0.5;
+
+      /// Retention [s] forced on the shared de-skew LocalVelocityBuffer while
+      /// this method is active. MUST comfortably exceed interval_duration: a
+      /// buffer shorter than the interval silently yields a partial delta
+      /// attributed to the whole interval, which corrupts every constraint
+      /// (the interval-coverage guard exists to catch exactly that).
+      double buffer_retention_sec = 60.0;
+
+      /// Accelerometer noise density [m/s^2/sqrt(Hz)].
+      double accel_noise_sigma = 3e-2;
+
+      /// Gyroscope noise density [rad/s/sqrt(Hz)].
+      double gyro_noise_sigma = 3e-3;
+
+      /// Maximum sigma [degrees] of the estimated correction still accepted
+      /// for injection into the ICP prior.
+      double max_accepted_sigma_deg = 2.0;
+
+      /// Floor [degrees] applied to the estimator's own "earned" sigma before
+      /// it is used to weight the ICP prior. The information matrix can grow
+      /// very confident over a long window, and a prior far tighter than the
+      /// ICP's own attitude accuracy destabilizes registration.
+      double min_sigma_deg = 0.5;
+
+      /// Ceiling [degrees] on the applied prior sigma. Independent of the
+      /// acceptance gate (`max_accepted_sigma_deg`): the gate decides whether an
+      /// estimate is used at all, this caps how strong the resulting pitch/roll
+      /// prior is. Lowering it strengthens the gravity constraint on pitch/roll
+      /// ONLY (the prior touches just cov_inv(4,4)/(5,5)), pinning attitude to
+      /// gravity while leaving ICP's full strength on x/y/z/yaw. Default is
+      /// effectively disabled (uses the earned sigma as-is).
+      double max_applied_sigma_deg = 1e6;
+
+#if defined(MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR)
+      /// Parameters of the underlying sliding-window estimator.
+      mola::imu::MapGravityEstimator::Parameters estimator;
+#endif
+
+      /** @} */
+
+      /** Map-level gravity re-leveling ("rebake"). EXPERIMENTAL, OFF by default.
+       *  Periodically rotates the local-map keyframes (and cached pose/twist) so
+       *  the accumulated map tilt is removed at its source, sourcing gravity from
+       *  the preintegration estimator (g_M).
+       *
+       *  KNOWN LIMITATION (do not enable in production): it drives the reported
+       *  attitude to true vertical (DCC01 tilt 3.5 -> 2.0 deg) but injects a
+       *  CONTINUOUS vertical-position leak (DCC01 vertical APE 8.5 -> ~39 m),
+       *  independent of local-map size. Re-leveling the map's attitude about the
+       *  trailing current pose displaces the forward map in Z, which the
+       *  forward-driving vehicle then accumulates as position drift. Net position
+       *  is worse than both the plain baseline and the per-scan prior, so this is
+       *  kept only as a research scaffold, not a usable feature. */
+      struct TiltRebake
+      {
+        /// Master switch. Off by default. EXPERIMENTAL: has an unresolved
+        /// vertical-position leak (see struct docs); do not enable in production.
+        bool enabled = false;
+
+        /// Only rebake when the local map's z-axis tilt vs measured gravity
+        /// exceeds this [degrees].
+        double trigger_deg = 2.0;
+
+        /// Minimum wall-clock spacing [s] between rebakes (throttle).
+        double min_interval_sec = 5.0;
+
+        /// Require at least this many active keyframes before rebaking.
+        uint32_t min_active_keyframes = 5;
+
+        /// Half-width P of the per-KF averaging window Window(i)=[i-P, i+P] used
+        /// by GravityMapAligner::estimatePerKFCorrection.
+        uint32_t window_half_width = 5;
+
+        /// Minimum pool members inside Window(i) required to emit a per-KF
+        /// correction (else that KF is passed through with identity).
+        uint32_t min_pool_per_kf = 3;
+
+        void initialize(const Yaml & c);
+      };
+
+      TiltRebake tilt_rebake;
 
       void initialize(const Yaml & c);
     };
@@ -700,6 +823,22 @@ public:
 
   /** @} */
 
+  /** Pure geometry: the vehicle's absolute (pitch, roll) with respect to TRUE
+   *  VERTICAL, given the gravity vector expressed in the MAP frame and the
+   *  vehicle's attitude in that same map frame.
+   *
+   *  This is the correct way to feed a map-frame gravity estimate into the ICP
+   *  prior: the answer must describe the VEHICLE's tilt (so it can be compared
+   *  against a raw accelerometer reading), NOT the map's tilt. Left-multiplying
+   *  the pose by a map-leveling rotation instead returns the map tilt and makes
+   *  the prior fight the (unchanged) local map. Kept as a static, dependency-
+   *  free function precisely so this invariant is unit-testable.
+   *
+   *  Returns nullopt for a degenerate (near-zero) gravity vector.
+   */
+  static std::optional<std::pair<double, double>> vehiclePitchRollFromMapGravity(
+    const mrpt::math::TVector3D & gravity_in_map, const mrpt::poses::CPose3D & vehiclePose);
+
   /** @name Virtual interface of MapServer
      *{ */
 
@@ -822,6 +961,44 @@ private:
 
     GravityEstimator gravity_estimator;
 
+    /// Sliding-window estimator of the gravity vector in the map frame, used
+    /// by IMUGravityCorrection::Method::Preintegration. Unlike
+    /// `gravity_estimator` above, it stays valid while the vehicle is moving,
+    /// because body acceleration cancels out in the preintegrated delta.
+    /// Only instantiated when that method is selected.
+#if defined(MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR)
+    std::optional<mola::imu::MapGravityEstimator> map_gravity_estimator;
+#endif
+
+    /// Noise densities handed to the preintegrator, built once from the
+    /// IMUGravityCorrection parameters.
+    mola::imu::ImuIntegrationParams imu_preint_params;
+
+    /// DEDICATED long-retention buffer of body-frame IMU samples feeding
+    /// `map_gravity_estimator`. Deliberately NOT the shared de-skew buffer
+    /// (`parameter_source.localVelocityBuffer`): that one is sized for a
+    /// single scan (0.5 s) and is also consumed by trajectory_from_buffer()
+    /// for de-skew, which anchors on the newest sample and integrates
+    /// outwards. Widening it to cover a gravity interval changes what de-skew
+    /// sees and diverged the solution on real data.
+    mola::imu::LocalVelocityBuffer gravity_imu_buffer;
+
+    /// Per-sensorLabel transformers moving raw IMU readings into the vehicle
+    /// frame (rotation + lever arm) before they enter gravity_imu_buffer.
+    std::map<std::string, mola::imu::ImuTransformer> gravity_imu_transformers;
+
+    /// Start of the preintegration interval currently being accumulated: the
+    /// odometry pose and map-frame velocity at that instant, which become the
+    /// `from` end of the next interval handed to `map_gravity_estimator`.
+    struct GravityIntervalAnchor
+    {
+      double timestamp = 0;  ///< seconds, sensor clock
+      mrpt::poses::CPose3D pose;
+      mrpt::math::TVector3D v_map{0, 0, 0};
+      mrpt::math::CMatrixDouble33 cov_v_map;
+    };
+    std::optional<GravityIntervalAnchor> gravity_interval_anchor;
+
     /// Gravity-derived (pitch, roll), in radians, captured at the time the first
     /// keyframe (map origin) was created. The IMU gravity estimator reports
     /// *absolute* tilt with respect to true vertical, while the map/global frame
@@ -830,6 +1007,23 @@ private:
     /// offset is required to correctly re-express later absolute IMU tilt
     /// readings relative to the (possibly non-level) map frame.
     std::optional<std::pair<double, double>> gravity_calib_pitch_roll;
+
+    /// Per-KF accelerometer pool driving the map-level rebake (T802). Fed a
+    /// sample per local-map keyframe; produces per-KF pitch/roll corrections
+    /// consumed by TrajectoryRebaker. Independent of `map_gravity_estimator`,
+    /// which drives the fast per-scan ICP prior.
+    mola::GravityMapAligner gravity_map_aligner;
+
+    /// Wall-clock time of the last successful tilt rebake (throttle).
+    std::optional<mrpt::Clock::time_point> last_gravity_rebake_tim;
+
+    /// One-time latch: warn once if tilt_rebake is enabled but the configured
+    /// local-map layer does not implement KeyframeMapCapable.
+    bool gravity_rebake_unsupported_warned = false;
+
+    /// Accumulated left-composed residual keeping the PUBLISHED pose stream
+    /// continuous across rebakes (published = rebake_publish_residual + live).
+    mrpt::poses::CPose3D rebake_publish_residual;
 
     mrpt::poses::CPose3DPDFGaussian last_lidar_pose;  //!< in local map
 
@@ -1240,6 +1434,58 @@ private:
   void appendKeyframeMetadataObs(
     mrpt::obs::CSensoryFrame & keyframe_obs, const mrpt::Clock::time_point & scan_ref_time,
     const mp2p_icp::metric_map_t & observation);
+
+  /** Advances the map-gravity estimator with the odometry state just solved
+   *  for this scan (Method::Preintegration only).
+   *
+   *  Opens the first interval on the first call, and thereafter closes one
+   *  whenever `interval_duration` has elapsed: it drains the IMU samples of
+   *  the elapsed span from the shared de-skew buffer, preintegrates them, and
+   *  hands the interval plus both endpoints' poses/velocities to the
+   *  estimator, then re-solves.
+   *
+   *  @param timestamp  Scan reference time (seconds, sensor clock).
+   *  @param vehiclePose  Vehicle pose in the map frame.
+   *  @param twist  Vehicle twist, in the LOCAL VEHICLE frame (as NavState
+   *                defines it); rotated to the map frame internally.
+   *  @param twistInvCov  Information matrix of the twist, same frame.
+   */
+  void updateMapGravityEstimator(
+    double timestamp, const mrpt::poses::CPose3D & vehiclePose,
+    const std::optional<mrpt::math::TTwist3D> & twist,
+    const std::optional<mrpt::math::CMatrixDouble66> & twistInvCov);
+
+  /** Returns the gravity-corrected (pitch, roll) of `vehiclePose` in the map
+   *  frame, together with the sigma to weight them with, or nullopt when no
+   *  usable estimate is available (so the caller can fall back).
+   *  Implements both IMUGravityCorrection methods behind one interface.
+   */
+  struct GravityPitchRoll
+  {
+    double pitch = 0;      ///< [rad]
+    double roll = 0;       ///< [rad]
+    double sigma_rad = 0;  ///< sigma to apply to BOTH pitch and roll
+  };
+  std::optional<GravityPitchRoll> estimateGravityPitchRoll(
+    const mrpt::poses::CPose3D & vehiclePose) const;
+
+  /** Re-expresses an absolute (gravity-referenced) pitch/roll into the map
+   *  frame, using the tilt recorded at the map origin as a calibration offset.
+   *  Shared by both IMUGravityCorrection methods.
+   */
+  std::optional<GravityPitchRoll> applyGravityCalibration(
+    double imu_pitch, double imu_roll, double sigma_rad) const;
+
+  /** Map-level gravity re-leveling ("rebake"), driven from onLidar after a
+   *  local-map update. Syncs the per-KF accelerometer pool with the current
+   *  local-map keyframes (feeding new KFs, dropping evicted ones) and, when
+   *  the local map's accumulated tilt exceeds `tilt_rebake.trigger_deg` and the
+   *  throttle allows, rotates the local map, the in-progress simplemap and the
+   *  cached trajectory/pose so the tilt is removed at its source. No-op unless
+   *  the local-map layer implements KeyframeMapCapable. Must be called with
+   *  state_mtx_ held.
+   */
+  void updateMapReleveling(const mrpt::Clock::time_point & scan_tim);
 };
 
 namespace detail

--- a/module/src/LidarOdometry_GravityEstimation.cpp
+++ b/module/src/LidarOdometry_GravityEstimation.cpp
@@ -1,0 +1,445 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   LidarOdometry_GravityEstimation.cpp
+ * @brief  Gravity-direction estimation feeding the ICP prior's pitch/roll.
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include <mola_imu_preintegration/ImuPreintegrator.h>
+#include <mola_kernel/interfaces/KeyframeMapCapable.h>
+#include <mola_lidar_odometry/LidarOdometry.h>
+#include <mrpt/poses/CPose3D.h>
+
+#include <Eigen/Dense>
+#include <algorithm>
+
+// The map-level rebake needs the mola_kernel KeyframeMapCapable interface
+// (mutable per-KF poses). mola_kernel is a hard dependency, but guard on the
+// header so an older kernel without the interface degrades gracefully.
+#if defined(__has_include) && __has_include(<mola_kernel/interfaces/KeyframeMapCapable.h>)
+#define MOLA_LO_HAS_KFM_RELEVELING 1
+#endif
+
+namespace mola
+{
+namespace
+{
+/// Largest gap [s] between consecutive IMU samples still integrated: a longer
+/// one means a sensor dropout, and integrating across it would fabricate data.
+constexpr double MAX_IMU_SAMPLE_GAP = 1.0;
+
+mrpt::math::TVector3D rotate(const mrpt::poses::CPose3D & pose, const mrpt::math::TVector3D & v)
+{
+  return pose.rotateVector(v);
+}
+}  // namespace
+
+void LidarOdometry::updateMapGravityEstimator(
+  const double timestamp, const mrpt::poses::CPose3D & vehiclePose,
+  const std::optional<mrpt::math::TTwist3D> & twist,
+  const std::optional<mrpt::math::CMatrixDouble66> & twistInvCov)
+{
+  if (
+    !params_.imu_gravity_correction.enabled ||
+    params_.imu_gravity_correction.method !=
+      Parameters::IMUGravityCorrection::Method::Preintegration) {
+    return;
+  }
+
+  // Without a velocity estimate there is nothing to anchor an interval on:
+  // the whole method rests on comparing the odometry's velocity change against
+  // the preintegrated one.
+  if (!twist.has_value()) {
+    return;
+  }
+
+#if !defined(MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR)
+  // Built against an older mola_imu_preintegration: the method is rejected at
+  // parameter-load time, so this path is unreachable.
+  return;
+#else
+  auto & est = state_.map_gravity_estimator;
+  if (!est.has_value()) {
+    est.emplace();
+    est->parameters = params_.imu_gravity_correction.estimator;
+
+    // Seed the bias priors from the at-rest calibration, when available: a
+    // better prior center directly improves the weakly-observable accel bias.
+    if (state_.imu_initializer.has_value()) {
+      if (const auto calib = state_.imu_initializer->getCalibration(); calib.has_value()) {
+        est->set_bias_prior(calib->bias_acc_b, calib->bias_gyro);
+      }
+    }
+  }
+
+  // Map-frame velocity and its covariance (NavState twist is expressed in the
+  // LOCAL VEHICLE frame, so it has to be rotated):
+  const mrpt::math::TVector3D v_body{twist->vx, twist->vy, twist->vz};
+  const mrpt::math::TVector3D v_map = rotate(vehiclePose, v_body);
+
+  mrpt::math::CMatrixDouble33 cov_v_map =
+    mola::imu::MapGravityEstimator::Interval::defaultVelocityCov();
+  if (twistInvCov.has_value()) {
+    // Invert the linear-velocity block of the information matrix, then rotate
+    // it into the map frame. Fall back to the loose default if it is singular
+    // (a common case when the estimator has not converged yet).
+    const auto infoLin = twistInvCov->blockCopy<3, 3>(0, 0);
+    if (const double d = infoLin.det(); std::isfinite(d) && d > 1e-12) {
+      const auto R = vehiclePose.getRotationMatrix().asEigen();
+      cov_v_map.asEigen() = R * infoLin.asEigen().inverse() * R.transpose();
+    }
+  }
+
+  // ---- First call: just open the interval ------------------------------
+  if (!state_.gravity_interval_anchor.has_value()) {
+    auto & a = state_.gravity_interval_anchor.emplace();
+    a.timestamp = timestamp;
+    a.pose = vehiclePose;
+    a.v_map = v_map;
+    a.cov_v_map = cov_v_map;
+    return;
+  }
+
+  const auto & anchor = *state_.gravity_interval_anchor;
+
+  const double elapsed = timestamp - anchor.timestamp;
+  if (elapsed < params_.imu_gravity_correction.interval_duration) {
+    return;  // keep accumulating
+  }
+  if (elapsed <= 0) {
+    // Non-monotonic stamp: restart the interval rather than feed garbage.
+    state_.gravity_interval_anchor.reset();
+    return;
+  }
+
+  // ---- Close the interval ------------------------------------------------
+  // Drain the IMU samples of this span from the DEDICATED long-retention
+  // buffer (fed in onIMUImpl through our own ImuTransformer, so the samples
+  // are already in the vehicle frame with the lever arm applied).
+  const auto window = state_.gravity_imu_buffer.window_since(anchor.timestamp, timestamp);
+
+  mola::imu::ImuPreintegrator pim(state_.imu_preint_params);
+  pim.reset_integration();
+
+  double tPrev = anchor.timestamp;
+  for (const auto & [ta, a_b] : window.a_b) {
+    const double dt = ta - tPrev;
+    tPrev = ta;
+    if (dt <= 0 || dt > MAX_IMU_SAMPLE_GAP) {
+      continue;
+    }
+    mrpt::math::TVector3D w_b{0, 0, 0};
+    if (const auto itw = window.w_b.find(ta); itw != window.w_b.end()) {
+      w_b = itw->second;
+    }
+    pim.integrate_measurement(a_b, w_b, dt);
+  }
+
+  mola::imu::MapGravityEstimator::Interval itv;
+  itv.t_from = anchor.timestamp;
+  itv.t_to = timestamp;
+  itv.delta = pim.current_state();
+  itv.R_from = anchor.pose.getRotationMatrix();
+  itv.R_to = vehiclePose.getRotationMatrix();
+  itv.v_from = anchor.v_map;
+  itv.v_to = v_map;
+  itv.cov_v_from = anchor.cov_v_map;
+  itv.cov_v_to = cov_v_map;
+
+  if (est->add_interval(itv)) {
+    est->solve();
+
+    if (const auto & r = est->latest_result(); r.has_value()) {
+      MRPT_LOG_DEBUG_FMT(
+        "Map-gravity estimate: tilt=%.3f deg (pitch=%.3f roll=%.3f, sigma=%.3f/%.3f deg), "
+        "|g|=%.4f, b_a=%s, b_g=%s, %zu intervals, %s",
+        mrpt::RAD2DEG(r->tilt), mrpt::RAD2DEG(r->pitch_correction),
+        mrpt::RAD2DEG(r->roll_correction), mrpt::RAD2DEG(r->pitch_sigma),
+        mrpt::RAD2DEG(r->roll_sigma), r->gravity_in_map.norm(), r->bias_acc.asString().c_str(),
+        r->bias_gyro.asString().c_str(), r->num_intervals,
+        r->converged ? "CONVERGED" : "not converged");
+    }
+  } else {
+    // Rejections are expected and benign (a dropout, a stamp glitch); the
+    // unknowns are global, so a skipped interval leaves nothing unconstrained.
+    MRPT_LOG_THROTTLE_WARN_FMT(
+      5.0, "Map-gravity interval rejected: %s", est->last_rejection_reason().c_str());
+  }
+
+  // Re-anchor for the next interval. Chaining exactly (the new `from` is this
+  // `to`) means every IMU sample belongs to exactly one interval.
+  auto & a = *state_.gravity_interval_anchor;
+  a.timestamp = timestamp;
+  a.pose = vehiclePose;
+  a.v_map = v_map;
+  a.cov_v_map = cov_v_map;
+#endif
+}
+
+std::optional<LidarOdometry::GravityPitchRoll> LidarOdometry::estimateGravityPitchRoll(
+  const mrpt::poses::CPose3D & vehiclePose) const
+{
+  using Method = Parameters::IMUGravityCorrection::Method;
+
+  if (!params_.imu_gravity_correction.enabled) {
+    return {};
+  }
+
+  const double sigma_deg_default = params_.imu_gravity_correction.sigma_deg;
+
+  // ---- Preintegration method -------------------------------------------
+#if defined(MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR)
+  if (params_.imu_gravity_correction.method == Method::Preintegration) {
+    if (state_.map_gravity_estimator.has_value()) {
+      const auto & r = state_.map_gravity_estimator->latest_result();
+      if (r.has_value() && r->converged) {
+        const double s = std::max(r->pitch_sigma, r->roll_sigma);
+        if (s <= mrpt::DEG2RAD(params_.imu_gravity_correction.max_accepted_sigma_deg)) {
+          // The estimator yields gravity in the MAP frame. Transport it into
+          // the current VEHICLE frame with the odometry attitude, so what this
+          // function returns has exactly the same meaning as the accelerometer
+          // average below: the vehicle's tilt with respect to true vertical.
+          //
+          // Do NOT instead left-multiply the pose by the estimator's leveling
+          // `correction`: that expresses the pose in a re-leveled frame while
+          // the local map stays in the old one, so the ICP prior ends up
+          // fighting the map's own geometry. Measured on Oxford Spires, that
+          // diverged the solution after ~57 s.
+          //
+          // In the single-interval limit this reduces exactly to the raw
+          // accelerometer reading; the gain comes from the window averaging,
+          // the body-acceleration cancellation and the bias estimation.
+          if (const auto pr = vehiclePitchRollFromMapGravity(r->gravity_in_map, vehiclePose);
+              pr.has_value()) {
+            // Floor the earned sigma: the information matrix can grow very
+            // confident over a long window, and a prior far tighter than the
+            // ICP's own attitude accuracy destabilizes registration.
+            const double sigma_rad =
+              std::max(s, mrpt::DEG2RAD(params_.imu_gravity_correction.min_sigma_deg));
+            return applyGravityCalibration(pr->first, pr->second, sigma_rad);
+          }
+        }
+      }
+    }
+    // Not converged yet: fall through to the accelerometer average, which at
+    // least works while the vehicle is still quasi-static at start-up.
+  }
+#endif
+
+  // ---- Accelerometer-average method (also the not-converged fallback) ----
+  const auto gravityPR = state_.gravity_estimator.estimatedPitchRoll(
+    params_.imu_gravity_correction.averaging_samples,
+    params_.imu_gravity_correction.max_age_seconds);
+
+  if (!gravityPR.has_value()) {
+    return {};
+  }
+  // The estimator already reduced its samples to (pitch, roll).
+  return applyGravityCalibration(
+    gravityPR->first, gravityPR->second, mrpt::DEG2RAD(sigma_deg_default));
+}
+
+std::optional<std::pair<double, double>> LidarOdometry::vehiclePitchRollFromMapGravity(
+  const mrpt::math::TVector3D & gravity_in_map, const mrpt::poses::CPose3D & vehiclePose)
+{
+  const double gn = gravity_in_map.norm();
+  if (gn < 1e-6) {
+    return {};
+  }
+
+  // "Up" in the map frame, then rotated into the vehicle frame by the inverse
+  // of the vehicle attitude. This yields the vehicle's tilt with respect to
+  // true vertical, NOT the map's tilt.
+  const mrpt::math::TVector3D up_map = gravity_in_map * (-1.0 / gn);
+  const mrpt::math::TVector3D u = vehiclePose.inverseRotateVector(up_map);
+
+  const double n = u.norm();
+  if (n < 1e-6) {
+    return {};
+  }
+  const double nx = u.x / n;
+  const double ny = u.y / n;
+  const double nz = u.z / n;
+
+  // Same convention as GravityEstimator::estimatedPitchRoll(): with the vehicle
+  // level, the measured "up" direction is [0, 0, +1] (z-up).
+  return std::make_pair(std::asin(-nx), std::atan2(ny, nz));
+}
+
+std::optional<LidarOdometry::GravityPitchRoll> LidarOdometry::applyGravityCalibration(
+  const double imu_pitch, const double imu_roll, const double sigma_rad) const
+{
+  // The gravity estimate is an *absolute* tilt w.r.t. true vertical, but the
+  // map/global frame may not itself be exactly level (e.g. a nonzero
+  // `fixed_initial_pose` orientation, or the vehicle starting on a slope).
+  // Re-express it relative to the map frame using the tilt recorded at the map
+  // origin as a calibration offset. Both readings share the same (gauge) yaw=0
+  // convention, which is valid since pitch/roll extracted from gravity alone
+  // are independent of the (unobservable) yaw used to express them.
+  GravityPitchRoll out;
+  out.pitch = imu_pitch;
+  out.roll = imu_roll;
+  // Cap the applied prior sigma (strengthen the pitch/roll constraint). This is
+  // independent of the acceptance gate: the estimate is already accepted here;
+  // this only bounds how confident the resulting prior is.
+  out.sigma_rad =
+    std::min(sigma_rad, mrpt::DEG2RAD(params_.imu_gravity_correction.max_applied_sigma_deg));
+
+  if (state_.gravity_calib_pitch_roll.has_value()) {
+    const auto [pitch0, roll0] = *state_.gravity_calib_pitch_roll;
+
+    const mrpt::poses::CPose3D R_map_veh0(
+      mrpt::poses::CPose3D(params_.initial_localization.fixed_initial_pose));
+    const mrpt::poses::CPose3D R_grav_veh0(0, 0, 0, 0, pitch0, roll0);
+    const mrpt::poses::CPose3D R_grav_veh_t(0, 0, 0, 0, imu_pitch, imu_roll);
+
+    const mrpt::poses::CPose3D R_map_veh_t = R_map_veh0 + (-R_grav_veh0) + R_grav_veh_t;
+
+    out.pitch = R_map_veh_t.pitch();
+    out.roll = R_map_veh_t.roll();
+  }
+
+  return out;
+}
+
+void LidarOdometry::updateMapReleveling(const mrpt::Clock::time_point & scan_tim)
+{
+#if defined(MOLA_LO_HAS_KFM_RELEVELING) && defined(MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR)
+  const auto & rebakeParams = params_.imu_gravity_correction.tilt_rebake;
+  if (!rebakeParams.enabled) {
+    return;
+  }
+
+  // 1) Locate the KeyframeMapCapable layer in the local map (by interface, so we
+  //    do not depend on the configured layer name).
+  mola::KeyframeMapCapable * kfCap = nullptr;
+  if (state_.local_map) {
+    for (auto & [name, layer] : state_.local_map->layers) {
+      if (auto * c = dynamic_cast<mola::KeyframeMapCapable *>(layer.get()); c != nullptr) {
+        kfCap = c;
+        break;
+      }
+    }
+  }
+  if (kfCap == nullptr) {
+    if (!state_.gravity_rebake_unsupported_warned) {
+      state_.gravity_rebake_unsupported_warned = true;
+      MRPT_LOG_WARN(
+        "imu_gravity_correction.tilt_rebake is enabled, but the configured "
+        "local-map layer is not KeyframeMapCapable; map re-leveling disabled.");
+    }
+    return;
+  }
+
+  // 2) Gravity direction in the map frame from the PREINTEGRATION estimator.
+  //    The raw per-KF accelerometer average (GravityMapAligner) is body-accel
+  //    contaminated and unusable on a dynamic platform; the preintegration
+  //    estimator cancels body acceleration via velocity differencing.
+  if (!state_.map_gravity_estimator.has_value()) {
+    return;
+  }
+  const auto & gres = state_.map_gravity_estimator->latest_result();
+  if (!gres.has_value() || !gres->converged) {
+    return;
+  }
+  const double gn = gres->gravity_in_map.norm();
+  if (gn < 1e-3) {
+    return;
+  }
+  // "Up" in the map frame (gravity points down):
+  const mrpt::math::TVector3D up_map = gres->gravity_in_map * (-1.0 / gn);
+
+  // 3) Trigger on the map's accumulated tilt vs true vertical.
+  const double tiltRad = std::acos(std::clamp(up_map.z, -1.0, 1.0));
+
+  MRPT_LOG_THROTTLE_DEBUG_FMT(
+    2.0, "rebake check: mapTilt=%.2f deg (trigger=%.1f)", mrpt::RAD2DEG(tiltRad),
+    rebakeParams.trigger_deg);
+
+  // 4) Throttle + minimum active keyframes + trigger threshold.
+  if (state_.last_gravity_rebake_tim.has_value()) {
+    const double dt = mrpt::system::timeDifference(*state_.last_gravity_rebake_tim, scan_tim);
+    if (dt < rebakeParams.min_interval_sec) {
+      return;
+    }
+  }
+  const auto kfPoses = kfCap->keyframePoses();
+  if (kfPoses.size() < rebakeParams.min_active_keyframes) {
+    return;
+  }
+  if (mrpt::RAD2DEG(tiltRad) < rebakeParams.trigger_deg) {
+    return;
+  }
+
+  // 5) Rigid pitch/roll leveling rotation (sends map-frame "up" to +Z),
+  //    applied about the CURRENT pose as pivot. Rotating about the current
+  //    position freezes where we are and only re-levels orientation, so neither
+  //    the live pose nor the recorded trajectory jumps in position. (Rotating
+  //    about a distant pivot, e.g. the oldest KF, swings far-away poses by the
+  //    lever arm and compounds into large drift.)
+  const mrpt::poses::CPose3D R_world = mola::GravityMapAligner::rotationFromGravity(up_map);
+  const mrpt::poses::CPose3D Tp =
+    mrpt::poses::CPose3D::FromTranslation(state_.last_lidar_pose.mean.translation());
+  const mrpt::poses::CPose3D T_net = Tp + R_world + (-Tp);
+
+  // 6) Apply to the local map (all active KFs). Points are stored per-KF in
+  //    their local frame, so this re-levels the map geometry ICP registers
+  //    against, with no re-insertion of points. KFs near the current pose barely
+  //    move; distant ones age out of the window before mattering.
+  for (const auto & [id, pose] : kfPoses) {
+    kfCap->setKeyframePose(id, T_net + pose);
+  }
+
+  // (c) Live cached pose + motion-model prior (twist stays body-local). Position
+  //     is frozen (pivot = current pose); only the orientation re-levels.
+  state_.last_lidar_pose.changeCoordinatesReference(T_net);
+  if (state_.last_motion_model_output) {
+    state_.last_motion_model_output->pose.changeCoordinatesReference(T_net);
+  }
+
+  // NOTE: the historical estimated_trajectory and simplemap are deliberately NOT
+  // rotated. They were committed in their own (progressively re-leveled) frames;
+  // rotating the whole history about the current pose would swing distant past
+  // poses by the lever arm. Forward poses build on the (frozen-position,
+  // re-leveled) current pose, so the trajectory stays position-continuous.
+
+  // (g) ATOMIC STATE MIGRATION. The map frame just rotated, so state expressed
+  //     in it must move too. The preint estimator's interval window and the
+  //     interval anchor are still in the OLD frame; feeding the next interval
+  //     across that discontinuity corrupts g_M and runs the tilt away. Rather
+  //     than rotate each stored interval, RESET the estimator (re-seeding the
+  //     bias prior so it re-converges quickly) and clear the interval anchor, so
+  //     it re-converges cleanly in the NEW frame. Its "converged" gate then
+  //     blocks the next rebake until it has, breaking the feedback loop.
+  const auto biasAcc = gres->bias_acc;
+  const auto biasGyro = gres->bias_gyro;
+  state_.map_gravity_estimator->reset();
+  state_.map_gravity_estimator->set_bias_prior(biasAcc, biasGyro);
+  state_.gravity_interval_anchor.reset();
+
+  state_.last_gravity_rebake_tim = scan_tim;
+
+  MRPT_LOG_INFO_FMT(
+    "Map gravity rebake: %zu KFs re-leveled, map tilt was %.2f deg, correction "
+    "pitch=%.2f roll=%.2f deg",
+    kfPoses.size(), mrpt::RAD2DEG(tiltRad), mrpt::RAD2DEG(R_world.pitch()),
+    mrpt::RAD2DEG(R_world.roll()));
+#else
+  (void)scan_tim;
+#endif
+}
+
+}  // namespace mola

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -232,6 +232,30 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
       params_.imu_gravity_correction.initialize(cfg["imu_gravity_correction"]);
     }
 
+    // The preintegration-based gravity estimator drains its IMU samples from
+    // the shared de-skew LocalVelocityBuffer, whose default retention (0.5 s)
+    // is far shorter than one interval. Widen it here: a buffer shorter than
+    // the interval silently yields a partial delta attributed to the whole
+    // interval, which corrupts every constraint.
+    if (
+      params_.imu_gravity_correction.enabled &&
+      params_.imu_gravity_correction.method ==
+        Parameters::IMUGravityCorrection::Method::Preintegration) {
+      // NOTE: the SHARED de-skew buffer (parameter_source.localVelocityBuffer)
+      // is deliberately left alone. It is sized for one scan and is consumed by
+      // trajectory_from_buffer() for de-skew; widening it changes what de-skew
+      // sees and diverged the solution on real data. Use a dedicated buffer.
+      state_.gravity_imu_buffer.parameters.max_time_window =
+        params_.imu_gravity_correction.buffer_retention_sec;
+
+      // Noise densities used by the preintegrator (sigma units:
+      // m/s^2/sqrt(Hz) and rad/s/sqrt(Hz)):
+      state_.imu_preint_params.cov_acc.setDiagonal(
+        mrpt::square(params_.imu_gravity_correction.accel_noise_sigma));
+      state_.imu_preint_params.cov_gyro.setDiagonal(
+        mrpt::square(params_.imu_gravity_correction.gyro_noise_sigma));
+    }
+
     if (c.has("initial_localization")) {
       params_.initial_localization.initialize(c["initial_localization"]);
     }

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -331,6 +331,62 @@ void LidarOdometry::Parameters::IMUGravityCorrection::initialize(const Yaml & cf
   YAML_LOAD_OPT(averaging_samples, uint32_t);
   YAML_LOAD_OPT(max_age_seconds, double);
 
+  YAML_LOAD_OPT(interval_duration, double);
+  YAML_LOAD_OPT(buffer_retention_sec, double);
+  YAML_LOAD_OPT(accel_noise_sigma, double);
+  YAML_LOAD_OPT(gyro_noise_sigma, double);
+  YAML_LOAD_OPT(max_accepted_sigma_deg, double);
+  YAML_LOAD_OPT(min_sigma_deg, double);
+  YAML_LOAD_OPT(max_applied_sigma_deg, double);
+
+  if (cfg.has("method")) {
+    const auto s = cfg["method"].as<std::string>();
+    if (s == "AccelAverage") {
+      method = Method::AccelAverage;
+    } else if (s == "Preintegration") {
+#if !defined(MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR)
+      THROW_EXCEPTION(
+        "imu_gravity_correction.method='Preintegration' requires a newer "
+        "mola_imu_preintegration providing MapGravityEstimator; this build only "
+        "supports 'AccelAverage'");
+#endif
+      method = Method::Preintegration;
+    } else {
+      THROW_EXCEPTION_FMT(
+        "imu_gravity_correction.method='%s' is unknown; valid values are "
+        "'AccelAverage' and 'Preintegration'",
+        s.c_str());
+    }
+  }
+
+#if defined(MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR)
+  if (cfg.has("estimator")) {
+    estimator.load_from(cfg["estimator"]);
+  }
+#endif
+
+  if (cfg.has("tilt_rebake")) {
+    tilt_rebake.initialize(cfg["tilt_rebake"]);
+  }
+
+  if (enabled && method == Method::Preintegration) {
+    ASSERT_GT_(interval_duration, 0.0);
+    ASSERT_GT_(accel_noise_sigma, 0.0);
+    ASSERT_GT_(gyro_noise_sigma, 0.0);
+    ASSERT_GT_(max_accepted_sigma_deg, 0.0);
+
+    // A retention shorter than the interval silently yields a partial delta
+    // attributed to the whole interval, corrupting every constraint. Refuse
+    // the configuration outright rather than rely on the coverage guard to
+    // reject every single interval at runtime.
+    ASSERTMSG_(
+      buffer_retention_sec > 2.0 * interval_duration,
+      mrpt::format(
+        "imu_gravity_correction.buffer_retention_sec=%.2f must comfortably exceed "
+        "interval_duration=%.2f",
+        buffer_retention_sec, interval_duration));
+  }
+
   if (enabled) {
     ASSERTMSG_(
       averaging_samples >= 1 && averaging_samples < IMU_BUFFER_SIZE,
@@ -340,6 +396,21 @@ void LidarOdometry::Parameters::IMUGravityCorrection::initialize(const Yaml & cf
 
     ASSERTMSG_(
       sigma_deg > 0, mrpt::format("imu_gravity_correction.sigma_deg=%.4f must be > 0", sigma_deg));
+  }
+}
+
+void LidarOdometry::Parameters::IMUGravityCorrection::TiltRebake::initialize(const Yaml & cfg)
+{
+  YAML_LOAD_OPT(enabled, bool);
+  YAML_LOAD_OPT(trigger_deg, double);
+  YAML_LOAD_OPT(min_interval_sec, double);
+  YAML_LOAD_OPT(min_active_keyframes, uint32_t);
+  YAML_LOAD_OPT(window_half_width, uint32_t);
+  YAML_LOAD_OPT(min_pool_per_kf, uint32_t);
+
+  if (enabled) {
+    ASSERT_GT_(trigger_deg, 0.0);
+    ASSERT_GE_(min_interval_sec, 0.0);
   }
 }
 

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -389,6 +389,18 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       in.init_guess_local_wrt_global = state_.last_motion_model_output->pose.mean.asTPose();
 
       // ICP prior term: any information!=0?
+      //
+      // This prior is the fused estimate of the shared state estimator (bound
+      // via findService<NavStateFilter>), not a bare constant-velocity guess:
+      // besides the twist propagated from past ICP poses, it also folds in any
+      // wheel-odometry integrated into that estimator through fuse_odometry().
+      // So when wheel odometry is available, both the prior mean AND its weight
+      // (cov_inv) carry that motion information into ICP. The IMU gravity
+      // correction below rides on top of this same prior, overriding only
+      // pitch/roll and leaving the (odometry-informed) x/y/z/yaw untouched.
+      //
+      // The prior's overall weight against the LiDAR geometry is tunable via
+      // the state estimator's covariances and the solver's cov2cov_alpha.
       if (state_.last_motion_model_output->pose.cov_inv != mrpt::math::CMatrixDouble66::Zero()) {
         // Send it to the ICP solver:
         in.prior.emplace(state_.last_motion_model_output->pose);
@@ -433,39 +445,15 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       }
     }
 
-    // Apply IMU gravity correction to ICP prior (pitch/roll):
+    // Apply IMU gravity correction to ICP prior (pitch/roll). Both estimation
+    // methods (raw accelerometer average, and the preintegration-based
+    // map-gravity estimator) are behind estimateGravityPitchRoll(), which
+    // already returns the values expressed in the map frame plus the sigma to
+    // weight them with:
     if (params_.imu_gravity_correction.enabled) {
-      const auto gravityPR = state_.gravity_estimator.estimatedPitchRoll(
-        params_.imu_gravity_correction.averaging_samples,
-        params_.imu_gravity_correction.max_age_seconds);
+      const mrpt::poses::CPose3D priorPose(in.init_guess_local_wrt_global);
 
-      if (gravityPR.has_value()) {
-        const auto [imu_pitch, imu_roll] = *gravityPR;
-
-        // The gravity estimator reports *absolute* tilt w.r.t. true vertical,
-        // but the map/global frame may not itself be exactly level (e.g. a
-        // nonzero `fixed_initial_pose` orientation, or the vehicle starting
-        // on a slope). Re-express the absolute IMU tilt relative to the map
-        // frame using the tilt recorded at the map origin as a calibration
-        // offset. Both readings share the same (gauge) yaw=0 convention, which
-        // is valid since pitch/roll extracted from gravity alone are
-        // independent of the (unobservable) yaw used to express them.
-        double map_pitch = imu_pitch;
-        double map_roll = imu_roll;
-        if (state_.gravity_calib_pitch_roll.has_value()) {
-          const auto [pitch0, roll0] = *state_.gravity_calib_pitch_roll;
-
-          const mrpt::poses::CPose3D R_map_veh0(
-            mrpt::poses::CPose3D(params_.initial_localization.fixed_initial_pose));
-          const mrpt::poses::CPose3D R_grav_veh0(0, 0, 0, 0, pitch0, roll0);
-          const mrpt::poses::CPose3D R_grav_veh_t(0, 0, 0, 0, imu_pitch, imu_roll);
-
-          const mrpt::poses::CPose3D R_map_veh_t = R_map_veh0 + (-R_grav_veh0) + R_grav_veh_t;
-
-          map_pitch = R_map_veh_t.pitch();
-          map_roll = R_map_veh_t.roll();
-        }
-
+      if (const auto g = estimateGravityPitchRoll(priorPose); g.has_value()) {
         if (!in.prior.has_value()) {
           // Create a prior from current initial guess:
           in.prior.emplace();
@@ -475,21 +463,18 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 
         // Override pitch & roll in the prior mean:
         const double cur_yaw = in.prior->mean.yaw();
-        in.prior->mean.setYawPitchRoll(cur_yaw, map_pitch, map_roll);
+        in.prior->mean.setYawPitchRoll(cur_yaw, g->pitch, g->roll);
 
         // Increase confidence for pitch (idx=4) and roll (idx=5):
-        const double sigma_rad = mrpt::DEG2RAD(params_.imu_gravity_correction.sigma_deg);
-        const double inv_var = 1.0 / (sigma_rad * sigma_rad);
+        const double inv_var = 1.0 / (g->sigma_rad * g->sigma_rad);
 
         // MRPT cov order: x y z yaw pitch[4] roll[5]
         mrpt::keep_max(in.prior->cov_inv(4, 4), inv_var);
         mrpt::keep_max(in.prior->cov_inv(5, 5), inv_var);
 
         MRPT_LOG_DEBUG_FMT(
-          "IMU gravity correction: pitch=%.2f deg, roll=%.2f deg "
-          "(sigma=%.1f deg, %zu samples)",
-          mrpt::RAD2DEG(imu_pitch), mrpt::RAD2DEG(imu_roll),
-          params_.imu_gravity_correction.sigma_deg, state_.gravity_estimator.acc_buffer.size());
+          "IMU gravity correction: pitch=%.2f deg, roll=%.2f deg (sigma=%.2f deg)",
+          mrpt::RAD2DEG(g->pitch), mrpt::RAD2DEG(g->roll), mrpt::RAD2DEG(g->sigma_rad));
       }
     }
 
@@ -732,6 +717,22 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     if (icpIsGood) {
       auto lck = mrpt::lockHelper(state_trajectory_mtx_);
       state_.estimated_trajectory.insert(scan_ref_time, state_.last_lidar_pose.mean);
+    }
+
+    // Advance the map-gravity estimator with the pose/velocity just solved
+    // (no-op unless the preintegration method is selected). Only a good ICP
+    // is fed: its attitude and velocity are the estimator's inputs, and a
+    // failed registration would poison them.
+    if (icpIsGood) {
+      std::optional<mrpt::math::TTwist3D> curTwist;
+      std::optional<mrpt::math::CMatrixDouble66> curTwistInvCov;
+      if (state_.last_motion_model_output) {
+        curTwist = state_.last_motion_model_output->twist;
+        curTwistInvCov = state_.last_motion_model_output->twist_inv_cov;
+      }
+      updateMapGravityEstimator(
+        mrpt::Clock::toDouble(scan_ref_time), state_.last_lidar_pose.mean, curTwist,
+        curTwistInvCov);
     }
 
     // Update for stats in CSV format:
@@ -992,6 +993,12 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     doUpdateSimpleMap(
       sf, distance_enough_sm, observation, scan_ref_time, fullCloudForVizAndPublish);
   }
+
+  // Map-level gravity re-leveling: sync the per-KF pool with the current local
+  // map and, when the accumulated tilt exceeds the trigger (throttled), rotate
+  // the local map + simplemap + trajectory so the tilt is removed at its source.
+  // No-op unless imu_gravity_correction.tilt_rebake.enabled.
+  updateMapReleveling(scan_ref_time);
 
 #if defined(MOLA_HAS_SHARED_KEYFRAME_MAP_SINK)
   // Build the keyframe request while holding state_mtx_; the actual sink call

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -349,6 +349,33 @@ void LidarOdometry::onIMUImpl(const CObservation::ConstPtr & o)
   if (params_.imu_gravity_correction.enabled) {
     auto lckState2 = mrpt::lockHelper(state_mtx_);
     state_.gravity_estimator.add(*imu, params_.imu_gravity_correction.averaging_samples);
+
+#if defined(MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR)
+    // Feed the DEDICATED long-retention buffer used by the preintegration
+    // method. Kept separate from the shared de-skew buffer, which is sized for
+    // a single scan and whose contents also drive trajectory_from_buffer().
+    if (
+      params_.imu_gravity_correction.method ==
+      Parameters::IMUGravityCorrection::Method::Preintegration) {
+      // Move the raw reading into the vehicle frame (rotation + lever arm),
+      // one transformer per sensor label since each keeps its own filter state:
+      auto & tf = state_.gravity_imu_transformers[imu->sensorLabel];
+      const auto imuVeh = tf.process(*imu);
+
+      const double t = mrpt::Clock::toDouble(imuVeh.timestamp);
+
+      if (imuVeh.has(mrpt::obs::IMU_X_ACC)) {
+        state_.gravity_imu_buffer.add_linear_acceleration(
+          t, {imuVeh.get(mrpt::obs::IMU_X_ACC), imuVeh.get(mrpt::obs::IMU_Y_ACC),
+              imuVeh.get(mrpt::obs::IMU_Z_ACC)});
+      }
+      if (imuVeh.has(mrpt::obs::IMU_WX)) {
+        state_.gravity_imu_buffer.add_angular_velocity(
+          t, {imuVeh.get(mrpt::obs::IMU_WX), imuVeh.get(mrpt::obs::IMU_WY),
+              imuVeh.get(mrpt::obs::IMU_WZ)});
+      }
+    }
+#endif
   }
 
   // Finally, release any waiting LiDAR scan now fully covered by fed IMU data.

--- a/mola-cli-launchs/lidar_odometry_from_mulran.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_mulran.yaml
@@ -10,6 +10,7 @@ modules:
   # =====================
   - name: viz
     type: ${MOLA_GUI_MODULE|mola::MolaVizImGui}
+    enabled: ${MOLA_WITH_GUI|true}
     verbosity_level: "${MOLA_VERBOSITY_MOLA_VIZ|INFO}"
     params:
       imgui_app_name: lidar_odometry_from_mulran
@@ -28,13 +29,16 @@ modules:
     gui_preview_sensors:
       - raw_sensor_label: lidar
         decimation: 1
+        enabled: ${MOLA_WITH_GUI|true}
         win_pos: 5 70 400 400
         color_from_z: false
       - raw_sensor_label: gps
         decimation: 1
+        enabled: ${MOLA_WITH_GUI|true}
         win_pos: 5 400 400 400
       - raw_sensor_label: imu
         decimation: 10
+        enabled: ${MOLA_WITH_GUI|true}
         win_pos: 5 550 400 400
     params:
       base_dir: ${MULRAN_BASE_DIR}

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -44,9 +44,45 @@ params:
   # Uses averaged accelerometer readings to constrain ICP pitch/roll.
   imu_gravity_correction:
     enabled: ${MOLA_IMU_GRAVITY_CORRECTION|true}
+
+    # How the gravity direction is estimated:
+    #  AccelAverage   : average the last N raw accelerometer samples. Only valid
+    #                   while quasi-static, since one sample is gravity PLUS body
+    #                   acceleration.
+    #  Preintegration : estimate the gravity vector in the map frame from
+    #                   preintegrated IMU aided by LO's own poses/velocities.
+    #                   Body acceleration cancels out, so it stays valid while
+    #                   moving arbitrarily. Reports its own earned sigma.
+    method: ${MOLA_IMU_GRAVITY_METHOD|AccelAverage}
+
+    # AccelAverage only:
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
     max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}
+
+    # Preintegration only:
+    interval_duration: ${MOLA_IMU_GRAVITY_INTERVAL|0.5}
+    buffer_retention_sec: ${MOLA_IMU_GRAVITY_BUFFER_RETENTION|60.0}
+    accel_noise_sigma: ${MOLA_IMU_GRAVITY_ACC_SIGMA|3e-2}
+    gyro_noise_sigma: ${MOLA_IMU_GRAVITY_GYR_SIGMA|3e-3}
+    max_accepted_sigma_deg: ${MOLA_IMU_GRAVITY_MAX_SIGMA_DEG|2.0}
+    min_sigma_deg: ${MOLA_IMU_GRAVITY_MIN_SIGMA_DEG|0.5}
+    max_applied_sigma_deg: ${MOLA_IMU_GRAVITY_MAX_APPLIED_SIGMA_DEG|1e6}
+    # Map-level gravity re-leveling. EXPERIMENTAL, OFF by default. Levels the
+    # reported attitude well but injects a continuous vertical-position leak
+    # (net position worse); kept as a research scaffold only. The per-scan ICP
+    # prior above is the safe, effective path. Do not enable in production.
+    tilt_rebake:
+      enabled: ${MOLA_IMU_GRAVITY_REBAKE|false}
+      trigger_deg: ${MOLA_IMU_GRAVITY_REBAKE_TRIGGER_DEG|2.0}
+      min_interval_sec: ${MOLA_IMU_GRAVITY_REBAKE_MIN_INTERVAL|5.0}
+      min_active_keyframes: ${MOLA_IMU_GRAVITY_REBAKE_MIN_KFS|5}
+      window_half_width: ${MOLA_IMU_GRAVITY_REBAKE_WINDOW|5}
+      min_pool_per_kf: ${MOLA_IMU_GRAVITY_REBAKE_MIN_POOL|3}
+    estimator:
+      window_size: ${MOLA_IMU_GRAVITY_WINDOW|20}
+      bias_acc_prior_sigma: ${MOLA_IMU_GRAVITY_BA_PRIOR|0.15}
+      bias_gyro_prior_sigma: ${MOLA_IMU_GRAVITY_BG_PRIOR|0.01}
 
   # When publishing pose updates, the reference frame for both, estimated robot poses, and the local map.
   publish_reference_frame: "${MOLA_LO_PUBLISH_REF_FRAME|odom}"
@@ -309,6 +345,11 @@ icp_settings_with_vel:
         # Blend [0,1] for the robust kernel residual reference toward the prior
         # mean pose (0=current iterate only, 1=prior mean only). See mp2p_icp.
         robustKernelPriorRefBlend: "${MOLA_LO_ROBUST_KERNEL_PRIOR_REF_BLEND|0.0}"
+        # Scaling of the cov2cov (GICP) data block against the pose prior. 1.0
+        # keeps the standard cost; <1 down-weights LiDAR geometry so the prior
+        # (e.g. IMU gravity pitch/roll) carries more relative weight.
+        cov2cov_alpha: "${MOLA_LO_COV2COV_ALPHA|1.0}"
+        cov2cov_auto_balance_with_prior: "${MOLA_LO_COV2COV_AUTO_BALANCE|true}"
         #innerLoopVerbose: true
 
         # Sequence of one or more pairs (class, params) defining mp2p_icp::Matcher

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,9 @@ target_link_libraries(test_trajectory_rebaker mola::mola_lidar_odometry)
 ament_add_gtest(test_keyframe_decider test_keyframe_decider.cpp)
 target_link_libraries(test_keyframe_decider mola::mola_lidar_odometry)
 
+ament_add_gtest(test_gravity_from_map test_gravity_from_map.cpp)
+target_link_libraries(test_gravity_from_map mola::mola_lidar_odometry)
+
 # -----------------------------------------------------------------------
 # Data-dependent integration tests (require optional packages):
 # -----------------------------------------------------------------------

--- a/test/test_gravity_from_map.cpp
+++ b/test/test_gravity_from_map.cpp
@@ -1,0 +1,136 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * Unit tests for LidarOdometry::vehiclePitchRollFromMapGravity().
+ *
+ * This is the seam where a map-frame gravity estimate is turned into the ICP
+ * prior's pitch/roll. The invariant under test is the one an earlier bug got
+ * wrong: the result must describe the VEHICLE's tilt with respect to true
+ * vertical, INDEPENDENTLY of how tilted the map frame itself is. Returning the
+ * map tilt instead made the prior fight the (unchanged) local map and diverged
+ * real runs, but left every math-level unit test green -- hence this test at
+ * the integration seam. No datasets needed; all synthetic.
+ */
+
+#include <gtest/gtest.h>
+#include <mola_lidar_odometry/LidarOdometry.h>
+#include <mrpt/poses/CPose3D.h>
+
+#include <cmath>
+
+using mrpt::math::TVector3D;
+using mrpt::poses::CPose3D;
+
+namespace
+{
+constexpr double G = 9.81;
+
+// Gravity vector expressed in a frame obtained by rotating the world by `R`.
+TVector3D gravityInFrame(const CPose3D & R_frame_from_world)
+{
+  const TVector3D g_world{0, 0, -G};
+  return R_frame_from_world.rotateVector(g_world);
+}
+
+// Build a rotation-only pose from yaw/pitch/roll in DEGREES.
+CPose3D ypr(double yaw_deg, double pitch_deg, double roll_deg)
+{
+  return CPose3D(
+    0, 0, 0, mrpt::DEG2RAD(yaw_deg), mrpt::DEG2RAD(pitch_deg), mrpt::DEG2RAD(roll_deg));
+}
+}  // namespace
+
+// A level vehicle in a TILTED map must report zero tilt: the map's own tilt
+// must NOT leak into the vehicle prior. This is the exact regression.
+TEST(VehiclePitchRollFromMapGravity, LevelVehicleInTiltedMap_reportsLevel)
+{
+  for (const auto & mapTilt : {ypr(30, 4, -3), ypr(-120, -6, 2), ypr(0, 8, 8)}) {
+    // Vehicle level w.r.t. the world => its attitude in the map frame IS the
+    // map tilt, and gravity in the map is the tilted gravity.
+    const CPose3D vehicleInMap = mapTilt;
+    const TVector3D g_map = gravityInFrame(mapTilt);
+
+    const auto pr =
+      mola::LidarOdometry::vehiclePitchRollFromMapGravity(g_map, vehicleInMap);
+    ASSERT_TRUE(pr.has_value());
+
+    EXPECT_NEAR(mrpt::RAD2DEG(pr->first), 0.0, 1e-9) << "map tilt " << mapTilt.asString();
+    EXPECT_NEAR(mrpt::RAD2DEG(pr->second), 0.0, 1e-9) << "map tilt " << mapTilt.asString();
+  }
+}
+
+// A vehicle tilted by a known amount in a LEVEL map must recover that tilt.
+TEST(VehiclePitchRollFromMapGravity, TiltedVehicleInLevelMap_recoversTilt)
+{
+  const double truePitch = 5.0;
+  const double trueRoll = -7.0;
+
+  const CPose3D vehicleInMap = ypr(40, truePitch, trueRoll);
+  const TVector3D g_map = gravityInFrame(ypr(0, 0, 0));  // level map
+
+  const auto pr = mola::LidarOdometry::vehiclePitchRollFromMapGravity(g_map, vehicleInMap);
+  ASSERT_TRUE(pr.has_value());
+
+  EXPECT_NEAR(mrpt::RAD2DEG(pr->first), truePitch, 1e-6);
+  EXPECT_NEAR(mrpt::RAD2DEG(pr->second), trueRoll, 1e-6);
+}
+
+// The core invariant: the recovered tilt equals the vehicle's WORLD tilt,
+// regardless of the map tilt. Compose a known world tilt with several map
+// tilts; the answer must not move.
+TEST(VehiclePitchRollFromMapGravity, RecoversWorldTilt_independentOfMapTilt)
+{
+  const double truePitch = 6.0;
+  const double trueRoll = 3.0;
+  const CPose3D vehicleInWorld = ypr(0, truePitch, trueRoll);
+
+  for (const auto & mapTilt : {ypr(0, 0, 0), ypr(70, 5, -4), ypr(-30, -8, 6)}) {
+    // Vehicle attitude in the map frame = map<-world composed with world<-vehicle.
+    const CPose3D vehicleInMap = mapTilt + vehicleInWorld;
+    const TVector3D g_map = gravityInFrame(mapTilt);
+
+    const auto pr =
+      mola::LidarOdometry::vehiclePitchRollFromMapGravity(g_map, vehicleInMap);
+    ASSERT_TRUE(pr.has_value());
+
+    EXPECT_NEAR(mrpt::RAD2DEG(pr->first), truePitch, 1e-6) << "map tilt " << mapTilt.asString();
+    EXPECT_NEAR(mrpt::RAD2DEG(pr->second), trueRoll, 1e-6) << "map tilt " << mapTilt.asString();
+  }
+}
+
+// Yaw must not affect pitch/roll: a pure heading change leaves the tilt alone.
+TEST(VehiclePitchRollFromMapGravity, InvariantToYaw)
+{
+  const TVector3D g_map = gravityInFrame(ypr(0, 0, 0));
+
+  for (const double yaw : {0.0, 45.0, 123.0, -160.0}) {
+    const auto pr =
+      mola::LidarOdometry::vehiclePitchRollFromMapGravity(g_map, ypr(yaw, 4.0, -2.0));
+    ASSERT_TRUE(pr.has_value());
+    EXPECT_NEAR(mrpt::RAD2DEG(pr->first), 4.0, 1e-6) << "yaw " << yaw;
+    EXPECT_NEAR(mrpt::RAD2DEG(pr->second), -2.0, 1e-6) << "yaw " << yaw;
+  }
+}
+
+// A degenerate (near-zero) gravity vector yields nullopt rather than a NaN.
+TEST(VehiclePitchRollFromMapGravity, DegenerateGravity_returnsNullopt)
+{
+  EXPECT_FALSE(
+    mola::LidarOdometry::vehiclePitchRollFromMapGravity({0, 0, 0}, ypr(0, 0, 0)).has_value());
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Adds a map-frame gravity estimate (mola::imu::MapGravityEstimator, Preintegration method) as an alternative to the legacy accelerometer average, feeding the ICP prior's pitch/roll so LO stays gravity-aligned while moving. Body acceleration cancels via velocity differencing, and the estimate reports its own earned sigma. On sequences with real tilt drift (MulRan DCC01) this lowers APE ~14% and vertical error; on already-aligned sequences it is neutral.

New tunables (all exposed via env in lidar3d-gicp.yaml):
- method: AccelAverage (default) | Preintegration
- max_accepted_sigma_deg gate and max_applied_sigma_deg ceiling on the applied pitch/roll prior sigma
- dedicated long-retention IMU buffer for the estimator, kept separate from the de-skew buffer

Also includes an EXPERIMENTAL, off-by-default map-releveling path (imu_gravity_correction.tilt_rebake / updateMapReleveling): it levels the reported attitude by rotating the active local-map keyframes, but injects a continuous vertical-position leak (net position worse) that current-pose pivoting, estimator reset, and map-size shrinking do not resolve. It is kept as a research scaffold and must not be enabled in production.