### PR TITLE
Add mola-lo-gui-grandtour launch script for the GrandTour dataset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,7 @@ install(
     scripts/mola-lo-gui-oxford-spires
     scripts/mola-lo-gui-botanicgarden
     scripts/mola-lo-gui-citrusfarm
+    scripts/mola-lo-gui-grandtour
   DESTINATION
     bin
 )

--- a/agents.md
+++ b/agents.md
@@ -17,6 +17,28 @@ assumed to be a ROS 1 bag and uses `lidar_odometry_from_rosbag1.yaml`
 (`MOLA_INPUT_ROSBAG1`), matching how `mola-lo-gui-rosbag1`/`mola-lo-gui-rosbag2`
 pick their launch file.
 
+## `lidar_odometry_from_rosbag1.yaml`: up to 3 bags replayed jointly
+
+`rosbag_filename` is a sequence fed from `MOLA_INPUT_ROSBAG1` plus two
+optional slots, `MOLA_INPUT_ROSBAG1_2` / `_3` (empty entries are dropped by
+`Rosbag1Dataset`). Per-topic datasets that ship `/tf`, the IMU or the odometry
+in separate bag files therefore need no launch file of their own.
+
+## `scripts/mola-lo-gui-grandtour`
+
+GrandTour (ANYmal-D + "Boxi" payload) publishes one bag per topic, so the
+wrapper takes a *mission directory* (or its `*_hesai_undist.bag`) and resolves
+its siblings by the `<mission>_<topic>.bag` naming: LiDAR (required), the
+`tf_minimal` and `adis` bags (optional). Notes specific to this dataset:
+
+- The robot body frame is `base`, not `base_link` (`MOLA_TF_BASE_LINK`).
+- Extrinsics come from the dataset's own `/tf_static`
+  (`base -> box_base -> hesai_lidar` / `adis16475_imu`), so no fixed sensor
+  poses are needed when the tf bag is present; without it the LiDAR falls
+  back to a fixed pose at the origin.
+- The LiDAR topic used is the already-undistorted one, so deskewing defaults
+  to `MotionCompensationMethod::None` to avoid over-compensating motion.
+
 ## `ros2-lidar-odometry.launch.py`: `initial_pose` argument
 
 Added because it was missing: `InitLocalization::FixedPose` has always

--- a/mola-cli-launchs/lidar_odometry_from_rosbag1.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_rosbag1.yaml
@@ -66,8 +66,14 @@ modules:
         win_pos: 5 370 600 200
 
     params:
-      # We use an environment variable to force the user to specify a bag file:
-      rosbag_filename: ${MOLA_INPUT_ROSBAG1}
+      # We use an environment variable to force the user to specify a bag file.
+      # Optionally, up to two additional bags can be replayed jointly with the
+      # first one, as a single merged stream: some datasets split /tf, the IMU
+      # or the odometry into their own bag files. Empty slots are ignored.
+      rosbag_filename:
+        - ${MOLA_INPUT_ROSBAG1}
+        - ${MOLA_INPUT_ROSBAG1_2|}
+        - ${MOLA_INPUT_ROSBAG1_3|}
       time_warp_scale: ${MOLA_TIME_WARP|1.0}
       start_paused: ${MOLA_DATASET_START_PAUSED|false}
 

