### PR TITLE
Visualize the robot /tf tree in the LO viewer (opt-in)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -61,6 +61,13 @@ GrandTour has `base -> odom` and `hesai_lidar -> dlio_odom`, so without
 excluding them a ~130 m translation drags an unrelated subtree into the
 robot's own tree.
 
+Links (`tf_tree_show_links`) render as thin `CCylinder`s, not GL lines: MRPT
+cannot draw lines with a configurable thickness, so they are barely visible.
+Radius is `tf_tree_link_radius` (`MOLA_LO_TF_TREE_LINK_RADIUS`, default 0.02 m),
+also live in the GUI. Orientation is derived from the two endpoints (pitch =
+`acos(nz)`, yaw = `atan2(ny, nx)` of the unit direction), the same approach
+used for `mola_mapper`'s graph-edge cylinders.
+
 ## `ros2-lidar-odometry.launch.py`: `initial_pose` argument
 
 Added because it was missing: `InitLocalization::FixedPose` has always

--- a/agents.md
+++ b/agents.md
@@ -38,6 +38,13 @@ its siblings by the `<mission>_<topic>.bag` naming: LiDAR (required), the
   back to a fixed pose at the origin.
 - The LiDAR topic used is the already-undistorted one, so deskewing defaults
   to `MotionCompensationMethod::None` to avoid over-compensating motion.
