### PR TITLE
feat(pipelines): make the GICP local-map class selectable via ${MOLA_LOCALMAP_CLASS}

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -228,12 +228,27 @@ complete example with all three env vars set.
 `${MOLA_LOCALMAP_CLASS|mola::KeyframePointCloudMap}` picks the class used for
 both the `localmap` layer and the `observation` (scan) layer -- `Matcher_Cov2Cov`
 pairs the two, so they must always be the same `mp2p_icp::NearestPointWithCovCapable`
-class. The alternative is `mola::IncrementalPointCloud` (odometry only, no loop
-closure; see `mola_metric_maps`), tuned by the `MOLA_INCREMENTAL_MAP_*` vars in
-the same `creationOpts` block. Both classes' option keys live side by side there:
+class. Both classes' option keys live side by side in one `creationOpts` block:
 each map class silently ignores the keys it does not define, which is what makes
 a single YAML enough. When adding keys, keep KFM's *required* ones
 (`max_search_keyframes`, `k_correspondences_for_cov`) present.
+
+- `mola::KeyframePointCloudMap` (default): keyframe-based, points kept in per-KF
+  local frames, so it survives loop-closure re-mapping. Tuned by the
+  `MOLA_LOCALMAP_*` vars.
+- `mola::IncrementalPointCloud`: single global frame, one incremental
+  self-balancing k-d tree, no per-scan tree rebuild. **Odometry only** (a global
+  SE(3) re-map would force a full rebuild). Tuned by `MOLA_INCREMENTAL_MAP_*`:
+  `MAX_SIZE` (eviction cube **half-side** [m] -- a much tighter budget than KFM's
+  `remove_frames_farther_than`, which is a radius over keyframe centres),
+  `ASYNC_REBUILD` (default `true`; moves the k-d tree rebuilds off the mapping
+  thread and is what keeps insertion latency flat), `ALPHA_BALANCE`,
+  `ALPHA_DELETED`, `RESERVE_POINTS`.
+
+`mola::IncrementalPointCloud` needs `mola_metric_maps` built against
+nanoflann >= 1.10.0. On distributions with an older one the class still exists
+and is registered, but instantiating it throws an explanatory error, so
+selecting it there fails with a clear message rather than silently falling back.
 
 ## Environment Variables (Debug/Tracing Flags)
 

--- a/agents.md
+++ b/agents.md
@@ -223,6 +223,18 @@ over multiple frames. Two consequences for pipeline tuning:
 See `mola-cli-launchs/lidar_odometry_from_botanicgarden_livox.yaml` for a
 complete example with all three env vars set.
 