--- a/scripts/mola-lo-gui-grandtour
+++ b/scripts/mola-lo-gui-grandtour
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# For usage instructions, see: https://docs.mola-slam.org/latest/
+#
+# Convenience wrapper around mola-cli for the GrandTour dataset
+# (https://grand-tour.leggedrobotics.com): an ANYbotics ANYmal-D quadruped
+# carrying the open-source "Boxi" sensor payload.
+#
+# Each mission is published as a set of per-topic ROS 1 bags, so the LiDAR,
+# the IMU and /tf live in SEPARATE files. This script locates them by their
+# "<mission>_<topic>.bag" naming and replays them jointly through the generic
+# lidar_odometry_from_rosbag1.yaml launch file (which accepts up to three bags
+# via MOLA_INPUT_ROSBAG1{,_2,_3}), so no dataset-specific launch file is needed.
+#
+# Usage:
+#   mola-lo-gui-grandtour /path/to/<mission-dir>/ [additional flags for mola-cli]
+#   mola-lo-gui-grandtour /path/to/<mission>_hesai_undist.bag [additional flags for mola-cli]
+#
+# Example:
+#   mola-lo-gui-grandtour ~/datasets/grand-tour-legged/2024-10-01-11-29-55/
+#
+# Sensors used (the rest of each mission's bags are ignored):
+#   <mission>_hesai_undist.bag  /boxi/hesai/points_undistorted  PointCloud2, 10 Hz  (required)
+#   <mission>_tf_minimal.bag    /tf, /tf_static                                     (optional)
+#   <mission>_adis.bag          /boxi/adis/imu                  Imu, 200 Hz         (optional)
+#
+# Sensor extrinsics come from the dataset's own /tf_static (base -> box_base ->
+# hesai_lidar / adis16475_imu), so no fixed sensor poses are needed as long as
+# the tf bag is present. Without it, the LiDAR falls back to a fixed pose at
+# the origin (the payload extrinsics are then simply unknown).
+
+if [ "$#" -eq 0 ]; then
+    echo "Error: A GrandTour mission directory (or its '*_hesai_undist.bag') is required."
+    echo "Usage: $0 /path/to/<mission-dir>/ [additional flags for mola-cli]"
+    echo "       $0 /path/to/<mission>_hesai_undist.bag [additional flags for mola-cli]"
+    exit 1
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+MOLA_LAUNCHS_DIR=$SCRIPT_DIR/../mola-cli-launchs/
+if [ -d $SCRIPT_DIR/../share/mola_lidar_odometry/mola-cli-launchs ]; then
+  MOLA_LAUNCHS_DIR=$SCRIPT_DIR/../share/mola_lidar_odometry/mola-cli-launchs
+fi
+
+ARG=$1
+shift 1
+
+# Resolve the "<dir>/<mission>" prefix shared by all of a mission's bags, from
+# either a mission directory or any one of its bag files:
+if [ -d "$ARG" ]; then
+    LIDAR_BAG=$(ls "${ARG%/}"/*_hesai_undist.bag 2>/dev/null | head -n 1)
+    if [ -z "$LIDAR_BAG" ]; then
+        echo "Error: no '*_hesai_undist.bag' found in directory '$ARG'."
+        exit 1
+    fi
+elif [ -f "$ARG" ]; then
+    LIDAR_BAG=$ARG
+else
+    echo "Error: '$ARG' is neither a directory nor a file."
+    exit 1
+fi
+
+PREFIX=${LIDAR_BAG%_hesai_undist.bag}
+if [ "$PREFIX" = "$LIDAR_BAG" ]; then
+    echo "Error: '$LIDAR_BAG' does not follow the expected '<mission>_hesai_undist.bag' naming."
+    exit 1
+fi
+
+TF_BAG=${PREFIX}_tf_minimal.bag
+IMU_BAG=${PREFIX}_adis.bag
+
+echo "GrandTour mission '$(basename "$PREFIX")':"
+echo "  LiDAR bag: $LIDAR_BAG"
+
+# GrandTour topic names and /tf frames:
+: "${MOLA_LIDAR_TOPIC:=/boxi/hesai/points_undistorted}"
+: "${MOLA_TF_BASE_LINK:=base}"   # the ANYmal body frame; NOT named 'base_link'
+export MOLA_LIDAR_TOPIC
+export MOLA_TF_BASE_LINK
+
+if [ -f "$TF_BAG" ]; then
+    echo "  TF bag   : $TF_BAG"
+    MOLA_INPUT_ROSBAG1_2=$TF_BAG
+else
+    echo "  TF bag   : (not found: '$TF_BAG'; using a fixed LiDAR pose at the origin)"
+    MOLA_INPUT_ROSBAG1_2=
+    : "${MOLA_USE_FIXED_LIDAR_POSE:=1}"
+    export MOLA_USE_FIXED_LIDAR_POSE
+fi
+
+if [ -f "$IMU_BAG" ]; then
+    echo "  IMU bag  : $IMU_BAG"
+    MOLA_INPUT_ROSBAG1_3=$IMU_BAG
+    : "${MOLA_IMU_TOPIC:=/boxi/adis/imu}"
+    # A legged robot pitches and rolls constantly from the very first scan, so
+    # level the initial pose from the IMU instead of assuming a flat start:
+    : "${MOLA_LO_INITIAL_LOCALIZATION_METHOD:=InitLocalization::PitchAndRollFromIMU}"
+else
+    echo "  IMU bag  : (not found: '$IMU_BAG'; running LiDAR-only odometry)"
+    MOLA_INPUT_ROSBAG1_3=
+    : "${MOLA_IMU_TOPIC:=}"
+fi
+export MOLA_IMU_TOPIC
+export MOLA_INPUT_ROSBAG1_2
+export MOLA_INPUT_ROSBAG1_3
+[ -n "${MOLA_LO_INITIAL_LOCALIZATION_METHOD:-}" ] && export MOLA_LO_INITIAL_LOCALIZATION_METHOD
+
+# The LiDAR stream used here is the dataset's already-undistorted one, so
+# deskewing it a second time would over-compensate the motion:
+: "${MOLA_DESKEW_METHOD:=MotionCompensationMethod::None}"
+export MOLA_DESKEW_METHOD
+
+MOLA_ODOMETRY_PIPELINE_YAML="${PIPELINE_YAML:-$MOLA_LAUNCHS_DIR/../pipelines/lidar3d-default.yaml}" \
+MOLA_INPUT_ROSBAG1="$LIDAR_BAG" \
+  mola-cli \
+    "$MOLA_LAUNCHS_DIR/lidar_odometry_from_rosbag1.yaml" \
+    "$@"

--- a/scripts/mola-lo-gui-grandtour
+++ b/scripts/mola-lo-gui-grandtour
@@ -37,9 +37,9 @@ fi
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-MOLA_LAUNCHS_DIR=$SCRIPT_DIR/../mola-cli-launchs/
-if [ -d $SCRIPT_DIR/../share/mola_lidar_odometry/mola-cli-launchs ]; then
-  MOLA_LAUNCHS_DIR=$SCRIPT_DIR/../share/mola_lidar_odometry/mola-cli-launchs
+MOLA_LAUNCHS_DIR="$SCRIPT_DIR/../mola-cli-launchs/"
+if [ -d "$SCRIPT_DIR/../share/mola_lidar_odometry/mola-cli-launchs" ]; then
+  MOLA_LAUNCHS_DIR="$SCRIPT_DIR/../share/mola_lidar_odometry/mola-cli-launchs"
 fi
 
 ARG=$1


### PR DESCRIPTION
Adds a launch helper for the [GrandTour](https://grand-tour.leggedrobotics.com) legged-robotics dataset (ANYbotics ANYmal-D + the "Boxi" sensor payload).

### Why a multi-bag change first

GrandTour publishes **one ROS 1 bag per topic**, so a single mission has the LiDAR, the IMU and `/tf` in three separate files. Rather than adding yet another dataset-specific launch YAML, `lidar_odometry_from_rosbag1.yaml` now feeds `rosbag_filename` as a sequence: `MOLA_INPUT_ROSBAG1` plus two optional slots `MOLA_INPUT_ROSBAG1_2` / `_3`. `Rosbag1Dataset` already supported joint replay of several bags and drops empty entries, so this is config-only and backwards compatible.

### `scripts/mola-lo-gui-grandtour`

Takes a mission directory (or its `*_hesai_undist.bag`) and resolves the siblings by the `<mission>_<topic>.bag` naming: LiDAR (required), `tf_minimal` and `adis` (both optional, with a documented fallback each).

Dataset specifics baked in:

- The robot body frame is **`base`**, not `base_link`.
- Extrinsics come from the dataset's own `/tf_static` (`base -> box_base -> hesai_lidar` / `adis16475_imu`), so **no fixed sensor poses are needed**. Verified in a real run:
  ```
  [findOutSensorPose] Found pose base -> hesai_lidar:   [0.378927 0.006448 0.293116 89.636850 -0.671173 0.042510]
  [findOutSensorPose] Found pose base -> adis16475_imu: [0.269661 -0.017621 0.201358 90.390241 -0.953217 -0.110399]
  ```
  Without the tf bag the LiDAR falls back to a fixed pose at the origin.
- The LiDAR topic used is the dataset's already-undistorted stream, so deskewing defaults to `MotionCompensationMethod::None` to avoid over-compensating the motion.
- A legged robot pitches/rolls from the first scan, so the initial pose is leveled from the IMU when the IMU bag is present.

### Testing

Ran headless on mission `2024-10-01-11-29-55` (eth-1): all three bags open and merge, both extrinsics resolve from TF, IMU pitch/roll initialization succeeds, no warnings or errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a GrandTour replay command for launching LiDAR odometry from mission data or a LiDAR bag.
  - Supports combining up to three ROS 1 bags, with optional IMU, odometry, and TF data.
  - Automatically discovers related mission files and configures topics, frames, and extrinsics.
  - Added the GrandTour command to the installed GUI demo tools.

- **Documentation**
  - Added usage guidance for GrandTour replay, supported files, frames, topics, and deskewing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->