+- The /tf tree view is ON by default here (this is a legged robot with a full
+  joint tree, which is the point), skipping the four frames that are not
+  physically on the body: `odom` (world-fixed, published inverted as a child
+  of `base`), `enu_origin` (geodetic, under `cpt7_imu`) and `dlio_odom` /
+  `dlio_map` (the onboard SLAM's frames, under `hesai_lidar`). Everything
+  else in the tree is real hardware, including the total-station `prism`.
+
 ## Robot /tf tree visualization (opt-in)
 
 `visualization.show_tf_tree` draws the subtree of coordinate frames below

--- a/agents.md
+++ b/agents.md
@@ -17,6 +17,29 @@ assumed to be a ROS 1 bag and uses `lidar_odometry_from_rosbag1.yaml`
 (`MOLA_INPUT_ROSBAG1`), matching how `mola-lo-gui-rosbag1`/`mola-lo-gui-rosbag2`
 pick their launch file.
 
+## Robot /tf tree visualization (opt-in)
+
+`visualization.show_tf_tree` draws the subtree of coordinate frames below
+`tf_tree_root_frame` (empty = ask the data source for its `base_link` frame),
+which on a legged robot is its joint tree. Off by default; every knob is also
+live in the GUI's "View" tab.
+
+The frames come from `mola::TransformTreeSource`, detected at init via
+`findService<>()` and guarded by `__has_include`
+(`MOLA_HAS_TRANSFORM_TREE_SOURCE`), so this still builds against an older
+`mola_kernel`. The source resolves the poses against the root and does the
+subtree filtering itself (see `mola`'s agents.md); LO only draws.
+
+Snapshots are pulled once per visualization update, at the current scan's
+timestamp, so the joints match the rendered cloud rather than the wall clock.
+The result is drawn at the vehicle pose, since the poses are body-relative.
+
+`tf_tree_exclude_frames` (comma-separated) drops a frame together with its
+subtree. It is needed in practice because datasets publish *inverted* edges:
+GrandTour has `base -> odom` and `hesai_lidar -> dlio_odom`, so without
+excluding them a ~130 m translation drags an unrelated subtree into the
+robot's own tree.
+
 ## `ros2-lidar-odometry.launch.py`: `initial_pose` argument
 
 Added because it was missing: `InitLocalization::FixedPose` has always

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -36,6 +36,12 @@
 #include <mola_kernel/interfaces/SharedKeyframeMap.h>
 #define MOLA_HAS_SHARED_KEYFRAME_MAP_SINK 1
 #endif
+#if __has_include(<mola_kernel/interfaces/TransformTreeSource.h>)
+#include <mola_kernel/interfaces/TransformTreeSource.h>
+/** Feature macro: mola_kernel provides mola::TransformTreeSource, enabling
+ *  the optional /tf tree visualization. */
+#define MOLA_HAS_TRANSFORM_TREE_SOURCE 1
+#endif
 #include <mola_kernel/version.h>
 
 // Other packages:
@@ -297,6 +303,31 @@ public:
              * setCurrentPoseCornerVisualization().
              */
       bool show_current_pose_corner = true;
+
+      // --- Robot /tf tree ---
+      /** Draws the subtree of coordinate frames below tf_tree_root_frame
+       * (e.g. a legged robot's joints) as it moves. Opt-in: it requires the
+       * data source to implement mola::TransformTreeSource, and costs one
+       * subtree snapshot per visualization update. */
+      bool show_tf_tree = false;
+
+      /** Subtree root. Empty (default) means "ask the data source" (its
+       * base_link_frame_id, via TransformTreeSource). */
+      std::string tf_tree_root_frame;
+
+      float tf_tree_corner_size = 0.1f;  //! [m]
+
+      /** Draws a line from each frame to its parent. */
+      bool tf_tree_show_links = true;
+
+      /** Draws each frame's name next to it. */
+      bool tf_tree_show_names = false;
+
+      /** Comma-separated frame names to leave out, together with their own
+       * subtrees. Datasets do publish inverted edges (e.g. "base -> odom"
+       * instead of "odom -> base"), which would otherwise drag a whole
+       * unrelated, far-away subtree into the robot's own tree. */
+      std::string tf_tree_exclude_frames;
 
       // --- Ground grid ---
       bool show_ground_grid = true;
@@ -1028,6 +1059,13 @@ private:
     std::shared_ptr<mola::SharedKeyframeMap> shared_keyframe_map_sink;
 #endif
 
+#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
+    // Data source exposing a /tf tree (dataset reader or live ROS bridge), if
+    // any is present in the running MOLA system. Optional: nullptr if none is
+    // found, in which case the /tf tree visualization stays empty.
+    std::shared_ptr<mola::TransformTreeSource> transform_tree_source;
+#endif
+
     std::optional<NavState> last_motion_model_output;
 
     /// The source of "dynamic variables" in ICP pipelines:
@@ -1355,6 +1393,12 @@ private:
   void updateVisualizationLocalMap(
     std::vector<std::function<void()>> & updateTasks, std::unique_lock<std::mutex> & lckState);
   void updateVisualizationPath(std::vector<std::function<void()>> & updateTasks);
+
+  /// Renders the /tf subtree below the configured root frame, as a child of
+  /// the vehicle frame (its poses are relative to the robot body). A no-op
+  /// unless enabled AND a mola::TransformTreeSource was found at init.
+  void updateVisualizationTfTree(
+    std::vector<std::function<void()>> & updateTasks, const std::string & vizFrame);
   void updateVisualizationGravityVector(std::vector<std::function<void()>> & updateTasks);
   void updateVisualizationTextLabels();
   void updateVisualizationAlways(std::unique_lock<std::mutex> & lckState);

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -317,8 +317,13 @@ public:
 
       float tf_tree_corner_size = 0.1f;  //! [m]
 
-      /** Draws a line from each frame to its parent. */
+      /** Draws a link from each frame to its parent. Rendered as thin
+       * cylinders rather than GL lines, which MRPT cannot draw with a
+       * configurable thickness and are barely visible. */
       bool tf_tree_show_links = true;
+
+      /** Radius of the tf_tree_show_links cylinders. */
+      float tf_tree_link_radius = 0.02f;  //! [m]
 
       /** Draws each frame's name next to it. */
       bool tf_tree_show_names = false;

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -86,26 +86,40 @@ std::set<std::string> splitCommaSeparated(const std::string & s)
 }
 
 /** Fills `out` with one XYZ corner per frame of `tree` (plus, optionally, the
- *  parent->child links and the frame names). Excluded frames are dropped
- *  together with their own subtrees.
+ *  parent->child links and the frame names), keeping the poses exactly as
+ *  given, i.e. relative to the tree's own root.
+ *
+ *  `subtreeRoot` (empty = the whole tree) selects which subtree to draw;
+ *  `excluded` frames are dropped together with their own subtrees.
+ *
+ *  \return how many frames were actually drawn.
  */
-void renderTfTree(
-  const mola::TransformTree & tree, const std::set<std::string> & excluded, float cornerSize,
-  bool showLinks, bool showNames, mrpt::opengl::CSetOfObjects & out)
+size_t renderTfTree(
+  const mola::TransformTree & tree, const std::string & subtreeRoot,
+  const std::set<std::string> & excluded, float cornerSize, bool showLinks, bool showNames,
+  mrpt::opengl::CSetOfObjects & out)
 {
   auto glLinks = mrpt::opengl::CSetOfLines::Create();
   glLinks->setColor_u8(0x80, 0x80, 0x80, 0xff);
 
-  // Nodes come ordered parents-before-children, so dropping a frame whose
-  // parent was already dropped prunes the whole subtree in one pass:
+  // Nodes come ordered parents-before-children, so both the "keep only this
+  // subtree" and the "drop this frame" tests propagate down in a single pass:
+  const bool wholeTree = subtreeRoot.empty() || subtreeRoot == tree.root;
+  std::set<std::string> kept;
   std::set<std::string> dropped;
   std::map<std::string, mrpt::poses::CPose3D> posesByFrame;
+  size_t nDrawn = 0;
 
   for (const auto & node : tree.nodes) {
+    if (!wholeTree && node.frame != subtreeRoot && kept.count(node.parent) == 0) {
+      continue;
+    }
     if (excluded.count(node.frame) != 0 || dropped.count(node.parent) != 0) {
       dropped.insert(node.frame);
       continue;
     }
+    kept.insert(node.frame);
+    nDrawn++;
     posesByFrame[node.frame] = node.pose_in_root;
 
     if (cornerSize > 0) {
@@ -130,6 +144,8 @@ void renderTfTree(
   if (showLinks) {
     out.insert(glLinks);
   }
+
+  return nDrawn;
 }
 #endif
 
@@ -948,26 +964,31 @@ void LidarOdometry::updateVisualizationTfTree(
   auto glTree = mrpt::opengl::CSetOfObjects::Create();
 
   if (vp.show_tf_tree && state_.transform_tree_source) {
-    // Empty root means "whatever the source calls the robot body".
-    std::string root = vp.tf_tree_root_frame;
-    if (root.empty()) {
-      root = state_.transform_tree_source->transform_tree_default_root();
+    // ALWAYS query from the robot body frame, whatever subtree is to be shown:
+    // the returned poses are relative to the queried root, and the result is
+    // drawn at the vehicle pose below, so querying from any other frame would
+    // offset the whole tree by the (unknown here) body -> root transform.
+    // tf_tree_root_frame then only selects which subtree of it to draw.
+    std::string queryRoot = state_.transform_tree_source->transform_tree_default_root();
+    if (queryRoot.empty()) {
+      queryRoot = vp.tf_tree_root_frame;
     }
 
     // Query at the scan time, so the joints match the rendered cloud rather
     // than the wall clock (the source falls back to its latest data itself).
     if (const auto tree =
-          state_.transform_tree_source->transform_tree(root, state_.last_obs_timestamp);
+          state_.transform_tree_source->transform_tree(queryRoot, state_.last_obs_timestamp);
         tree) {
-      renderTfTree(
-        *tree, splitCommaSeparated(vp.tf_tree_exclude_frames), vp.tf_tree_corner_size,
-        vp.tf_tree_show_links, vp.tf_tree_show_names, *glTree);
+      const size_t n = renderTfTree(
+        *tree, vp.tf_tree_root_frame, splitCommaSeparated(vp.tf_tree_exclude_frames),
+        vp.tf_tree_corner_size, vp.tf_tree_show_links, vp.tf_tree_show_names, *glTree);
 
       MRPT_LOG_THROTTLE_DEBUG_FMT(
-        5.0, "[tf tree] Rendering %zu frame(s) below '%s'.", tree->nodes.size(), root.c_str());
+        5.0, "[tf tree] Rendering %zu of %zu frame(s) under '%s'.", n, tree->nodes.size(),
+        queryRoot.c_str());
     } else {
       MRPT_LOG_THROTTLE_WARN_FMT(
-        5.0, "[tf tree] Root frame '%s' is not known to the data source.", root.c_str());
+        5.0, "[tf tree] Root frame '%s' is not known to the data source.", queryRoot.c_str());
     }
   }
 

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -31,6 +31,7 @@
 #include <mrpt/obs/customizable_obs_viz.h>
 #include <mrpt/opengl/CArrow.h>
 #include <mrpt/opengl/CAssimpModel.h>
+#include <mrpt/opengl/CCylinder.h>
 #include <mrpt/opengl/CGridPlaneXY.h>
 #include <mrpt/opengl/COpenGLScene.h>
 #include <mrpt/opengl/CPointCloudColoured.h>
@@ -43,6 +44,7 @@
 
 // STD:
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <map>
 #include <mutex>
@@ -85,6 +87,36 @@ std::set<std::string> splitCommaSeparated(const std::string & s)
   return out;
 }
 
+// tf links render as CCylinder (thin tubes), visible even at a distance,
+// unlike GL lines, which MRPT cannot draw with a configurable thickness.
+// Few radial slices and no end caps keep the per-link triangle count low.
+constexpr uint32_t kTfLinkCylinderSlices = 6;
+
+// A CCylinder's local Z axis runs from its base (at the object's origin) to
+// its top (at height `len`). Orient it so that axis points from `a` to `b`:
+// pitch = acos(nz), yaw = atan2(ny, nx) for the unit direction (nx,ny,nz),
+// derived from MRPT's R = Rz(yaw)*Ry(pitch)*Rx(roll) convention applied to
+// local Z (roll is a free rotation about the cylinder's own axis, so 0 is
+// fine). Returns nullptr for a degenerate (near-zero-length) link.
+mrpt::opengl::CCylinder::Ptr makeTfLinkCylinder(
+  const mrpt::math::TPoint3D & a, const mrpt::math::TPoint3D & b, float radius)
+{
+  const mrpt::math::TPoint3D d = b - a;
+  const double len = d.norm();
+  if (len < 1e-6) {
+    return {};
+  }
+  const double pitch = std::acos(std::clamp(d.z / len, -1.0, 1.0));
+  const double yaw = std::atan2(d.y, d.x);
+
+  auto glCyl =
+    mrpt::opengl::CCylinder::Create(radius, radius, static_cast<float>(len), kTfLinkCylinderSlices);
+  glCyl->setHasBases(false, false);
+  glCyl->setColor_u8(0x80, 0x80, 0x80, 0xff);
+  glCyl->setPose(mrpt::poses::CPose3D(a.x, a.y, a.z, yaw, pitch, 0.0));
+  return glCyl;
+}
+
 /** Fills `out` with one XYZ corner per frame of `tree` (plus, optionally, the
  *  parent->child links and the frame names), keeping the poses exactly as
  *  given, i.e. relative to the tree's own root.
@@ -96,12 +128,9 @@ std::set<std::string> splitCommaSeparated(const std::string & s)
  */
 size_t renderTfTree(
   const mola::TransformTree & tree, const std::string & subtreeRoot,
-  const std::set<std::string> & excluded, float cornerSize, bool showLinks, bool showNames,
-  mrpt::opengl::CSetOfObjects & out)
+  const std::set<std::string> & excluded, float cornerSize, bool showLinks, float linkRadius,
+  bool showNames, mrpt::opengl::CSetOfObjects & out)
 {
-  auto glLinks = mrpt::opengl::CSetOfLines::Create();
-  glLinks->setColor_u8(0x80, 0x80, 0x80, 0xff);
-
   // Nodes come ordered parents-before-children, so both the "keep only this
   // subtree" and the "drop this frame" tests propagate down in a single pass:
   const bool wholeTree = subtreeRoot.empty() || subtreeRoot == tree.root;
@@ -136,13 +165,13 @@ size_t renderTfTree(
 
     if (showLinks && !node.parent.empty()) {
       if (const auto it = posesByFrame.find(node.parent); it != posesByFrame.end()) {
-        glLinks->appendLine(it->second.translation(), node.pose_in_root.translation());
+        if (auto glCyl = makeTfLinkCylinder(
+              it->second.translation(), node.pose_in_root.translation(), linkRadius);
+            glCyl) {
+          out.insert(glCyl);
+        }
       }
     }
-  }
-
-  if (showLinks) {
-    out.insert(glLinks);
   }
 
   return nDrawn;
@@ -338,6 +367,21 @@ mola::gui::Tab LidarOdometry::buildTabView()
                  this->enqueue_request(
                    [this, checked]() { params_.visualization.tf_tree_show_names = checked; });
                }});