+## Selectable local-map class in `pipelines/lidar3d-gicp.yaml`
+
+`${MOLA_LOCALMAP_CLASS|mola::KeyframePointCloudMap}` picks the class used for
+both the `localmap` layer and the `observation` (scan) layer -- `Matcher_Cov2Cov`
+pairs the two, so they must always be the same `mp2p_icp::NearestPointWithCovCapable`
+class. The alternative is `mola::IncrementalPointCloud` (odometry only, no loop
+closure; see `mola_metric_maps`), tuned by the `MOLA_INCREMENTAL_MAP_*` vars in
+the same `creationOpts` block. Both classes' option keys live side by side there:
+each map class silently ignores the keys it does not define, which is what makes
+a single YAML enough. When adding keys, keep KFM's *required* ones
+(`max_search_keyframes`, `k_correspondences_for_cov`) present.
+
 ## Environment Variables (Debug/Tracing Flags)
 
 Debug/tracing flags in C++ code use `mrpt::get_env<T>(name, default)` (from

--- a/docs/mola_lo_pipelines.rst
+++ b/docs/mola_lo_pipelines.rst
@@ -149,7 +149,8 @@ layer and the per-scan ``observation`` layer, since ICP pairs the two:
    * - ``mola::KeyframePointCloudMap``
      - **Default.** Keyframe-based: points are stored in per-keyframe local
        frames, so the map survives a loop-closure re-map. Required for SLAM
-       (``mola_sm_loop_closure``) and for map building in general.
+       (``mola_sm_loop_closure``) and for any mapping session where the
+       trajectory may be corrected after the fact.
    * - ``mola::IncrementalPointCloud``
      - Single global frame, holding one incremental, self-balancing k-d tree
        that is updated in place instead of being rebuilt on every scan.

--- a/docs/mola_lo_pipelines.rst
+++ b/docs/mola_lo_pipelines.rst
@@ -76,6 +76,11 @@ To use a prepared ``.mm`` map for localization, ensure it contains a layer named
 +=======================+=========================================================+=============================================+
 | ``lidar3d-gicp.yaml`` | Keyframe-based 3D point clouds (layer: ``localmap``)    | Generalized ICP (“cov-to-cov”)              |
 |    (Default)          | (:ref:`doxid-classmola_1_1_keyframe_point_cloud_map`)   |                                             |
+|                       |                                                         |                                             |
+|                       | Optionally, an incremental k-d tree point cloud         |                                             |
+|                       | (``mola::IncrementalPointCloud``), selected via         |                                             |
+|                       | ``MOLA_LOCALMAP_CLASS``: see                            |                                             |
+|                       | :ref:`gicp_localmap_class`.                             |                                             |
 +-----------------------+---------------------------------------------------------+---------------------------------------------+
 | ``lidar3d-icp.yaml``  | Voxel-based 3D point clouds (layer: ``localmap``)       | Standard ICP (point-to-point)               |
 |                       | (:ref:`doxid-classmola_1_1_hashed_voxel_point_cloud`)   |                                             |
@@ -124,6 +129,63 @@ local map based on key-frames of point clouds, and exploits the Generalized ICP 
 .. note::
 
    See: :ref:`pipelines_env_vars`
+
+.. _gicp_localmap_class:
+
+Selecting the local map class
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This pipeline can build its local map with either of two classes. Both implement
+the ``mp2p_icp::NearestPointWithCovCapable`` interface required by the
+``Matcher_Cov2Cov`` matcher, and the choice applies to **both** the ``localmap``
+layer and the per-scan ``observation`` layer, since ICP pairs the two:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - ``MOLA_LOCALMAP_CLASS``
+     - Description
+   * - ``mola::KeyframePointCloudMap``
+     - **Default.** Keyframe-based: points are stored in per-keyframe local
+       frames, so the map survives a loop-closure re-map. Required for SLAM
+       (``mola_sm_loop_closure``) and for map building in general.
+   * - ``mola::IncrementalPointCloud``
+     - Single global frame, holding one incremental, self-balancing k-d tree
+       that is updated in place instead of being rebuilt on every scan.
+       **Odometry only:** a global SE(3) re-map would force a full rebuild, so
+       it must not be used together with loop closure.
+
+To try the incremental map from the CLI:
+
+.. code-block:: bash
+
+   MOLA_LOCALMAP_CLASS=mola::IncrementalPointCloud \
+   MOLA_ODOMETRY_PIPELINE_YAML=$(ros2 pkg prefix mola_lidar_odometry)/share/mola_lidar_odometry/pipelines/lidar3d-gicp.yaml \
+   mola-lo-gui-rosbag2 /path/to/dataset.mcap
+
+or from a ROS 2 launch file:
+
+.. code-block:: bash
+
+   MOLA_LOCALMAP_CLASS=mola::IncrementalPointCloud \
+   ros2 launch mola_lidar_odometry ros2-lidar-odometry.launch.py [...]
+
+Note that ``lidar3d-gicp.yaml`` is already the default pipeline, so
+``MOLA_ODOMETRY_PIPELINE_YAML`` only needs to be set for the dataset wrappers
+that default to another one (e.g. ``mola-lo-gui-oxford-spires``).
+
+.. note::
+
+   ``mola::IncrementalPointCloud`` requires ``mola_metric_maps`` to have been
+   built against **nanoflann >= 1.10.0**, the release that introduced the
+   incremental k-d tree index. On ROS distributions shipping an older nanoflann
+   the class still exists and is registered, but instantiating it throws an
+   explanatory error, so selecting it fails with a clear message rather than
+   silently falling back.
+
+Tuning is done through the ``MOLA_INCREMENTAL_MAP_*`` variables, see
+:ref:`pipelines_env_vars`.
 
 .. dropdown:: YAML listing
     :icon: code-review
@@ -509,6 +571,33 @@ ICP settings
 
 - ``MOLA_LOCALMAP_LAYER_NAME`` (Default: ``localmap``; GICP and ICP pipelines): Name of the metric map layer used
   as the local map for ICP matching and map insertion.
+
+- ``MOLA_LOCALMAP_CLASS`` (Default: ``mola::KeyframePointCloudMap``; GICP pipeline only): C++ class used for
+  both the local map and the per-scan observation layer. The alternative is ``mola::IncrementalPointCloud``
+  (odometry only, no loop closure). See :ref:`gicp_localmap_class`.
+
+The following only apply when ``MOLA_LOCALMAP_CLASS=mola::IncrementalPointCloud``:
+
+- ``MOLA_INCREMENTAL_MAP_MAX_SIZE`` (Default: ``max(25.0, 0.5*ESTIMATED_OBSERVATION_RADIUS)`` [m]): **Half side**
+  of the axis-aligned cube of points kept around the robot; everything outside it is evicted on each map update.
+  Note this is a much tighter budget than the keyframe map's ``MOLA_LOCAL_MAP_MAX_SIZE``, which is a radius over
+  keyframe *centers*: here every point inside the cube is kept in a single tree and rendered, so setting it too
+  large makes the local map accumulate scans instead of sliding.
+
+- ``MOLA_INCREMENTAL_MAP_ASYNC_REBUILD`` (Default: ``true``): Run the k-d tree balancing rebuilds on a background
+  thread, so the mapping thread never pays for them. Measured on the Oxford Spires dataset, this takes local map
+  insertion from mean 28 ms / max 371 ms down to mean 10 ms / max 38 ms, removing all latency spikes. Costs
+  roughly twice the index memory plus one worker thread; set to ``false`` on core-constrained targets.
+
+- ``MOLA_INCREMENTAL_MAP_RESERVE_POINTS`` (Default: ``2000000``): Point storage reserved up front. With
+  ``ASYNC_REBUILD`` enabled this also prevents the mapping thread from ever having to wait for the background
+  worker, which it must do before the point buffers can be reallocated.
+
+- ``MOLA_INCREMENTAL_MAP_ALPHA_BALANCE`` (Default: ``0.75``): A subtree is rebuilt when its larger child holds
+  more than this fraction of its points. Lower values keep queries faster at the price of more frequent rebuilds.
+
+- ``MOLA_INCREMENTAL_MAP_ALPHA_DELETED`` (Default: ``0.5``): A subtree is rebuilt, physically dropping evicted
+  points, once this fraction of it is dead. Lower values reclaim memory more aggressively.
 
 - ``MOLA_LO_ROBUST_KERNEL`` (Default: ``RobustKernel::GemanMcClure``): Robust kernel type used in the ICP
   Gauss-Newton solver.

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -350,10 +350,26 @@ localmap_generator:
         #
         # Two local-map classes are supported here, both implementing
         # mp2p_icp::NearestPointWithCovCapable (required by Matcher_Cov2Cov):
+        #
         #  - mola::KeyframePointCloudMap (default): keyframe-based, points kept
         #    in per-KF local frames, so it survives loop-closure re-mapping.
+        #    Required for SLAM and map building.
+        #
         #  - mola::IncrementalPointCloud: single global frame, one incremental
-        #    self-balancing k-d tree, no per-scan tree rebuild. Odometry only.
+        #    self-balancing k-d tree updated in place instead of rebuilt on
+        #    every scan. ODOMETRY ONLY: a global SE(3) re-map would force a full
+        #    rebuild, so do not combine it with loop closure. Needs
+        #    mola_metric_maps built against nanoflann >= 1.10.
+        #
+        #    To try it (the class applies to the 'observation' layer below too,
+        #    since Matcher_Cov2Cov pairs the two):
+        #
+        #      MOLA_LOCALMAP_CLASS=mola::IncrementalPointCloud \
+        #      ros2 launch mola_lidar_odometry ros2-lidar-odometry.launch.py [...]
+        #
+        #    Tuned by the MOLA_INCREMENTAL_MAP_* variables below. See
+        #    https://docs.mola-slam.org/latest/mola_lo_pipelines.html
+        #
         # Option keys not understood by the selected class are simply ignored,
         # so both sets can coexist below.
         class: ${MOLA_LOCALMAP_CLASS|mola::KeyframePointCloudMap}

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -353,7 +353,7 @@ localmap_generator:
         #
         #  - mola::KeyframePointCloudMap (default): keyframe-based, points kept
         #    in per-KF local frames, so it survives loop-closure re-mapping.
-        #    Required for SLAM and map building.
+        #    Required for loop-closure-capable SLAM.
         #
         #  - mola::IncrementalPointCloud: single global frame, one incremental
         #    self-balancing k-d tree updated in place instead of rebuilt on

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -319,7 +319,8 @@ icp_settings_with_vel:
         threshold: "2.0*ADAPTIVE_THRESHOLD_SIGMA"
         pairingsPerPoint: 1
         allowMatchAlreadyMatchedGlobalPoints: true # faster
-        # Both layers here must be of type 'mola::KeyframePointCloudMap'
+        # Both layers here must be of the very same cov-capable map class, the
+        # one selected below by ${MOLA_LOCALMAP_CLASS}.
         layerMatches:
           - { global: "${MOLA_LOCALMAP_LAYER_NAME|localmap}", local: "observation" }
 
@@ -346,13 +347,43 @@ localmap_generator:
 
       metric_map_definition:
         # Any class derived from mrpt::maps::CMetricMap https://docs.mrpt.org/reference/stable/group_mrpt_maps_grp.html
-        class: mola::KeyframePointCloudMap
+        #
+        # Two local-map classes are supported here, both implementing
+        # mp2p_icp::NearestPointWithCovCapable (required by Matcher_Cov2Cov):
+        #  - mola::KeyframePointCloudMap (default): keyframe-based, points kept
+        #    in per-KF local frames, so it survives loop-closure re-mapping.
+        #  - mola::IncrementalPointCloud: single global frame, one incremental
+        #    self-balancing k-d tree, no per-scan tree rebuild. Odometry only.
+        # Option keys not understood by the selected class are simply ignored,
+        # so both sets can coexist below.
+        class: ${MOLA_LOCALMAP_CLASS|mola::KeyframePointCloudMap}
         plugin: "libmola_metric_maps.so" # Import additional custom user-defined map classes (search in LD_LIBRARY_PATH)
         creationOpts:
-          max_search_keyframes: ${MOLA_LOCALMAP_MAX_SEARCH_KEYFRAMES|3}
+          # --- common to both classes ---
           k_correspondences_for_cov: ${MOLA_LOCALMAP_K_CORRESPONDENCES_FOR_COV|20}
           min_correspondences_for_cov: ${MOLA_LOCALMAP_MIN_CORRESPONDENCES_FOR_COV|5}
           max_distance_for_cov: ${MOLA_LOCALMAP_MAX_DISTANCE_FOR_COV|2.0}
+          # --- mola::IncrementalPointCloud only ---
+          # Half side [m] of the cube of points kept around the robot on each
+          # insertion (Chebyshev distance, as in HashedVoxelPointCloud's
+          # remove_voxels_farther_than). Unlike the keyframe map, EVERY point
+          # inside this cube is kept in a single tree and rendered, so this is
+          # a much tighter budget than 'remove_frames_farther_than' below:
+          # keep it near the sensor range, not several times it.
+          remove_points_farther_than: "${MOLA_INCREMENTAL_MAP_MAX_SIZE|$f{max(25.0, 0.5*ESTIMATED_OBSERVATION_RADIUS)}}" # [m]
+          # Run the k-d tree balancing rebuilds on a background thread, so the
+          # mapping thread never pays for them. Measured on Oxford Spires, this
+          # takes local-map insertion from mean 28 ms / max 371 ms (with 9 calls
+          # over 200 ms) down to mean 10 ms / max 38 ms and no spike at all:
+          async_rebuild: ${MOLA_INCREMENTAL_MAP_ASYNC_REBUILD|true}
+          alpha_balance: ${MOLA_INCREMENTAL_MAP_ALPHA_BALANCE|0.75}
+          alpha_deleted: ${MOLA_INCREMENTAL_MAP_ALPHA_DELETED|0.5}
+          # Pre-allocated point storage. With async_rebuild this also keeps the
+          # mapping thread from ever having to wait for the background worker,
+          # which it must do before the point buffers can be reallocated:
+          reserve_points: ${MOLA_INCREMENTAL_MAP_RESERVE_POINTS|2000000}
+          # --- mola::KeyframePointCloudMap only ---
+          max_search_keyframes: ${MOLA_LOCALMAP_MAX_SEARCH_KEYFRAMES|3}
           use_view_direction_filter: ${MOLA_LOCALMAP_USE_VIEW_DIRECTION_FILTER|true}
           max_view_angle_deg: ${MOLA_LOCALMAP_VIEW_DIRECTION_FILTER_ANGLE_DEG|120}
           rotation_distance_weight: 2.0
@@ -395,7 +426,8 @@ observations_generator:
       process_class_names_regex: ".*"
       process_sensor_labels_regex: ".*"
 
-  # This just creates an empty layer of the custom class 'mola::KeyframePointCloudMap'
+  # This just creates an empty layer of the local map class: Matcher_Cov2Cov
+  # pairs it against the local map, so both must be of the same class.
   - class_name: mp2p_icp_filters::Generator
     params:
       name: "Generator (obs)"
@@ -407,9 +439,9 @@ observations_generator:
 
       metric_map_definition:
         # Any class derived from mrpt::maps::CMetricMap https://docs.mrpt.org/reference/stable/group_mrpt_maps_grp.html
-        class: mola::KeyframePointCloudMap
+        class: ${MOLA_LOCALMAP_CLASS|mola::KeyframePointCloudMap}
         plugin: "libmola_metric_maps.so" # Import additional custom user-defined map classes (search in LD_LIBRARY_PATH)
-        creationOpts: ~ # none required
+        creationOpts: ~ # none required: defaults are fine for a single scan
         insertOpts: ~
         likelihoodOpts: ~ # none required
         renderOpts: ~


### PR DESCRIPTION
## What

`pipelines/lidar3d-gicp.yaml` now takes the local-map class from `${MOLA_LOCALMAP_CLASS|mola::KeyframePointCloudMap}`, applied to **both** the `localmap` layer and the `observation` (scan) layer — `Matcher_Cov2Cov` pairs the two, so they must always be of the same cov-capable class.

The alternative is the new `mola::IncrementalPointCloud` (MOLAorg/mola#184). Both classes' option keys live side by side in the same `creationOpts` block: each MRPT map class silently ignores keys it does not define, so one YAML covers both and no duplicated pipeline file is needed.

```bash
MOLA_ODOMETRY_PIPELINE_YAML=$(ros2 pkg prefix mola_lidar_odometry)/share/mola_lidar_odometry/pipelines/lidar3d-gicp.yaml \
MOLA_LOCALMAP_CLASS=mola::IncrementalPointCloud \
mola-lo-gui-oxford-spires /path/to/sequences/2024-03-12-keble-college-01/
```

## Defaults

Unchanged for `mola::KeyframePointCloudMap` — this is a no-op on the existing path.

For the incremental map, `async_rebuild` defaults to **true**. Measured on Oxford Spires `2024-03-12-keble-college-01`, moving the k-d tree balancing rebuilds off the mapping thread changes local-map insertion from:

| `async_rebuild` | mean | p50 | p95 | max | >100 ms | >200 ms |
|---|---|---|---|---|---|---|
| `false` | 28.3 ms | 13.5 | 125.4 | 370.8 | 14 | 9 |
| `true` | 10.3 ms | 8.5 | 25.1 | 37.8 | 0 | 0 |

## Note on `remove_points_farther_than`

It is a **cube half-side over points**, not a radius over keyframe centres like `remove_frames_farther_than`. Every point inside it is kept in a single tree and rendered, so it needs a far tighter budget than the keyframe map's equivalent — it defaults to roughly the sensor range (`max(25.0, 0.5*ESTIMATED_OBSERVATION_RADIUS)`) rather than several times it. Setting it too large makes the local map accumulate every scan indefinitely instead of sliding.

## Dependency

Needs MOLAorg/mola#184 for `mola::IncrementalPointCloud` to exist; without it the default keyframe-map path is unaffected, so this can land independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `MOLA_LOCALMAP_CLASS` to dynamically select the local-map type used by the 3D GICP matcher and observation layers (default keyframe map or incremental “odometry only” mode).
  * Added incremental-map configuration options for insertion and asynchronous KD-tree rebuilding.

* **Documentation**
  * Expanded pipeline documentation with usage examples for `MOLA_LOCALMAP_CLASS` and `MOLA_INCREMENTAL_MAP_*`, including compatibility notes and behavior on older nanoflann versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->