### PR TITLE
Add option to hide the current-pose XYZ corner opengl object

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -282,6 +282,14 @@ public:
       float current_pose_corner_size = 1.5f;  //! [m]
       float sensor_poses_corner_size = 0.5f;  //! [m], 0 to disable
 
+      /** Whether to render the current-pose XYZ corner at all (independently
+             * of current_pose_corner_size). Useful to turn off from a
+             * first-person camera, where the corner ends up filling the whole
+             * view. Can also be changed at runtime via
+             * setCurrentPoseCornerVisualization().
+             */
+      bool show_current_pose_corner = true;
+
       // --- Ground grid ---
       bool show_ground_grid = true;
       float ground_grid_spacing = 5.0f;
@@ -710,6 +718,11 @@ public:
      *  its RGBA color (each component in [0,1]). Lets a host own the
      *  trajectory appearance instead of toggling the scene object externally. */
   void setTrajectoryVisualization(bool show, const std::vector<float> & rgba);
+
+  /** Shows or hides the current-pose XYZ corner opengl object. Useful for a
+     *  host using a first-person camera placed at the vehicle pose, where the
+     *  corner would otherwise fill the whole view. */
+  void setCurrentPoseCornerVisualization(bool show);
 
   /** @} */
 

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -368,6 +368,11 @@ void LidarOdometry::setTrajectoryVisualization(bool show, const std::vector<floa
   });
 }
 