+    row.widgets.emplace_back(TextBox{
+      "link radius", std::to_string(params_.visualization.tf_tree_link_radius), 5,
+      [this](std::string s) {  // NOLINT
+        float v = 0;
+        try {
+          v = std::stof(s);
+        } catch (const std::exception &) {
+          return false;
+        }
+        if (v < 0) {
+          return false;
+        }
+        this->enqueue_request([this, v]() { params_.visualization.tf_tree_link_radius = v; });
+        return true;
+      }});
     tab.widgets.emplace_back(std::move(row));
   }
 
@@ -981,7 +1025,8 @@ void LidarOdometry::updateVisualizationTfTree(
         tree) {
       const size_t n = renderTfTree(
         *tree, vp.tf_tree_root_frame, splitCommaSeparated(vp.tf_tree_exclude_frames),
-        vp.tf_tree_corner_size, vp.tf_tree_show_links, vp.tf_tree_show_names, *glTree);
+        vp.tf_tree_corner_size, vp.tf_tree_show_links, vp.tf_tree_link_radius,
+        vp.tf_tree_show_names, *glTree);
 
       MRPT_LOG_THROTTLE_DEBUG_FMT(
         5.0, "[tf tree] Rendering %zu of %zu frame(s) under '%s'.", n, tree->nodes.size(),

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -34,15 +34,20 @@
 #include <mrpt/opengl/CGridPlaneXY.h>
 #include <mrpt/opengl/COpenGLScene.h>
 #include <mrpt/opengl/CPointCloudColoured.h>
+#include <mrpt/opengl/CSetOfLines.h>
 #include <mrpt/opengl/CText.h>
 #include <mrpt/opengl/stock_objects.h>
 #include <mrpt/system/filesystem.h>
+#include <mrpt/system/string_utils.h>
 #include <mrpt/version.h>
 
 // STD:
 #include <algorithm>
 #include <limits>
+#include <map>
 #include <mutex>
+#include <set>
+#include <sstream>
 
 namespace mola
 {
@@ -64,6 +69,70 @@ public:
 private:
   std::unique_lock<std::mutex> & lck_;
 };
+#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
+/** Splits "a, b ,c" into {"a","b","c"}, ignoring empty items. */
+std::set<std::string> splitCommaSeparated(const std::string & s)
+{
+  std::set<std::string> out;
+  std::stringstream ss(s);
+  std::string item;
+  while (std::getline(ss, item, ',')) {
+    item = mrpt::system::trim(item);
+    if (!item.empty()) {
+      out.insert(item);
+    }
+  }
+  return out;
+}
+
+/** Fills `out` with one XYZ corner per frame of `tree` (plus, optionally, the
+ *  parent->child links and the frame names). Excluded frames are dropped
+ *  together with their own subtrees.
+ */
+void renderTfTree(
+  const mola::TransformTree & tree, const std::set<std::string> & excluded, float cornerSize,
+  bool showLinks, bool showNames, mrpt::opengl::CSetOfObjects & out)
+{
+  auto glLinks = mrpt::opengl::CSetOfLines::Create();
+  glLinks->setColor_u8(0x80, 0x80, 0x80, 0xff);
+
+  // Nodes come ordered parents-before-children, so dropping a frame whose
+  // parent was already dropped prunes the whole subtree in one pass:
+  std::set<std::string> dropped;
+  std::map<std::string, mrpt::poses::CPose3D> posesByFrame;
+
+  for (const auto & node : tree.nodes) {
+    if (excluded.count(node.frame) != 0 || dropped.count(node.parent) != 0) {
+      dropped.insert(node.frame);
+      continue;
+    }
+    posesByFrame[node.frame] = node.pose_in_root;
+
+    if (cornerSize > 0) {
+      auto corner = mrpt::opengl::stock_objects::CornerXYZSimple(cornerSize);
+      corner->setPose(node.pose_in_root);
+      out.insert(corner);
+    }
+
+    if (showNames) {
+      auto label = mrpt::opengl::CText::Create(node.frame);
+      label->setLocation(node.pose_in_root.translation());
+      out.insert(label);
+    }
+
+    if (showLinks && !node.parent.empty()) {
+      if (const auto it = posesByFrame.find(node.parent); it != posesByFrame.end()) {
+        glLinks->appendLine(it->second.translation(), node.pose_in_root.translation());
+      }
+    }
+  }
+
+  if (showLinks) {
+    out.insert(glLinks);
+  }
+}
+#endif
+
 }  // namespace
 
 mola::gui::Tab LidarOdometry::buildTabStatus()
