### PR TITLE
fix: potential deadlock for large maps with the new incremental map class

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -156,6 +156,22 @@ sudden ~30-40 deg yaw error that then persisted for the rest of the run,
 instead of a brief quality dip that recovers to the true pose).
 
 
+## Local-map locking: `state_mtx_` vs `local_map_content_mtx_`
+
+Rendering the local map (`updateVisualizationLocalMap()`) is O(map size) and
+must not run under `state_mtx_`, or it stalls the dataset reader, IMU worker
+and executor threads once the map is large. So it releases `state_mtx_` (via
+the caller's `std::unique_lock`, passed down through
+`updateVisualization*()`) and takes the finer-grained `local_map_content_mtx_`
+instead, which every mutation of `state_.local_map` contents (insert, `clear()`,
+`load_from_file()`) must also hold.
+
+Lock order: take `state_mtx_` first, then `local_map_content_mtx_`; never hold
+the latter while acquiring the former. Note the renderer therefore *releases*
+`state_mtx_` before taking the contents mutex, and releases the contents mutex
+before re-acquiring `state_mtx_`.
+
+
 ## Keyframe-creation policy (shared by local map and simplemap)
 
 `mola::KeyframeDecider` + `mola::KeyframeDecisionOptions`

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -84,6 +84,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <regex>
 #include <string>
 #include <vector>
@@ -1097,7 +1098,9 @@ private:
     // to the GUI thread directly: each update clones it into a fresh
     // CSetOfObjects wrapper before dispatch.
     mrpt::opengl::CSetOfLines::Ptr glEstimatedPath;
-    int mapUpdateCnt = std::numeric_limits<int>::max();
+    /// Decimation counter for the local map visualization. Saturating (never
+    /// wraps around), so its maximum value means "refresh at the next chance".
+    unsigned int mapUpdateCnt = std::numeric_limits<unsigned int>::max();
 
     // List of old observations to be unload()'ed, to save RAM if:
     // 1) building a simplemap, and
@@ -1246,6 +1249,15 @@ private:
   mutable std::mutex drop_stats_mtx_;
   mutable std::mutex state_flags_mtx_;
   mutable std::mutex state_mtx_;
+
+  /// Guards the *contents* (layers) of MethodState::local_map.
+  /// Rendering the map is O(map size) and would stall every other user of
+  /// state_mtx_ (dataset reader, IMU worker, executor thread) if done under it,
+  /// so updateVisualizationLocalMap() temporarily releases state_mtx_ and takes
+  /// this one instead. Lock order: a thread that needs both must take
+  /// state_mtx_ first; it must never be held while acquiring state_mtx_.
+  mutable std::mutex local_map_content_mtx_;
+
   mutable std::mutex state_trajectory_mtx_;
   mutable std::recursive_mutex state_simplemap_mtx_;
   mutable std::mutex state_gui_mtx_;
@@ -1301,19 +1313,23 @@ private:
   void updatePipelineTwistVariables(const mrpt::math::TTwist3D & tw);
   void updatePipelineDynamicVariablesRobotPoseOnly();
 
+  /// All these methods read state_, so the caller must own state_mtx_ and pass
+  /// its lock object down: it is momentarily released while rendering the
+  /// local map (see local_map_content_mtx_).
   void updateVisualization(
     const mp2p_icp::metric_map_t & currentObservation,
-    const mrpt::maps::CPointsMap::Ptr & deskewedCloud);
+    const mrpt::maps::CPointsMap::Ptr & deskewedCloud, std::unique_lock<std::mutex> & lckState);
 
   void updateVisualizationInitVehFrame();
   void updateVisualizationCurrentObservation(
     const mp2p_icp::metric_map_t & currentObservation,
     const mrpt::maps::CPointsMap::Ptr & deskewedCloud);
-  void updateVisualizationLocalMap(std::vector<std::function<void()>> & updateTasks);
+  void updateVisualizationLocalMap(
+    std::vector<std::function<void()>> & updateTasks, std::unique_lock<std::mutex> & lckState);
   void updateVisualizationPath(std::vector<std::function<void()>> & updateTasks);
   void updateVisualizationGravityVector(std::vector<std::function<void()>> & updateTasks);
   void updateVisualizationTextLabels();
