### PR TITLE
Yaw-free gravity constraint with self-silencing sigma

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -249,6 +249,44 @@ a single YAML enough. When adding keys, keep KFM's *required* ones
 nanoflann >= 1.10.0. On distributions with an older one the class still exists
 and is registered, but instantiating it throws an explanatory error, so
 selecting it there fails with a clear message rather than silently falling back.
+## IMU gravity correction
+
+`params.imu_gravity_correction` constrains the ICP solution's tilt from the
+accelerometer. Two knobs decide *how*, both defaulting to `true`:
+
+- `use_rank2_prior`: deliver it as mp2p_icp's yaw-free, rank-2 `gravityPrior`,
+  which touches only the two tilt DOFs. The legacy path (`false`) folds
+  pitch/roll into the SE(3) pose prior, whose diagonal only isolates roll/pitch
+  near yaw=0 and which injects translation. Compiled only when the mp2p_icp in
+  use provides `mp2p_icp::GravityPrior` (`__has_include` guard in
+  `LidarOdometry.h`); older versions still build and fall back with a warning.
+- `adaptive_sigma`: widen `sigma_deg` by the measured dispersion of the buffered
+  accelerometer directions. Required in practice: the quasi-static gate accepts
+  `|norm(a)-g| <= 2 m/s^2`, i.e. up to ~11.8 deg of aliased tilt, so without it
+  the constraint asserts tilt the reading does not contain and net-degrades
+  odometry on a moving vehicle.
+
+Note that the two are not independent in effect: the rank-2 form alone is a
+correctness fix but does not improve odometry, because the tilt-to-Z coupling
+lives in the geometry Hessian and is parameterization-invariant. The gain comes
+from `adaptive_sigma`.
+
+## Reproducible odometry evaluation
+
+Trajectory-to-trajectory comparisons are only meaningful under all of:
+
+- the **batch CLI** (`mola-lidar-odometry-cli`), never the real-time GUI: under
+  real-time pacing scans are dropped and the motion prior is extrapolated with
+  queueing delay, which alone moved APE on one sequence by several times.
+- **`taskset -c N`**: `tbb::parallel_reduce` is FP non-associative, so thread
+  scheduling changes the result. Pinning makes runs bit-identical; check with
+  `md5sum` on the output `.tum` before comparing anything.
+- **`MOLA_ASYNC_BACKEND=false`** when using the smoother state estimator (its
+  async serving path is non-deterministic).
+
+The smoother also needs `-l <libmola_state_estimation_smoother.so>`; the CLI
+does not load that plugin by default and the class factory otherwise fails with
+"unknown class name".
 
 ## Environment Variables (Debug/Tracing Flags)
 

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -48,6 +48,16 @@
 #include <mp2p_icp_filters/FilterBase.h>
 #include <mp2p_icp_filters/Generator.h>
 
+// The yaw-free, rank-2 gravity prior is only available in recent mp2p_icp
+// versions. Keep building against older ones, falling back at run time to the
+// legacy path that folds tilt into the SE(3) pose prior.
+#if defined(__has_include)
+#if __has_include(<mp2p_icp/GravityPrior.h>)
+#include <mp2p_icp/GravityPrior.h>
+#define MOLA_LO_HAS_MP2P_GRAVITY_PRIOR 1
+#endif
+#endif
+
 // MRPT
 #include <mrpt/containers/circular_buffer.h>
 #include <mrpt/core/WorkerThreadsPool.h>