@@ -216,6 +285,61 @@ mola::gui::Tab LidarOdometry::buildTabView()
       this->enqueue_request(
         [this, checked]() { params_.visualization.show_gravity_align_vector = checked; });
     }});
+
+  {
+    Row row;
+    row.widgets.emplace_back(CheckBox{
+      "Show /tf tree", params_.visualization.show_tf_tree, [this](bool checked) {
+        this->enqueue_request([this, checked]() { params_.visualization.show_tf_tree = checked; });
+      }});
+    row.widgets.emplace_back(TextBox{
+      "size", std::to_string(params_.visualization.tf_tree_corner_size), 5,
+      [this](std::string s) {  // NOLINT
+        float v = 0;
+        try {
+          v = std::stof(s);
+        } catch (const std::exception &) {
+          return false;
+        }
+        if (v < 0) {
+          return false;
+        }
+        this->enqueue_request([this, v]() { params_.visualization.tf_tree_corner_size = v; });
+        return true;
+      }});
+    tab.widgets.emplace_back(std::move(row));
+  }
+
+  {
+    Row row;
+    row.widgets.emplace_back(
+      CheckBox{"tf links", params_.visualization.tf_tree_show_links, [this](bool checked) {
+                 this->enqueue_request(
+                   [this, checked]() { params_.visualization.tf_tree_show_links = checked; });
+               }});
+    row.widgets.emplace_back(
+      CheckBox{"tf names", params_.visualization.tf_tree_show_names, [this](bool checked) {
+                 this->enqueue_request(
+                   [this, checked]() { params_.visualization.tf_tree_show_names = checked; });
+               }});
+    tab.widgets.emplace_back(std::move(row));
+  }
+
+  {
+    Row row;
+    row.widgets.emplace_back(TextBox{
+      "tf root", params_.visualization.tf_tree_root_frame, 13, [this](std::string f) {  // NOLINT
+        this->enqueue_request([this, f]() { params_.visualization.tf_tree_root_frame = f; });
+        return true;
+      }});
+    row.widgets.emplace_back(TextBox{
+      "exclude", params_.visualization.tf_tree_exclude_frames, 13,
+      [this](std::string f) {  // NOLINT
+        this->enqueue_request([this, f]() { params_.visualization.tf_tree_exclude_frames = f; });
+        return true;
+      }});
+    tab.widgets.emplace_back(std::move(row));
+  }
 
   const float sensorPosesSize = params_.visualization.sensor_poses_corner_size > 0.0f
                                   ? params_.visualization.sensor_poses_corner_size