-  void updateVisualizationAlways();
+  void updateVisualizationAlways(std::unique_lock<std::mutex> & lckState);
 
   void internalBuildGUI();
   mola::gui::Tab buildTabStatus();

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -729,8 +729,18 @@ void LidarOdometry::updateVisualizationLocalMap(std::vector<std::function<void()
     rp.points.allLayers.render_voxelmaps_free_space =
       params_.visualization.local_map_render_voxelmap_free_space;
 
-    // local map:
+    // local map: this recolors/renders every point currently in the map, an
+    // O(map size) cost that keeps growing with it (e.g. under
+    // mola::IncrementalPointCloud, whose local map never shrinks back below
+    // its eviction cube). It runs under state_mtx_ (held by the caller since
+    // processLidarScan()), which stalls the dataset reader, IMU worker, and
+    // executor threads for the whole call once the local map gets large. Its
+    // only shared_state touched is state_.local_map, whose *content* is only
+    // ever mutated by this same worker thread earlier in processLidarScan(),
+    // never concurrently, so it is safe to read here without the lock:
+    state_mtx_.unlock();
     auto glMap = state_.local_map->get_visualization(rp);
+    state_mtx_.lock();
 
     updateTasks.emplace_back([visualizer = visualizer_, glMap, vizFrame]() {
       vizUpsert3D(visualizer, "liodom/localmap", glMap, vizFrame);

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -39,8 +39,32 @@
 #include <mrpt/system/filesystem.h>
 #include <mrpt/version.h>
 
+// STD:
+#include <algorithm>
+#include <limits>
+#include <mutex>
+
 namespace mola
 {
+
+namespace
+{
+/** Temporarily releases an already-held lock, re-acquiring it on scope exit
+ *  (including if the guarded code throws).
+ */
+class ScopedUnlock
+{
+public:
+  explicit ScopedUnlock(std::unique_lock<std::mutex> & lck) : lck_(lck) { lck_.unlock(); }
+  ~ScopedUnlock() { lck_.lock(); }
+
+  ScopedUnlock(const ScopedUnlock &) = delete;
+  ScopedUnlock & operator=(const ScopedUnlock &) = delete;
+
+private:
+  std::unique_lock<std::mutex> & lck_;
+};
+}  // namespace
 
 mola::gui::Tab LidarOdometry::buildTabStatus()
 {
@@ -385,14 +409,16 @@ std::string LidarOdometry::vizParentFrame() const
 
 void LidarOdometry::updateVisualization(
   const mp2p_icp::metric_map_t & currentObservation,
-  const mrpt::maps::CPointsMap::Ptr & deskewedCloud)
+  const mrpt::maps::CPointsMap::Ptr & deskewedCloud, std::unique_lock<std::mutex> & lckState)
 {
   const ProfilerEntry tle(profiler_, "updateVisualization");
 
   gui_.timestampLastUpdateUI = mrpt::Clock::nowDouble();
 
-  // In this point, we are called by the LIDAR worker thread, so it's safe
-  // to read the state without mutexes.
+  // We may be called either from the LIDAR worker thread or from the executor
+  // thread (spinOnce()), so state_ is read under state_mtx_, already held by
+  // the caller (see lckState).
+  ASSERT_(lckState.owns_lock());
   ASSERT_(visualizer_);
 
   // Movable scene-frame to draw under (empty = viewport root):
@@ -528,15 +554,17 @@ void LidarOdometry::updateVisualization(
     MRPT_LOG_INFO(s);
   }
 
-  updateVisualizationAlways();
+  updateVisualizationAlways(lckState);
 }
 
-void LidarOdometry::updateVisualizationAlways()
+void LidarOdometry::updateVisualizationAlways(std::unique_lock<std::mutex> & lckState)
 {
+  ASSERT_(lckState.owns_lock());
+
   // Local map: update whenever map content changed, independent of ICP quality.
   {
     std::vector<std::function<void()>> updateTasks;
-    updateVisualizationLocalMap(updateTasks);
+    updateVisualizationLocalMap(updateTasks, lckState);
     for (const auto & ut : updateTasks) {
       ut();
     }
@@ -707,13 +735,27 @@ void LidarOdometry::updateVisualizationCurrentObservation(
   (void)fut;
 }
 
-void LidarOdometry::updateVisualizationLocalMap(std::vector<std::function<void()>> & updateTasks)
+void LidarOdometry::updateVisualizationLocalMap(
+  std::vector<std::function<void()>> & updateTasks, std::unique_lock<std::mutex> & lckState)
 {
+  ASSERT_(lckState.owns_lock());
+
   const std::string vizFrame = vizParentFrame();
-  if (
-    params_.visualization.show_localmap && state_.local_map &&
-    ((state_.mapUpdateCnt++ > params_.visualization.map_update_decimation) &&
-     state_.local_map_needs_viz_update)) {
+
+  bool decimationReached = false;
+  if (params_.visualization.show_localmap && state_.local_map) {
+    const auto decimation =
+      static_cast<unsigned int>(std::max(0, params_.visualization.map_update_decimation));
+    decimationReached = state_.mapUpdateCnt > decimation;
+
+    // Saturating increment: the counter is *set* to its maximum value elsewhere
+    // to request an immediate refresh, so it must not wrap around.
+    if (state_.mapUpdateCnt < std::numeric_limits<unsigned int>::max()) {
+      state_.mapUpdateCnt++;
+    }
+  }
+
+  if (decimationReached && state_.local_map_needs_viz_update) {
     const ProfilerEntry tle2(profiler_, "updateVisualization.update_local_map");
 
     state_.mapUpdateCnt = 0;
@@ -732,15 +774,23 @@ void LidarOdometry::updateVisualizationLocalMap(std::vector<std::function<void()
     // local map: this recolors/renders every point currently in the map, an
     // O(map size) cost that keeps growing with it (e.g. under
     // mola::IncrementalPointCloud, whose local map never shrinks back below
-    // its eviction cube). It runs under state_mtx_ (held by the caller since
-    // processLidarScan()), which stalls the dataset reader, IMU worker, and
-    // executor threads for the whole call once the local map gets large. Its
-    // only shared_state touched is state_.local_map, whose *content* is only
-    // ever mutated by this same worker thread earlier in processLidarScan(),
-    // never concurrently, so it is safe to read here without the lock:
-    state_mtx_.unlock();
-    auto glMap = state_.local_map->get_visualization(rp);
-    state_mtx_.lock();
+    // its eviction cube). Doing it under state_mtx_ stalls the dataset reader,
+    // IMU worker, and executor threads for the whole call once the local map
+    // gets large, so state_mtx_ is temporarily released here and the map
+    // contents are guarded by the finer-grained local_map_content_mtx_ instead.
+    // Note the strict order: state_mtx_ is released *before* acquiring the
+    // contents mutex, since holders of the latter may be waiting for the
+    // former (see the lock order documented in the class declaration).
+    mrpt::opengl::CSetOfObjects::Ptr glMap;
+    {
+      // Keep the map alive even if state_ is reset while unlocked:
+      const auto localMap = state_.local_map;
+
+      const ScopedUnlock unlockState(lckState);
+      auto lckMapContents = mrpt::lockHelper(local_map_content_mtx_);
+
+      glMap = localMap->get_visualization(rp);
+    }
 
     updateTasks.emplace_back([visualizer = visualizer_, glMap, vizFrame]() {
       vizUpsert3D(visualizer, "liodom/localmap", glMap, vizFrame);
@@ -757,7 +807,7 @@ void LidarOdometry::updateVisualizationLocalMap(std::vector<std::function<void()
     // Force an immediate redraw the next time the local map is shown again,
     // since it may not change on its own (e.g. localization-only mode):
     state_.local_map_needs_viz_update = true;
-    state_.mapUpdateCnt = std::numeric_limits<int>::max();
+    state_.mapUpdateCnt = std::numeric_limits<unsigned int>::max();
   }
 }
 

--- a/module/src/LidarOdometry_InitialLocalization.cpp
+++ b/module/src/LidarOdometry_InitialLocalization.cpp
@@ -128,7 +128,10 @@ void LidarOdometry::handleInitialLocalization()
         // call): otherwise this would discard a map inherited from a
         // previous mapping session (multisession/multi-robot mapping).
         if (!state_.map_has_been_loaded) {
-          state_.local_map->clear();
+          {
+            auto lckMapContents = mrpt::lockHelper(local_map_content_mtx_);
+            state_.local_map->clear();
+          }
           state_.gravity_calib_pitch_roll.reset();  // new map origin: recapture at next first KF
           ASSERT_(state_.local_map->empty());
           {

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -521,6 +521,9 @@ void LidarOdometry::doPreloadLocalMap()
       "Loading map from file: '" << params_.local_map_updates.load_existing_local_map << "'...");
 
     auto lckState = mrpt::lockHelper(state_mtx_);
+    // Guards the map contents against a concurrent visualization render,
+    // which runs without state_mtx_ (see local_map_content_mtx_ docs):
+    auto lckMapContents = mrpt::lockHelper(local_map_content_mtx_);
 
     const bool loadOk =
       state_.local_map->load_from_file(params_.local_map_updates.load_existing_local_map);

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -46,6 +46,7 @@
 
 // STD:
 #include <chrono>
+#include <mutex>
 #include <thread>
 
 // Portable config path
@@ -160,11 +161,19 @@ void LidarOdometry::spinOnce()
     auto lckGuiMtx = mrpt::lockHelper(state_gui_mtx_);
     guiCreated = gui_.gui_created;
   }
-  if (
-    visualizer_ &&
-    ((state_.local_map && state_.local_map->empty()) || !isActive() || !guiCreated)) {
-    if (mrpt::Clock::nowDouble() - gui_.timestampLastUpdateUI > 1.0) {
-      updateVisualization({}, {});
+  // Evaluated before taking state_mtx_, since it uses state_flags_mtx_:
+  const bool isNowActive = isActive();
+
+  if (visualizer_) {
+    // updateVisualization() reads state_, so it must be called with state_mtx_
+    // held (it takes care of momentarily releasing it while rendering the
+    // potentially large local map):
+    std::unique_lock<std::mutex> lckState(state_mtx_);
+
+    if (
+      ((state_.local_map && state_.local_map->empty()) || !isNowActive || !guiCreated) &&
+      mrpt::Clock::nowDouble() - gui_.timestampLastUpdateUI > 1.0) {
+      updateVisualization({}, {}, lckState);
     }
   }
 

--- a/module/src/LidarOdometry_MapServer.cpp
+++ b/module/src/LidarOdometry_MapServer.cpp
@@ -89,6 +89,9 @@ MapServer::ReturnStatus LidarOdometry::map_load_impl(const std::string & path)
   bool mmLoadOk = false;
   {
     auto lckState = mrpt::lockHelper(state_mtx_);
+    // Guards the map contents against a concurrent visualization render,
+    // which runs without state_mtx_ (see local_map_content_mtx_ docs):
+    auto lckMapContents = mrpt::lockHelper(local_map_content_mtx_);
 
     ASSERT_(state_.local_map);
     state_.local_map->clear();

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -35,6 +35,7 @@
 #include <mrpt/poses/Lie/SO.h>
 
 #include <algorithm>
+#include <mutex>
 
 namespace mola
 {
@@ -270,7 +271,7 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
   obs->load();
   const auto this_obs_tim = obs->timestamp;
 
-  auto lckState = mrpt::lockHelper(state_mtx_);
+  std::unique_lock<std::mutex> lckState(state_mtx_);
 
   // for rate stats:
   state_.append_lidar_stamp(obs->sensorLabel, obs->timestamp, *this);
@@ -1127,7 +1128,10 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     !state_.last_icp_was_good && state_.estimated_trajectory.size() == 1 &&
     params_.local_map_updates.enabled && !state_.map_has_been_loaded) {
     // Re-start the local map:
-    state_.local_map->clear();
+    {
+      auto lckMapContents = mrpt::lockHelper(local_map_content_mtx_);
+      state_.local_map->clear();
+    }
     state_.estimated_trajectory.clear();
     state_.gravity_calib_pitch_roll.reset();  // new map origin: recapture at next first KF
     updateLocalMap = false;
@@ -1139,6 +1143,10 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
   // Should we create a new KF?
   if (updateLocalMap) {
     ProfilerEntry tle2(profiler_, "onLidar.4.update_local_map");
+
+    // The whole block below mutates the local map layers, so it must exclude
+    // a concurrent visualization render (see local_map_content_mtx_ docs):
+    auto lckMapContents = mrpt::lockHelper(local_map_content_mtx_);
 
     // If the local map is empty, create it from this first observation:
     if (state_.local_map->empty()) {
@@ -1182,6 +1190,9 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     for (const auto & [lyName, lyMap] : observation->layers) {
       state_.local_map->layers.erase(lyName);
     }
+
+    // No more changes to the map contents below:
+    lckMapContents.unlock();
 
     tle3.stop();
 
@@ -1281,12 +1292,12 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     const ProfilerEntry tle(profiler_, "onLidar.6.updateVisualization");
 
     if (state_.last_icp_was_good) {
-      updateVisualization(observationRawForViz, fullCloudForVizAndPublish);
+      updateVisualization(observationRawForViz, fullCloudForVizAndPublish, lckState);
     } else {
       // On bad ICP: still update the local map display, GUI panel, and text
       // labels. Skipping the full updateVisualization() avoids 3D pose/path
       // updates that would be based on an unreliable ICP result.
-      updateVisualizationAlways();
+      updateVisualizationAlways(lckState);
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local-map visualization responsiveness by releasing the main state lock during rendering and limiting lock contention.
  * Prevented race conditions when loading, clearing, or updating the local map while visualization is active during scanning.
  * Made forced local-map refreshes more reliable after hide/show, using safer counter saturation.
  * Improved consistency of GUI-triggered visualization refresh timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->