+void LidarOdometry::setCurrentPoseCornerVisualization(bool show)
+{
+  enqueue_request([this, show]() { params_.visualization.show_current_pose_corner = show; });
+}
+
 std::string LidarOdometry::vizParentFrame() const
 {
 #if defined(MOLA_KERNEL_VIZ_HAS_MOVABLE_FRAMES)
@@ -411,7 +416,8 @@ void LidarOdometry::updateVisualization(
   // the parent (MolaViz::update_3d_object deep-reads it on the GUI
   // thread while the lidar worker may keep producing new frames).
   auto glVehicle = mrpt::opengl::CSetOfObjects::Create();
-  if (const auto l = params_.visualization.current_pose_corner_size; l > 0) {
+  if (const auto l = params_.visualization.current_pose_corner_size;
+      params_.visualization.show_current_pose_corner && l > 0) {
     glVehicle->insert(mrpt::opengl::stock_objects::CornerXYZ(l));
   }
   if (const auto l = params_.visualization.sensor_poses_corner_size; l > 0) {

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -124,6 +124,7 @@ void LidarOdometry::Parameters::Visualization::initialize(const Yaml & cfg)
   YAML_LOAD_OPT(ground_grid_spacing, float);
   YAML_LOAD_OPT(current_pose_corner_size, float);
   YAML_LOAD_OPT(sensor_poses_corner_size, float);
+  YAML_LOAD_OPT(show_current_pose_corner, bool);
   YAML_LOAD_OPT(local_map_point_size, float);
   YAML_LOAD_OPT(current_observation_point_size, float);
   YAML_LOAD_OPT(last_deskewed_observations_point_size, float);

--- a/pipelines/extras/lidar3d-dual-map.yaml
+++ b/pipelines/extras/lidar3d-dual-map.yaml
@@ -81,6 +81,7 @@ params:
     show_trajectory: true
     #current_pose_corner_size: 1.5
     #sensor_poses_corner_size: 0.5  # XYZ corner for each LiDAR sensor pose; 0 to disable
+    show_current_pose_corner: ${MOLA_LO_SHOW_CURRENT_POSE_CORNER|true} # Set to false to hide the current-pose XYZ corner (e.g. for a first-person camera)
     #model_file: ${HOME}/Downloads/ParrotBebop2_assembled.dae
     #model_tf.roll: 90.0 # deg
 

--- a/pipelines/extras/lidar3d-edges.yaml
+++ b/pipelines/extras/lidar3d-edges.yaml
@@ -91,6 +91,7 @@ params:
     show_trajectory: true
     #current_pose_corner_size: 1.5
     #sensor_poses_corner_size: 0.5  # XYZ corner for each LiDAR sensor pose; 0 to disable
+    show_current_pose_corner: ${MOLA_LO_SHOW_CURRENT_POSE_CORNER|true} # Set to false to hide the current-pose XYZ corner (e.g. for a first-person camera)
     model:
       - file: ${MOLA_VEHICLE_MODEL_FILE|""} # Default: none
         tf.roll: 90.0 # deg

--- a/pipelines/extras/rgbd.yaml
+++ b/pipelines/extras/rgbd.yaml
@@ -110,6 +110,7 @@ params:
     show_trajectory: true
     #current_pose_corner_size: 1.5
     #sensor_poses_corner_size: 0.5  # XYZ corner for each LiDAR sensor pose; 0 to disable
+    show_current_pose_corner: ${MOLA_LO_SHOW_CURRENT_POSE_CORNER|true} # Set to false to hide the current-pose XYZ corner (e.g. for a first-person camera)
     local_map_point_size: 3
     model:
       - file: ${MOLA_VEHICLE_MODEL_FILE|""} # Default: none

--- a/pipelines/lidar2d.yaml
+++ b/pipelines/lidar2d.yaml
@@ -121,6 +121,7 @@ params:
     show_current_observation: true # shows "live raw" LiDAR points
     #current_pose_corner_size: 1.5
     #sensor_poses_corner_size: 0.5  # XYZ corner for each LiDAR sensor pose; 0 to disable
+    show_current_pose_corner: ${MOLA_LO_SHOW_CURRENT_POSE_CORNER|true} # Set to false to hide the current-pose XYZ corner (e.g. for a first-person camera)
     local_map_point_size: 3
     local_map_render_voxelmap_free_space: ${MOLA_RENDER_VOXELMAP_FREESPACE|true} # for 2D-LIDAR SLAM this may be affordable; for 3D it slows down too much
     model:

--- a/pipelines/lidar3d-gicp-optimize-twist.yaml
+++ b/pipelines/lidar3d-gicp-optimize-twist.yaml
@@ -169,6 +169,7 @@ params:
     ground_grid_spacing: 5.0 # [m]
     #current_pose_corner_size: 1.5
     #sensor_poses_corner_size: 0.5  # XYZ corner for each LiDAR sensor pose; 0 to disable
+    show_current_pose_corner: ${MOLA_LO_SHOW_CURRENT_POSE_CORNER|true} # Set to false to hide the current-pose XYZ corner (e.g. for a first-person camera)
     model:
       - file: ${MOLA_VEHICLE_MODEL_FILE|""} # Default: none
         tf.x: ${MOLA_VEHICLE_MODEL_X|0.0} # deg

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -213,6 +213,7 @@ params:
     ground_grid_spacing: 5.0 # [m]
     #current_pose_corner_size: 1.5
     #sensor_poses_corner_size: 0.5  # XYZ corner for each LiDAR sensor pose; 0 to disable
+    show_current_pose_corner: ${MOLA_LO_SHOW_CURRENT_POSE_CORNER|true} # Set to false to hide the current-pose XYZ corner (e.g. for a first-person camera)
     model:
       - file: ${MOLA_VEHICLE_MODEL_FILE|""} # Default: none
         tf.x: ${MOLA_VEHICLE_MODEL_X|0.0} # deg

--- a/pipelines/lidar3d-icp.yaml
+++ b/pipelines/lidar3d-icp.yaml
@@ -170,6 +170,7 @@ params:
     ground_grid_spacing: 5.0 # [m]
     #current_pose_corner_size: 1.5
     #sensor_poses_corner_size: 0.5  # XYZ corner for each LiDAR sensor pose; 0 to disable
+    show_current_pose_corner: ${MOLA_LO_SHOW_CURRENT_POSE_CORNER|true} # Set to false to hide the current-pose XYZ corner (e.g. for a first-person camera)
     model:
       - file: ${MOLA_VEHICLE_MODEL_FILE|""} # Default: none
         tf.x: ${MOLA_VEHICLE_MODEL_X|0.0} # deg

--- a/pipelines/lidar3d-ndt.yaml
+++ b/pipelines/lidar3d-ndt.yaml
@@ -143,6 +143,7 @@ params:
     ground_grid_spacing: 5.0 # [m]
     #current_pose_corner_size: 1.5
     #sensor_poses_corner_size: 0.5  # XYZ corner for each LiDAR sensor pose; 0 to disable
+    show_current_pose_corner: ${MOLA_LO_SHOW_CURRENT_POSE_CORNER|true} # Set to false to hide the current-pose XYZ corner (e.g. for a first-person camera)
     local_map_point_size: 3
     model:
       - file: ${MOLA_VEHICLE_MODEL_FILE|""} # Default: none


### PR DESCRIPTION
## Summary
- Adds `Visualization::show_current_pose_corner` (default `true`) to independently gate rendering of the current-pose XYZ corner, on top of the existing `current_pose_corner_size` scale.
- Adds `LidarOdometry::setCurrentPoseCornerVisualization(bool)`, a thread-safe runtime setter following the same pattern as `setTrajectoryVisualization()`.
- Wires `show_current_pose_corner: ${MOLA_LO_SHOW_CURRENT_POSE_CORNER|true}` into the shipped pipeline YAMLs, next to the other corner-size options.

## Motivation
A host application using a first-person camera anchored at the vehicle pose ends up with the corner geometry filling (and blocking) the entire view, since the camera sits right at the corner's origin. This lets such a host disable it without editing the LO pipeline config, either via the env var or the new setter.

## Test plan
- [x] `colcon build --packages-select mola_lidar_odometry` succeeds
- [x] `clang-format-14` applied to touched sources
- [ ] CI green