### PR TITLE
fix(lidar-odometry): ICP prior information matrix used the wrong tangent indices

### DIFF
--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -403,10 +403,15 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
           m.z(0);
           m.setYawPitchRoll(m.yaw(), .0, .0);
 
-          // MRPT cov_inv order: x[0] y[1] z[2] yaw[3] pitch[4] roll[5]
+          // The ICP solver applies this information matrix to the residual
+          // log(P_prior^-1 * P_cur), i.e. in the SE(3) *Lie* tangent, whose
+          // rotation entries are the rotation-vector components
+          // [3]=w_x (~roll), [4]=w_y (~pitch), [5]=w_z (~yaw). That is NOT
+          // MRPT's (x,y,z,yaw,pitch,roll) Euler ordering: the two swap
+          // indices 3 and 5. SE(2) fixes z/pitch/roll, leaving x, y and yaw:
           in.prior->cov_inv(2, 2) = large_certainty;  // dz
-          in.prior->cov_inv(4, 4) = large_certainty;  // pitch
-          in.prior->cov_inv(5, 5) = large_certainty;  // roll
+          in.prior->cov_inv(3, 3) = large_certainty;  // roll  (w_x)
+          in.prior->cov_inv(4, 4) = large_certainty;  // pitch (w_y)
         }
 
         MRPT_LOG_DEBUG_STREAM("ICP prior=" << *in.prior);
@@ -477,13 +482,21 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
         const double cur_yaw = in.prior->mean.yaw();
         in.prior->mean.setYawPitchRoll(cur_yaw, map_pitch, map_roll);
 
-        // Increase confidence for pitch (idx=4) and roll (idx=5):
         const double sigma_rad = mrpt::DEG2RAD(params_.imu_gravity_correction.sigma_deg);
         const double inv_var = 1.0 / (sigma_rad * sigma_rad);
 
-        // MRPT cov order: x y z yaw pitch[4] roll[5]
-        mrpt::keep_max(in.prior->cov_inv(4, 4), inv_var);
-        mrpt::keep_max(in.prior->cov_inv(5, 5), inv_var);
+        // Gravity observes the two TILT axes only, and must leave yaw free.
+        //
+        // The ICP solver applies this information matrix to the residual
+        // log(P_prior^-1 * P_cur), i.e. in the SE(3) *Lie* tangent, whose
+        // rotation entries are the rotation-vector components
+        // [3]=w_x (~roll), [4]=w_y (~pitch), [5]=w_z (~yaw). That is NOT
+        // MRPT's (x,y,z,yaw,pitch,roll) Euler ordering used by
+        // CPose3DPDFGaussian elsewhere: the two swap indices 3 and 5. Writing
+        // "roll" at index 5 therefore pinned YAW to the motion model's own
+        // yaw and left roll completely unconstrained.
+        mrpt::keep_max(in.prior->cov_inv(3, 3), inv_var);  // roll  (w_x)
+        mrpt::keep_max(in.prior->cov_inv(4, 4), inv_var);  // pitch (w_y)
 
         MRPT_LOG_DEBUG_FMT(
           "IMU gravity correction: pitch=%.2f deg, roll=%.2f deg "


### PR DESCRIPTION
## The bug

The ICP prior's information matrix (`in.prior->cov_inv`) is consumed by mp2p_icp's
Gauss-Newton solver as the weight of the residual `log(P_prior^-1 * P_cur)`
(`optimal_tf_gauss_newton.cpp`), i.e. in the SE(3) **Lie** tangent, whose rotation
entries are the rotation-vector components `[3]=w_x, [4]=w_y, [5]=w_z`.

It was being filled as if it followed MRPT's `(x, y, z, yaw, pitch, roll)` Euler
ordering that `CPose3DPDFGaussian` uses elsewhere. **The two orderings swap indices
3 and 5.** Verified numerically against MRPT:

| perturbation | `asVector[3..5]` (Euler) | `SE3::log[3..5]` (Lie) |
|---|---|---|
| yaw +5 deg   | **(.0873, 0, 0)** | (0, 0, **.0873**) |
| pitch +5 deg | (0, .0873, 0) | (0, **.0873**, 0) |
| roll +5 deg  | (0, 0, **.0873**) | **(.0873, 0, 0)** |

Consequences of writing pitch/roll at indices 4/5:

- **IMU gravity correction**: pitch was constrained (index 4 happens to coincide),
  but "roll" landed on `w_z`, so it **pinned yaw** to the motion model's own yaw
  while leaving **roll completely unconstrained**. Gravity should observe the two
  tilt axes and leave yaw free; it was doing the opposite on one axis.
- **2D lidars** (SE(2) branch): intended to freeze z/pitch/roll, it froze **yaw**
  instead of roll.

Fixed to indices 3 (`w_x` ~ roll) and 4 (`w_y` ~ pitch) in both places, leaving
index 5 (`w_z` ~ yaw) free.

## Honest evaluation: this is a correctness fix, NOT a performance improvement

Measured on MulRan DCC01 with shipped defaults (`imu_gravity_correction` enabled,
`sigma_deg=2.0`). Runs are bit-reproducible: batch CLI (`mola-lidar-odometry-cli`,
which applies backpressure so no scan is dropped) pinned with `taskset -c 0` (which
serializes the TBB reduction in the ICP solver, otherwise FP summation order varies
run to run).

| config | APE | horiz | vert | tilt mean |
|---|---|---|---|---|
| gravity OFF (reference) | **9.118** | 6.714 | **6.169** | 3.868 |
| gravity ON, `develop` (buggy) | 11.544 | 6.269 | 9.693 | 3.527 |
| gravity ON, **this PR** | 11.856 | 6.355 | 10.009 | 3.544 |

**The fix is ~2.7% worse in APE and ~3.3% worse in vertical RMSE than the buggy
code on this dataset.** Control: the gravity-OFF run is bit-identical across both
arms (md5 `3c2a0a8574ce`), confirming the arms differ only where intended.

This is coherent rather than surprising: both variants push tilt through the pose
prior, and the fix pushes it *more correctly* (roll is now genuinely constrained
instead of ignored), so it relocates slightly more error into Z. The harm comes
from the mechanism, not from which axis it grabbed.

It is proposed anyway because the code demonstrably does not do what it says it
does, and the 2D-lidar path freezing yaw instead of roll is wrong on its face.

## Separate, larger finding (not addressed here)

The same measurements show `imu_gravity_correction` at its **default** setting is
net-harmful on DCC01: enabling it costs +27% APE and +57% vertical RMSE, buying
only 0.34 deg of tilt. That tilt->Z tradeoff is a property of pushing gravity
through the SE(3) pose prior and needs its own fix (a yaw-free rank-2 gravity
factor, so translation is untouched by construction); tracked separately.

## Note on remaining approximation

A diagonal in the Lie tangent only isolates roll/pitch near zero tilt, so this
remains a small-angle approximation. The exact formulation is a yaw-free rank-2
projector; that is being developed separately in mp2p_icp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 2D lidar odometry alignment by applying rotation constraints to the correct axes.
  * Updated IMU gravity correction to constrain the observed roll and pitch directions while leaving yaw unconstrained.
  * Improved scan-matching accuracy and stability in scenarios using lidar and IMU data together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->