@@ -460,6 +584,10 @@ void LidarOdometry::updateVisualization(
   updateTasks.emplace_back([visualizer = visualizer_, glVehicle, vizFrame]() {
     vizUpsert3D(visualizer, "liodom/vehicle", glVehicle, vizFrame);
   });
+
+  // Robot /tf tree (opt-in):
+  // ---------------------------
+  updateVisualizationTfTree(updateTasks, vizFrame);
 
   // Update current observation
   // ----------------------------
@@ -809,6 +937,50 @@ void LidarOdometry::updateVisualizationLocalMap(
     state_.local_map_needs_viz_update = true;
     state_.mapUpdateCnt = std::numeric_limits<unsigned int>::max();
   }
+}
+
+void LidarOdometry::updateVisualizationTfTree(
+  std::vector<std::function<void()>> & updateTasks, const std::string & vizFrame)
+{
+#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
+  const auto & vp = params_.visualization;
+
+  auto glTree = mrpt::opengl::CSetOfObjects::Create();
+
+  if (vp.show_tf_tree && state_.transform_tree_source) {
+    // Empty root means "whatever the source calls the robot body".
+    std::string root = vp.tf_tree_root_frame;
+    if (root.empty()) {
+      root = state_.transform_tree_source->transform_tree_default_root();
+    }
+
+    // Query at the scan time, so the joints match the rendered cloud rather
+    // than the wall clock (the source falls back to its latest data itself).
+    if (const auto tree =
+          state_.transform_tree_source->transform_tree(root, state_.last_obs_timestamp);
+        tree) {
+      renderTfTree(
+        *tree, splitCommaSeparated(vp.tf_tree_exclude_frames), vp.tf_tree_corner_size,
+        vp.tf_tree_show_links, vp.tf_tree_show_names, *glTree);
+
+      MRPT_LOG_THROTTLE_DEBUG_FMT(
+        5.0, "[tf tree] Rendering %zu frame(s) below '%s'.", tree->nodes.size(), root.c_str());
+    } else {
+      MRPT_LOG_THROTTLE_WARN_FMT(
+        5.0, "[tf tree] Root frame '%s' is not known to the data source.", root.c_str());
+    }
+  }
+
+  // The tree poses are relative to the robot body, so draw it at the same
+  // pose as the vehicle model:
+  glTree->setPose(state_.last_lidar_pose.mean);
+  updateTasks.emplace_back([visualizer = visualizer_, glTree, vizFrame]() {
+    vizUpsert3D(visualizer, "liodom/tf_tree", glTree, vizFrame);
+  });
+#else
+  (void)updateTasks;
+  (void)vizFrame;
+#endif
 }
 
 void LidarOdometry::updateVisualizationPath(std::vector<std::function<void()>> & updateTasks)

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -483,6 +483,22 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
   }
 #endif
 