@@ -551,11 +561,37 @@ public:
 
     struct IMUGravityCorrection
     {
-      /// Enable accelerometer-based pitch/roll correction in ICP prior.
+      /// Enable accelerometer-based pitch/roll correction of the ICP solution.
       bool enabled = true;
 
-      /// Sigma [degrees] for the gravity-derived pitch/roll prior.
-      /// Lower values = more trust in IMU. Typical: 1–5 deg.
+      /// Apply the verticality constraint as mp2p_icp's yaw-free, rank-2
+      /// `gravityPrior` (recommended) instead of folding the gravity-derived
+      /// pitch/roll into the SE(3) pose prior.
+      ///
+      /// The legacy path (false) encodes tilt in a 6x6 prior information
+      /// matrix, whose diagonal only isolates roll/pitch near yaw=0 and which
+      /// injects translation directly. Kept selectable for reproducibility of
+      /// older results.
+      ///
+      /// Requires an mp2p_icp version providing mp2p_icp::GravityPrior; when
+      /// built against an older one this silently falls back to the legacy
+      /// path (with a warning), it does not fail.
+      bool use_rank2_prior = true;
+
+      /// Widen `sigma_deg` in quadrature by the MEASURED angular dispersion of
+      /// the buffered accelerometer directions, so the constraint stands down
+      /// automatically when the accelerometer is not actually measuring
+      /// gravity.
+      ///
+      /// Needed because the quasi-static acceptance gate alone is far too
+      /// permissive: accepting |norm(a) - g| <= 2 m/s^2 admits up to
+      /// asin(2/9.81) ~= 11.8 deg of aliased tilt. Without this, on a real
+      /// vehicle the gravity constraint asserts tilt information the reading
+      /// does not contain, and odometry gets worse rather than better.
+      bool adaptive_sigma = true;
+
+      /// Sigma [degrees] for the gravity-derived verticality constraint.
+      /// Lower values = more trust in IMU. Typical: 1 to 5 deg.
       double sigma_deg = 2.0;
 
       /// Number of recent accelerometer samples to average for gravity estimation.
@@ -744,6 +780,11 @@ private:
 
     mrpt::poses::CPose3D last_keyframe_pose;
     std::optional<mrpt::poses::CPose3DPDFGaussianInf> prior;
+#if defined(MOLA_LO_HAS_MP2P_GRAVITY_PRIOR)
+    /// Yaw-free, rank-2 gravity observation (alternative to folding tilt into
+    /// `prior`; see buildGravityPrior()). Only set when the rank-2 path is on.
+    std::optional<mp2p_icp::GravityPrior> gravityPrior;
+#endif
     id_t global_id = mola::INVALID_ID;
     id_t local_id = mola::INVALID_ID;
     double time_since_last_keyframe = 0;
@@ -818,6 +859,20 @@ private:
       /// max_age_seconds <= 0 means no age filtering.
       std::optional<std::pair<double, double>> estimatedPitchRoll(
         uint32_t required_samples, double max_age_seconds) const;
+
+      /// Empirical 1-sigma [rad] of the gravity DIRECTION over the samples
+      /// currently in the buffer: the RMS angle between each buffered sample's
+      /// direction and their mean direction.
+      ///
+      /// This is the honest uncertainty of the reading, measured rather than
+      /// assumed. While quasi-static it is small; under real vehicle dynamics
+      /// (braking, cornering, vibration) the accepted samples disagree and it
+      /// grows, so a caller that adds it in quadrature to its configured sigma
+      /// gets a verticality constraint that self-silences exactly when the
+      /// quasi-static assumption behind it stops holding.
+      ///
+      /// nullopt if fewer than 2 usable samples.
+      std::optional<double> directionDispersionSigma(double max_age_seconds) const;
     };
 
     GravityEstimator gravity_estimator;
@@ -1021,6 +1076,19 @@ private:
   /// Sensor timestamp [s] of the previous LiDAR scan seen at input, for the
   /// arrival-based period estimate above. Guarded by the wait-list mutex.
   double last_lidar_arrival_stamp_ = 0;
+
+#if defined(MOLA_LO_HAS_MP2P_GRAVITY_PRIOR)
+  /// Builds the yaw-free rank-2 gravity observation for the current scan from
+  /// the accelerometer gravity estimate, expressed against the map-frame
+  /// gravity direction captured at the map origin. nullopt if no reading yet.
+  /// Caller must hold state_mtx_.
+  [[nodiscard]] std::optional<mp2p_icp::GravityPrior> buildGravityPrior() const;
+#endif
+
+  /// The gravity sigma [rad] actually applied this scan: the configured
+  /// `imu_gravity_correction.sigma_deg`, optionally widened by the measured
+  /// direction dispersion (see `adaptive_sigma`). Caller must hold state_mtx_.
+  [[nodiscard]] double effectiveGravitySigmaRad() const;
 
   /** The worker thread pool with 1 thread for processing incoming observations*/
   mrpt::WorkerThreadsPool worker_others_{

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -232,6 +232,18 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
       params_.imu_gravity_correction.initialize(cfg["imu_gravity_correction"]);
     }
 
