### PR TITLE
CI: don't let one broken distro cancel the sibling x86_64 jobs

### DIFF
--- a/.github/workflows/build-ros.yml
+++ b/.github/workflows/build-ros.yml
@@ -24,6 +24,9 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
     continue-on-error: ${{ matrix.allow_failure == true }}
     strategy:
+      # Without this, one broken distro cancels the sibling jobs, so a known
+      # failure hides the results that would otherwise be actionable.
+      fail-fast: false
       matrix:
         include:
           # Humble Hawksbill (May 2022 - May 2027)


### PR DESCRIPTION
The x86_64 build matrix has no `fail-fast` setting, so it defaults to `true`: the moment one distro fails, GitHub cancels its siblings.

Right now `ros-humble-mola-input-rosbag2` is missing from the humble *testing* repo, so `x86_64 / humble testing` fails on every branch, `develop` included:

```
E: Unable to locate package ros-humble-mola-input-rosbag2
ERROR: the following rosdeps failed to install
```

With fail-fast on, that one known failure takes the jazzy jobs down with it. They finish as **cancelled**, which `gh pr checks` renders as "fail", so every open PR currently looks like it has three red x86_64 jobs when it really has one, and there is no actionable jazzy result on any of them until an unrelated packaging gap is resolved upstream.

The arm64 matrix already sets `fail-fast: false`. This makes x86_64 match it.

Does not address the humble packaging gap itself, which is out of this repo's hands; it just stops that gap from suppressing the results that still work.