### PR TITLE
Fix silently-ignored IMU label filter in state-estimation-simple.yaml

### DIFF
--- a/state-estimator-params/state-estimation-simple.yaml
+++ b/state-estimator-params/state-estimation-simple.yaml
@@ -50,4 +50,4 @@ params:
   gnss_fuse_z: ${MOLA_NAVSTATE_GNSS_FUSE_Z|false}
 
   # regex for IMU sensor labels (ROS topics) to accept as IMU readings:
-  do_process_imu_labels: ${MOLA_NAVSTATE_IMU_SENSOR_NAME|.*}
+  do_process_imu_labels_re: ${MOLA_NAVSTATE_IMU_SENSOR_NAME|.*}


### PR DESCRIPTION
The parameter loader reads `do_process_imu_labels_re` (see `mola_state_estimation_simple/src/Parameters.cpp`), but the shipped `state-estimator-params/state-estimation-simple.yaml` wrote `do_process_imu_labels`, without the `_re` suffix. The key was parsed as an unknown extra and dropped silently.

Consequence: `MOLA_NAVSTATE_IMU_SENSOR_NAME` had no effect at all, and the filter always stayed at its default `.*`.

Harmless with the default, since `.*` is what an unset filter accepts anyway. It matters on a multi-IMU setup, where someone narrowing the filter to one sensor silently got all of them fused instead.

Found while auditing the LO-to-state-estimator wiring during gravity-fusion work.