+#if !defined(MOLA_LO_HAS_MP2P_GRAVITY_PRIOR)
+    // Built against an mp2p_icp without the rank-2 gravity prior: degrade to
+    // the legacy path instead of failing, so older setups keep working.
+    if (params_.imu_gravity_correction.enabled && params_.imu_gravity_correction.use_rank2_prior) {
+      MRPT_LOG_WARN(
+        "imu_gravity_correction.use_rank2_prior requires a newer mp2p_icp "
+        "providing mp2p_icp::GravityPrior; falling back to the legacy "
+        "pose-prior path.");
+      params_.imu_gravity_correction.use_rank2_prior = false;
+    }
+#endif
+
     if (c.has("initial_localization")) {
       params_.initial_localization.initialize(c["initial_localization"]);
     }

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -327,6 +327,8 @@ void LidarOdometry::Parameters::ObservationValidityChecks::initialize(const Yaml
 void LidarOdometry::Parameters::IMUGravityCorrection::initialize(const Yaml & cfg)
 {
   YAML_LOAD_OPT(enabled, bool);
+  YAML_LOAD_OPT(use_rank2_prior, bool);
+  YAML_LOAD_OPT(adaptive_sigma, bool);
   YAML_LOAD_OPT(sigma_deg, double);
   YAML_LOAD_OPT(averaging_samples, uint32_t);
   YAML_LOAD_OPT(max_age_seconds, double);

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -71,6 +71,68 @@ bool LidarOdometry::isPipelineUsingIMU_locked() const
   return *state_.isPipelinesUsingIMU;
 }
 
+#if defined(MOLA_LO_HAS_MP2P_GRAVITY_PRIOR)
+std::optional<mp2p_icp::GravityPrior> LidarOdometry::buildGravityPrior() const
+{
+  // Caller holds state_mtx_.
+  const auto pr = state_.gravity_estimator.estimatedPitchRoll(
+    params_.imu_gravity_correction.averaging_samples,
+    params_.imu_gravity_correction.max_age_seconds);
+  if (!pr.has_value()) {
+    return std::nullopt;
+  }
+
+  // "Up" unit vector from (pitch, roll), matching the convention of
+  // GravityEstimator::estimatedPitchRoll(): pitch = asin(-u.x),
+  // roll = atan2(u.y, u.z). At rest the accelerometer's specific force points
+  // up, so this IS the measured gravity-up direction in the vehicle frame.
+  const auto upFrom = [](double p, double r) {
+    return mrpt::math::TVector3D(
+      -std::sin(p), std::cos(p) * std::sin(r), std::cos(p) * std::cos(r));
+  };
+
+  mp2p_icp::GravityPrior g;
+  g.up_body = upFrom(pr->first, pr->second);
+
+  // Gravity direction expressed in the MAP frame. The map origin is not
+  // necessarily level (nonzero fixed_initial_pose, or starting on a slope), so
+  // rotate the tilt captured there into map coordinates. No Euler algebra is
+  // involved: this is a plain vector rotation, valid at any yaw.
+  if (state_.gravity_calib_pitch_roll.has_value()) {
+    const auto [pitch0, roll0] = *state_.gravity_calib_pitch_roll;
+    const mrpt::poses::CPose3D R_map_veh0(
+      mrpt::poses::CPose3D(params_.initial_localization.fixed_initial_pose));
+    g.up_map = R_map_veh0.rotateVector(upFrom(pitch0, roll0));
+  } else {
+    g.up_map = {0, 0, 1};
+  }
+
+  g.sigma_rad = effectiveGravitySigmaRad();
+  return g;
+}
+#endif
+
+double LidarOdometry::effectiveGravitySigmaRad() const
+{
+  // Caller holds state_mtx_.
+  const double sigma0 = mrpt::DEG2RAD(params_.imu_gravity_correction.sigma_deg);
+  if (!params_.imu_gravity_correction.adaptive_sigma) {
+    return sigma0;
+  }
+
+  // Add the MEASURED dispersion of the buffered gravity directions in
+  // quadrature. Quasi-static -> dispersion ~0 -> sigma ~= sigma0 (unchanged).
+  // Under real vehicle dynamics the accepted samples disagree, sigma grows, and
+  // the constraint self-silences instead of asserting an aliased tilt that the
+  // reading does not actually contain.
+  const auto disp = state_.gravity_estimator.directionDispersionSigma(
+    params_.imu_gravity_correction.max_age_seconds);
+  if (!disp.has_value()) {
+    return sigma0;
+  }
+  return std::sqrt(sigma0 * sigma0 + (*disp) * (*disp));
+}
+
 // here happens the main stuff:
 void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOLINT
 {
@@ -438,8 +500,24 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       }
     }
 
