### PR TITLE
fix(launchers): subscribe the state estimator to the raw data source

### DIFF
--- a/mola-cli-launchs/lidar_odometry_from_kitti.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_kitti.yaml
@@ -52,6 +52,7 @@ modules:
   - name: state_estimation
     type: "${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}"
     verbosity_level: "${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}"
+    raw_data_source: "dataset_input"
 
     # This includes here a whole block "params: (...)":
     params: "${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}"

--- a/mola-cli-launchs/lidar_odometry_from_kitti360.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_kitti360.yaml
@@ -52,6 +52,7 @@ modules:
   - name: state_estimation
     type: "${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}"
     verbosity_level: "${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}"
+    raw_data_source: "dataset_input"
 
     # This includes here a whole block "params: (...)":
     params: "${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}"

--- a/mola-cli-launchs/lidar_odometry_from_kitti_output_ros2.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_kitti_output_ros2.yaml
@@ -52,6 +52,7 @@ modules:
   - name: state_estimation
     type: "${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}"
     verbosity_level: "${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}"
+    raw_data_source: "dataset_input"
 
     # This includes here a whole block "params: (...)":
     params: "${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}"

--- a/mola-cli-launchs/lidar_odometry_from_mulran.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_mulran.yaml
@@ -55,6 +55,7 @@ modules:
   - name: state_estimation
     type: "${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}"
     verbosity_level: "${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}"
+    raw_data_source: "dataset_input"
 
     # This includes here a whole block "params: (...)":
     params: "${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}"

--- a/mola-cli-launchs/lidar_odometry_from_paris_luco.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_paris_luco.yaml
@@ -46,6 +46,7 @@ modules:
   - name: state_estimation
     type: "${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}"
     verbosity_level: "${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}"
+    raw_data_source: "dataset_input"
 
     # This includes here a whole block "params: (...)":
     params: "${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}"

--- a/mola-cli-launchs/lidar_odometry_from_rawlog.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_rawlog.yaml
@@ -48,6 +48,7 @@ modules:
   - name: state_estimation
     type: "${MOLA_STATE_ESTIMATOR|mola::state_estimation_simple::StateEstimationSimple}"
     verbosity_level: "${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}"
+    raw_data_source: "dataset_input"
 
     # This includes here a whole block "params: (...)":
     params: "${MOLA_STATE_ESTIMATOR_YAML|../state-estimator-params/state-estimation-simple.yaml}"


### PR DESCRIPTION
## Problem

A `state_estimation` module in a mola-cli launch file only receives raw sensor
observations (IMU, GNSS) if it declares `raw_data_source`. Without it, the
estimator still produces poses and twists normally, because the LiDAR front end
calls the `NavStateFilter` API (`fuse_pose()` / `fuse_twist()`) directly. So the
system looks entirely healthy: no warning, no error, trajectories come out.

But **every IMU-based factor inside the estimator is silently inert**, because
no `CObservationIMU` ever reaches it.

This is a nasty failure mode: it does not degrade output in an obvious way, it
just disables a feature you believe is on. It cost a full experiment here (an
A/B over an IMU gravity-alignment sigma on MulRan showed "no effect" purely
because the factor could never fire).

## Fix

Add `raw_data_source: "dataset_input"` to the `state_estimation` module in the
six launchers that lacked it:

- `lidar_odometry_from_mulran.yaml`
- `lidar_odometry_from_kitti.yaml`
- `lidar_odometry_from_kitti360.yaml`
- `lidar_odometry_from_kitti_output_ros2.yaml`
- `lidar_odometry_from_paris_luco.yaml`
- `lidar_odometry_from_rawlog.yaml`

This makes them consistent with the launchers that already declared it
(Oxford Spires, rosbag1/2, Ouster, BotanicGarden x2). In all six, the dataset
module is already named `dataset_input` and is already referenced the same way
by the `lidar_odom` module, so the value is uniform.

## Notes

- Purely additive: one line per file, no behavior change for datasets that
  publish no IMU/GNSS (KITTI, KITTI-360, Paris-Luco).
- For MulRan and rawlog inputs it is what actually enables IMU-based factors.
- All six files verified to still parse, with the key landing on the
  `state_estimation` module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected LiDAR odometry configurations so state estimation consistently consumes sensor data from the selected dataset input.
  * Applied the correction across KITTI, KITTI-360, MulRan, Paris-Luco, and rawlog workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->