+#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
+  // Optional: a data source exposing a /tf tree, used only by the (opt-in)
+  // tf-tree visualization. Absent in datasets without /tf, which is fine.
+  {
+    auto srcs = findService<mola::TransformTreeSource>();
+    if (!srcs.empty()) {
+      state_.transform_tree_source = std::dynamic_pointer_cast<TransformTreeSource>(srcs[0]);
+      MRPT_LOG_DEBUG("Detected a TransformTreeSource: /tf tree visualization is available.");
+    } else if (params_.visualization.show_tf_tree) {
+      MRPT_LOG_WARN(
+        "visualization.show_tf_tree is enabled, but no module in this system provides a "
+        "mola::TransformTreeSource: nothing will be drawn.");
+    }
+  }
+#endif
+
   // If using FromStateEstimator initialization, also subscribe to map updates
   // from the state estimator to receive geo-referencing information:
   if (params_.initial_localization.method == InitLocalization::FromStateEstimator) {

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -125,6 +125,12 @@ void LidarOdometry::Parameters::Visualization::initialize(const Yaml & cfg)
   YAML_LOAD_OPT(current_pose_corner_size, float);
   YAML_LOAD_OPT(sensor_poses_corner_size, float);
   YAML_LOAD_OPT(show_current_pose_corner, bool);
+  YAML_LOAD_OPT(show_tf_tree, bool);
+  YAML_LOAD_OPT(tf_tree_root_frame, std::string);
+  YAML_LOAD_OPT(tf_tree_corner_size, float);
+  YAML_LOAD_OPT(tf_tree_show_links, bool);
+  YAML_LOAD_OPT(tf_tree_show_names, bool);
+  YAML_LOAD_OPT(tf_tree_exclude_frames, std::string);
   YAML_LOAD_OPT(local_map_point_size, float);
   YAML_LOAD_OPT(current_observation_point_size, float);
   YAML_LOAD_OPT(last_deskewed_observations_point_size, float);

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -129,6 +129,7 @@ void LidarOdometry::Parameters::Visualization::initialize(const Yaml & cfg)
   YAML_LOAD_OPT(tf_tree_root_frame, std::string);
   YAML_LOAD_OPT(tf_tree_corner_size, float);
   YAML_LOAD_OPT(tf_tree_show_links, bool);
+  YAML_LOAD_OPT(tf_tree_link_radius, float);
   YAML_LOAD_OPT(tf_tree_show_names, bool);
   YAML_LOAD_OPT(tf_tree_exclude_frames, std::string);
   YAML_LOAD_OPT(local_map_point_size, float);

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -248,6 +248,18 @@ params:
     #current_pose_corner_size: 1.5
     #sensor_poses_corner_size: 0.5  # XYZ corner for each LiDAR sensor pose; 0 to disable
     show_current_pose_corner: ${MOLA_LO_SHOW_CURRENT_POSE_CORNER|true} # Set to false to hide the current-pose XYZ corner (e.g. for a first-person camera)
+
+    # Robot /tf tree (e.g. a legged robot's joints). Requires the data source
+    # to implement mola::TransformTreeSource (rosbag1/rosbag2 inputs and the
+    # ROS 2 bridge do). All of these can also be toggled at runtime, in the
+    # GUI's "View" tab.
+    show_tf_tree: ${MOLA_LO_SHOW_TF_TREE|false}
+    tf_tree_root_frame: ${MOLA_LO_TF_TREE_ROOT|''} # empty: use the data source's base_link frame
+    tf_tree_corner_size: ${MOLA_LO_TF_TREE_CORNER_SIZE|0.1} # [m]
+    tf_tree_show_links: ${MOLA_LO_TF_TREE_SHOW_LINKS|true}
+    tf_tree_show_names: ${MOLA_LO_TF_TREE_SHOW_NAMES|false}
+    tf_tree_exclude_frames: ${MOLA_LO_TF_TREE_EXCLUDE|''} # comma-separated; drops each frame and its subtree
+
     model:
       - file: ${MOLA_VEHICLE_MODEL_FILE|""} # Default: none
         tf.x: ${MOLA_VEHICLE_MODEL_X|0.0} # deg

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -257,6 +257,7 @@ params:
     tf_tree_root_frame: ${MOLA_LO_TF_TREE_ROOT|''} # empty: use the data source's base_link frame
     tf_tree_corner_size: ${MOLA_LO_TF_TREE_CORNER_SIZE|0.1} # [m]
     tf_tree_show_links: ${MOLA_LO_TF_TREE_SHOW_LINKS|true}
+    tf_tree_link_radius: ${MOLA_LO_TF_TREE_LINK_RADIUS|0.02} # [m], cylinder radius for tf links
     tf_tree_show_names: ${MOLA_LO_TF_TREE_SHOW_NAMES|false}
     tf_tree_exclude_frames: ${MOLA_LO_TF_TREE_EXCLUDE|''} # comma-separated; drops each frame and its subtree
 

--- a/scripts/mola-lo-gui-grandtour
+++ b/scripts/mola-lo-gui-grandtour
@@ -110,6 +110,10 @@ export MOLA_INPUT_ROSBAG1_3
 : "${MOLA_DESKEW_METHOD:=MotionCompensationMethod::None}"
 export MOLA_DESKEW_METHOD
 
+# Use a shorter minimum range since the robot body is small in this dataset:
+: "${MOLA_MINIMUM_RANGE_FILTER:=1.5}"
+export MOLA_MINIMUM_RANGE_FILTER
+
 # This is a legged robot with a full joint tree in /tf, which is the whole
 # point of showing it here, so turn the tf tree view on by default.
 # The four frames skipped below are the ones that are NOT physically part of

--- a/scripts/mola-lo-gui-grandtour
+++ b/scripts/mola-lo-gui-grandtour
@@ -110,6 +110,22 @@ export MOLA_INPUT_ROSBAG1_3
 : "${MOLA_DESKEW_METHOD:=MotionCompensationMethod::None}"
 export MOLA_DESKEW_METHOD
 
+# This is a legged robot with a full joint tree in /tf, which is the whole
+# point of showing it here, so turn the tf tree view on by default.
+# The four frames skipped below are the ones that are NOT physically part of
+# the robot, and would otherwise be drawn as if they were:
+#   odom                  the world-fixed odometry frame (published inverted,
+#                         as a child of 'base', hence inside its subtree)
+#   enu_origin            the geodetic reference frame (child of 'cpt7_imu')
+#   dlio_odom, dlio_map   the onboard SLAM's own frames (children of
+#                         'hesai_lidar')
+# Everything else in the tree is real hardware on the body: the four legs,
+# the IMUs, the LiDARs, the cameras, and the total-station 'prism'.
+: "${MOLA_LO_SHOW_TF_TREE:=true}"
+: "${MOLA_LO_TF_TREE_EXCLUDE:=odom,enu_origin,dlio_odom,dlio_map}"
+export MOLA_LO_SHOW_TF_TREE
+export MOLA_LO_TF_TREE_EXCLUDE
+
 MOLA_ODOMETRY_PIPELINE_YAML="${PIPELINE_YAML:-$MOLA_LAUNCHS_DIR/../pipelines/lidar3d-default.yaml}" \
 MOLA_INPUT_ROSBAG1="$LIDAR_BAG" \
   mola-cli \


### PR DESCRIPTION
Draws the subtree of coordinate frames below a root frame — a legged robot's joint tree, say — in the MOLA-LO viz window, updating as the robot moves.

Depends on the new `mola::TransformTreeSource` ([MOLAorg/mola#188](https://github.com/MOLAorg/mola/pull/188), plus [mola_input_rosbag1#2](https://github.com/MOLAorg/mola_input_rosbag1/pull/2)), but does **not** require it: everything is behind `__has_include` / `MOLA_HAS_TRANSFORM_TREE_SOURCE`, so this still builds against the current released `mola_kernel` (with the feature simply absent).

### What is drawn

One XYZ corner per frame, plus optionally the parent→child links and the frame names. Off by default; every knob is live in the GUI's **View** tab as well as settable from the pipeline YAML / env vars:

| Param | Env var | Default |
|---|---|---|
| `show_tf_tree` | `MOLA_LO_SHOW_TF_TREE` | `false` |
| `tf_tree_root_frame` | `MOLA_LO_TF_TREE_ROOT` | empty = ask the data source for its `base_link` frame |
| `tf_tree_corner_size` | `MOLA_LO_TF_TREE_CORNER_SIZE` | `0.1` m |
| `tf_tree_show_links` | `MOLA_LO_TF_TREE_SHOW_LINKS` | `true` |
| `tf_tree_show_names` | `MOLA_LO_TF_TREE_SHOW_NAMES` | `false` (they clutter the view fast) |
| `tf_tree_exclude_frames` | `MOLA_LO_TF_TREE_EXCLUDE` | empty |

### Notes on the design

- **Pull, not push.** The snapshot is taken once per visualization update (a few Hz), only while the feature is on, so there is zero cost when it is off and no new threading. It is queried at the *current scan's* timestamp, so the joints match the rendered cloud rather than the wall clock.
- **The source does the filtering.** LO asks for the subtree below one root and only draws it; it never walks the full frame set.
- **`tf_tree_exclude_frames` is not cosmetic.** Real datasets publish *inverted* edges: GrandTour has `base -> odom` and `hesai_lidar -> dlio_odom`, so the subtree below `base` legitimately contains `odom` and the whole `dlio_*` chain — and `base -> odom` carries a ~130 m translation. Excluding a frame drops its subtree with it.

### Testing

GrandTour `2024-10-01-11-29-55` (ANYmal-D quadruped): 81 frames render below `base`, with links and names, verified in a live GUI run. Rendering was checked with corners only, with links, and with names on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `/tf` tree visualization for inspecting robot frames in the GUI.
  * Added controls for root frame selection, display size, links, frame names, link radius, and excluded subtrees.
  * Added timestamp-aware, vehicle-relative rendering with configurable frame and link display.
  * Enabled visualization by default in the GrandTour workflow with common non-hardware frames excluded.
  * Added compatibility handling when no transform-tree provider is available.

* **Documentation**
  * Documented setup, controls, compatibility requirements, timestamp behavior, and filtering options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->