-    // Apply IMU gravity correction to ICP prior (pitch/roll):
-    if (params_.imu_gravity_correction.enabled) {
+    // Apply the IMU verticality constraint as a yaw-free, rank-2 observation
+    // handled by the solver itself: it constrains only the two tilt DOFs and
+    // never touches yaw or translation.
+#if defined(MOLA_LO_HAS_MP2P_GRAVITY_PRIOR)
+    if (params_.imu_gravity_correction.enabled && params_.imu_gravity_correction.use_rank2_prior) {
+      in.gravityPrior = buildGravityPrior();
+      if (in.gravityPrior.has_value()) {
+        MRPT_LOG_DEBUG_FMT(
+          "IMU gravity (rank-2): up_body=[%.4f %.4f %.4f] up_map=[%.4f %.4f %.4f] sigma=%.2f deg",
+          in.gravityPrior->up_body.x, in.gravityPrior->up_body.y, in.gravityPrior->up_body.z,
+          in.gravityPrior->up_map.x, in.gravityPrior->up_map.y, in.gravityPrior->up_map.z,
+          mrpt::RAD2DEG(in.gravityPrior->sigma_rad));
+      }
+    }
+#endif
+
+    // Legacy path: fold the gravity-derived pitch/roll into the SE(3) prior.
+    if (params_.imu_gravity_correction.enabled && !params_.imu_gravity_correction.use_rank2_prior) {
       const auto gravityPR = state_.gravity_estimator.estimatedPitchRoll(
         params_.imu_gravity_correction.averaging_samples,
         params_.imu_gravity_correction.max_age_seconds);
@@ -482,7 +560,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
         const double cur_yaw = in.prior->mean.yaw();
         in.prior->mean.setYawPitchRoll(cur_yaw, map_pitch, map_roll);
 
-        const double sigma_rad = mrpt::DEG2RAD(params_.imu_gravity_correction.sigma_deg);
+        const double sigma_rad = effectiveGravitySigmaRad();
         const double inv_var = 1.0 / (sigma_rad * sigma_rad);
 
         // Gravity observes the two TILT axes only, and must leave yaw free.
@@ -620,8 +698,14 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
       }
 
       // Run ICP:
+#if defined(MOLA_LO_HAS_MP2P_GRAVITY_PRIOR)
+      icpCase.icp->align(
+        *observation, *state_.local_map, current_solution, icp_params, icp_result, in.prior,
+        std::nullopt /*outputDebugInfo*/, in.gravityPrior);
+#else
       icpCase.icp->align(
         *observation, *state_.local_map, current_solution, icp_params, icp_result, in.prior);
+#endif
 
       if (icp_result.nIterations <= remainingIcpIters) {
         remainingIcpIters -= icp_result.nIterations;

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -638,4 +638,69 @@ LidarOdometry::MethodState::GravityEstimator::estimatedPitchRoll(
   return std::make_pair(pitch, roll);
 }
 
+std::optional<double> LidarOdometry::MethodState::GravityEstimator::directionDispersionSigma(
+  double max_age_seconds) const
+{
+  const auto n = acc_buffer.size();
+  if (n < 2) {
+    return std::nullopt;
+  }
+
+  const double newest_stamp = acc_buffer.peek(n - 1).timestamp;
+  const bool use_age_filter = max_age_seconds > 0;
+
+  const auto isUsable = [&](std::size_t i, double & nrm) {
+    const auto & e = acc_buffer.peek(i);
+    if (use_age_filter && (newest_stamp - e.timestamp) > max_age_seconds) {
+      return false;
+    }
+    nrm = std::sqrt(e.acc[0] * e.acc[0] + e.acc[1] * e.acc[1] + e.acc[2] * e.acc[2]);
+    return nrm >= 1e-6;
+  };
+
+  // Mean direction. The sensor frame suffices: a fixed rotation to the vehicle
+  // frame does not change the angles between directions.
+  double mx = 0;
+  double my = 0;
+  double mz = 0;
+  std::size_t count = 0;
+  for (std::size_t i = 0; i < n; i++) {
+    double nrm = 0;
+    if (!isUsable(i, nrm)) {
+      continue;
+    }
+    const auto & e = acc_buffer.peek(i);
+    mx += e.acc[0] / nrm;
+    my += e.acc[1] / nrm;
+    mz += e.acc[2] / nrm;
+    ++count;
+  }
+  if (count < 2) {
+    return std::nullopt;
+  }
+
+  const double mn = std::sqrt(mx * mx + my * my + mz * mz);
+  if (mn < 1e-6) {
+    return std::nullopt;
+  }
+  mx /= mn;
+  my /= mn;
+  mz /= mn;
+
+  // RMS angle of each sample's direction about the mean direction:
+  double sumSqAng = 0;
+  for (std::size_t i = 0; i < n; i++) {
+    double nrm = 0;
+    if (!isUsable(i, nrm)) {
+      continue;
+    }
+    const auto & e = acc_buffer.peek(i);
+    const double dot = (e.acc[0] * mx + e.acc[1] * my + e.acc[2] * mz) / nrm;
+    const double ang = std::acos(std::min(1.0, std::max(-1.0, dot)));
+    sumSqAng += ang * ang;
+  }
+
+  return std::sqrt(sumSqAng / static_cast<double>(count));
+}
+
 }  // namespace mola

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -44,6 +44,14 @@ params:
   # Uses averaged accelerometer readings to constrain ICP pitch/roll.
   imu_gravity_correction:
     enabled: ${MOLA_IMU_GRAVITY_CORRECTION|true}
+    # Yaw-free, rank-2 verticality constraint solved by mp2p_icp. Set to false
+    # only to reproduce results from the legacy path, which folded tilt into
+    # the SE(3) pose prior.
+    use_rank2_prior: ${MOLA_IMU_GRAVITY_RANK2|true}
+    # Widen sigma_deg by the measured dispersion of the accelerometer
+    # directions, so the constraint stands down when the readings are not
+    # actually gravity (braking, cornering, vibration).
+    adaptive_sigma: ${MOLA_IMU_GRAVITY_ADAPTIVE_SIGMA|true}
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
     max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}


