### PR TITLE
fix(mulran launcher): honor MOLA_WITH_GUI for headless runs

### DIFF
--- a/mola-cli-launchs/lidar_odometry_from_mulran.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_mulran.yaml
@@ -10,6 +10,7 @@ modules:
   # =====================
   - name: viz
     type: ${MOLA_GUI_MODULE|mola::MolaVizImGui}
+    enabled: ${MOLA_WITH_GUI|true}
     verbosity_level: "${MOLA_VERBOSITY_MOLA_VIZ|INFO}"
     params:
       imgui_app_name: lidar_odometry_from_mulran
@@ -28,13 +29,16 @@ modules:
     gui_preview_sensors:
       - raw_sensor_label: lidar
         decimation: 1
+        enabled: ${MOLA_WITH_GUI|true}
         win_pos: 5 70 400 400
         color_from_z: false
       - raw_sensor_label: gps
         decimation: 1
+        enabled: ${MOLA_WITH_GUI|true}
         win_pos: 5 400 400 400
       - raw_sensor_label: imu
         decimation: 10
+        enabled: ${MOLA_WITH_GUI|true}
         win_pos: 5 550 400 400
     params:
       base_dir: ${MULRAN_BASE_DIR}


### PR DESCRIPTION
## Problem

The MulRan launcher did not gate its GUI components on `MOLA_WITH_GUI`, so
`MOLA_WITH_GUI=false` still opened the MolaViz window and the three sensor
preview windows. Headless / batch evaluation runs could not fully disable the
GUI.

## Fix

Add `enabled: ${MOLA_WITH_GUI|true}` to:
- the `viz` (MolaViz) module
- the `lidar`, `gps`, and `imu` `gui_preview_sensors`

This matches the pattern already used by the other launchers, and defaults to
`true` so interactive use is unchanged.

## Notes

These four lines were originally authored on the `feat/imu-gravity-prior`
branch (draft #106); this cherry-picks just the headless-GUI part onto develop,
independently of the gravity work. The `raw_data_source` on the
`state_estimation` module (from #107) is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable GUI activation through the `MOLA_WITH_GUI` setting.
  * Added enable/disable controls for LiDAR, GPS, and IMU preview windows.
  * Added configurable window positions for GPS and IMU previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->