### PR DESCRIPTION
Changes how the IMU verticality constraint reaches ICP, and makes it stand down when the accelerometer is not actually measuring gravity.

Two new params under `imu_gravity_correction`, both defaulting to `true`.

## `use_rank2_prior`

Applies the constraint as mp2p_icp's yaw-free, rank-2 `gravityPrior` (MOLAorg/mp2p_icp#76) instead of folding the gravity-derived pitch/roll into the SE(3) pose prior.

The legacy path encodes tilt in a 6x6 information matrix. Its diagonal only isolates roll/pitch when yaw is near zero, so on a turning vehicle the constraint quietly becomes something else, and it injects translation directly. The rank-2 form constrains exactly the two tilt DOFs and leaves yaw and all three translations free at any attitude. It also handles a non-level map frame as a plain vector rotation, with no Euler composition.

## `adaptive_sigma`

Widens `sigma_deg` in quadrature by the measured angular dispersion of the buffered accelerometer directions.

This matters because the quasi-static acceptance gate alone is far too permissive: accepting `|norm(a) - g| <= 2 m/s^2` admits up to `asin(2/9.81)` ~= 11.8 deg of aliased tilt. Without this, the constraint asserts tilt information the reading does not contain, and on a real vehicle that makes odometry worse rather than better.

## Evidence

Deterministic runs (batch CLI, pinned core, md5-verified), APE / horizontal / vertical RMSE in meters:

| MulRan DCC01 (vehicle) | APE | horiz | vert |
|---|---|---|---|
| gravity off | 9.118 | 6.714 | 6.169 |
| rank-2 alone | 11.361 | 6.299 | 9.455 |
| **rank-2 + adaptive (new default)** | **8.910** | 6.298 | 6.303 |

| Oxford Spires Blenheim (handheld) | APE | horiz | vert |
|---|---|---|---|
| gravity off | 1.015 | 0.892 | 0.484 |
| **rank-2 + adaptive (new default)** | **0.969** | 0.827 | 0.504 |

On a real vehicle the shipped default goes from clearly harmful (+24.6% APE vs gravity off, +53% vertical) to mildly beneficial (-2.3% APE, +2.2% vertical). The handheld sequence is unchanged within noise, which is the expected result: a quasi-static unit makes the dispersion term vanish, so `adaptive_sigma` reduces to the plain rank-2 constraint there.

Note the middle row of the DCC01 table: the rank-2 reformulation **on its own** does not fix anything. It is a correctness fix for how the constraint is expressed, but the tilt-to-Z coupling lives in the geometry Hessian and is parameterization-invariant. What actually helps is declining to assert tilt the accelerometer did not measure.

Verified that the YAML defaults reproduce the measured arm byte for byte, so the numbers above describe the shipped behavior and not a nearby configuration.

## Compatibility

Both paths stay selectable; set `use_rank2_prior: false` to reproduce older results.

The rank-2 code is compiled only when the mp2p_icp in use provides `mp2p_icp::GravityPrior` (detected with `__has_include`). Against older versions the build still succeeds and the parameter degrades to the legacy path with a warning at startup, rather than failing. Both configurations were compile-tested.

## Caveat

The evidence is two sequences, one vehicle and one handheld. Broader MulRan validation is the obvious follow-up before treating the vehicle result as general.