### PR TITLE
fix: keep the local-map render and the IMU worker off the LiDAR critical path

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -246,10 +246,27 @@ be overtaken by a render already in flight.
 
 `visualization.map_update_decimation` (`MOLA_GUI_MAP_UPDATE_DECIMATION`,
 default 10 in most pipelines) bounds how often that render is even requested.
-It is the knob that matters on large maps: the render holds
-`local_map_content_mtx_` for its whole duration (161 ms mean / 290 ms max on
-Oxford Spires), so a scan that needs to insert into the map meanwhile waits for
-it. That wait, not the insertion itself, is what now sets `onLidar`'s max there.
+The render itself no longer holds `local_map_content_mtx_` for its whole
+duration: `cheapLayerSnapshot()` deep-copies the layers under the mutex and the
+O(map size) recolorize/OpenGL build then runs on that private copy, unlocked.
+The copy is ~6x cheaper than the render it replaces in the critical section
+(27 ms vs 182 ms mean on Oxford Spires), which takes `onLidar`'s max from
+216 ms to 107 ms and makes `onLidar.4.update_local_map` equal to the insertion
+it wraps, i.e. zero lock wait.
+
+Point layers are copied into a plain `CGenericPointsMap` rather than cloned
+through their own type: `insertAnotherMap()` calls `registerPointFieldsFrom()`
+(so every per-point field survives) and skips non-finite points (so the slots
+`IncrementalPointCloud` blanks on eviction are dropped), while the target has no
+spatial index to build. Cloning an `IncrementalPointCloud` through its own copy
+constructor would instead `resetIndex()`, an O(N log N) k-d tree bulk build the
+renderer never queries. The copy does pick up the storage slots that are
+tombstoned but not reclaimed yet; that measured under 2% of storage
+(`MOLA_INCREMENTAL_MAP_DEBUG_STATS`: live/storage 0.999 mean, 0.982 worst), and
+it is the same trade-off `doPublishUpdatedLocalMap()` already makes.
+
+The render worker pays ~20 ms more per render for the extra copy step, which is
+fine: it is off the critical path by construction.
 
 ## `imu_state_mtx_`: the IMU worker no longer waits on the LiDAR worker
 

--- a/agents.md
+++ b/agents.md
@@ -225,18 +225,31 @@ instead of a brief quality dip that recovers to the true pose).
 
 ## Local-map locking: `state_mtx_` vs `local_map_content_mtx_`
 
-Rendering the local map (`updateVisualizationLocalMap()`) is O(map size) and
-must not run under `state_mtx_`, or it stalls the dataset reader, IMU worker
-and executor threads once the map is large. So it releases `state_mtx_` (via
-the caller's `std::unique_lock`, passed down through
-`updateVisualization*()`) and takes the finer-grained `local_map_content_mtx_`
-instead, which every mutation of `state_.local_map` contents (insert, `clear()`,
-`load_from_file()`) must also hold.
+Rendering the local map is O(map size) and must not run on the LiDAR worker
+thread, nor under `state_mtx_`: under `mola::IncrementalPointCloud` it measured
+~55 ms mean / ~120 ms max on a GrandTour mission, which turned roughly one
+`onLidar` in 18 into a >100 ms spike and backed the scan queue up to 18 entries.
+So `updateVisualizationLocalMap()` only makes the decimation decision and
+snapshots what the render needs (map `shared_ptr`, `render_params_t`, viz frame),
+then enqueues the render on `worker_viz_local_map_`. There it takes only the
+finer-grained `local_map_content_mtx_`, which every mutation of
+`state_.local_map` contents (insert, `clear()`, `load_from_file()`) must also
+hold. Effect on the same run: the inline cost drops to ~5 us and `onLidar`'s max
+from 155 ms to 66 ms, with the same number of renders.
+
+`worker_viz_local_map_` is deliberately a **separate** 1-thread
+`POLICY_DROP_OLD` pool from `worker_viz_`: with one thread that policy caps the
+queue at a single pending task, so sharing the pool would let the per-scan
+current-observation frames drop the much rarer local-map render before it ever
+ran. The "hide the local map" clear is routed through the same pool so it cannot
+be overtaken by a render already in flight.
 
 Lock order: take `state_mtx_` first, then `local_map_content_mtx_`; never hold
-the latter while acquiring the former. Note the renderer therefore *releases*
-`state_mtx_` before taking the contents mutex, and releases the contents mutex
-before re-acquiring `state_mtx_`.
+the latter while acquiring the former. The render thread takes only the contents
+mutex and never `state_mtx_`, so it cannot invert the order.
+
+`visualization.map_update_decimation` (`MOLA_GUI_MAP_UPDATE_DECIMATION`,
+default 10 in most pipelines) bounds how often that render is even requested.
 
 
 ## Keyframe-creation policy (shared by local map and simplemap)

--- a/agents.md
+++ b/agents.md
@@ -244,12 +244,44 @@ current-observation frames drop the much rarer local-map render before it ever
 ran. The "hide the local map" clear is routed through the same pool so it cannot
 be overtaken by a render already in flight.
 
-Lock order: take `state_mtx_` first, then `local_map_content_mtx_`; never hold
-the latter while acquiring the former. The render thread takes only the contents
-mutex and never `state_mtx_`, so it cannot invert the order.
-
 `visualization.map_update_decimation` (`MOLA_GUI_MAP_UPDATE_DECIMATION`,
 default 10 in most pipelines) bounds how often that render is even requested.
+It is the knob that matters on large maps: the render holds
+`local_map_content_mtx_` for its whole duration (161 ms mean / 290 ms max on
+Oxford Spires), so a scan that needs to insert into the map meanwhile waits for
+it. That wait, not the insertion itself, is what now sets `onLidar`'s max there.
+
+## `imu_state_mtx_`: the IMU worker no longer waits on the LiDAR worker
+
+`processLidarScan()` holds `state_mtx_` for its whole body, so an `onIMU()` that
+also took `state_mtx_` blocked for the duration of every scan. At 200-400 Hz IMU
+vs 10 Hz LiDAR that meant the IMU worker's total time tracked `onLidar`'s almost
+exactly (33.1 s vs 32.7 s on Oxford Spires), and since
+`releaseReadyLidarScansToWorker()` is the last thing `onIMU()` does, the wait fed
+straight back into scan-submission latency.
+
+`imu_state_mtx_` (recursive) now guards exactly the state the two threads share:
+`imu_initializer`, `gravity_estimator`, `map_gravity`, `recent_imu_stamps`,
+`parameter_source` (variable map, `realize()` flags, and the
+`localVelocityBuffer` that IMU samples write and the deskew stage reads), and
+any *invocation* of `obs_generators`. `onIMU()` takes only this mutex; the LiDAR
+thread takes it in short windows on top of `state_mtx_`. Result on the same
+sequence: `onIMU` mean 957 -> 349 us, max 138.6 -> 9.7 ms, total 33.1 -> 12.4 s,
+with `onLidar` unchanged.
+
+The residual 12.4 s is accounted for exactly by the two stages that genuinely
+share those objects, `onLidar.0.apply_generators` (3.0 ms/scan) and
+`onLidar.1.deskew_early` (3.8 ms/scan), plus the ~176 us of real per-sample work.
+Removing it means making `mola::imu::LocalVelocityBuffer` internally thread-safe
+(it has no mutex today) so `FilterDeskew`'s single
+`collect_samples_around_reference_time()` snapshot can run concurrently with IMU
+appends; that is a `mola_imu_preintegration` change, not one for this repo.
+
+Full lock order: `state_mtx_` -> `local_map_content_mtx_` -> `imu_state_mtx_`.
+Never the reverse. The IMU worker takes only `imu_state_mtx_` and the local-map
+render worker only `local_map_content_mtx_`, so neither can invert it. Anything
+that replaces `state_` wholesale (`reset()`) or rebuilds the pipelines
+(`initialize()`) must hold `state_mtx_` **and** `imu_state_mtx_`.
 
 
 ## Keyframe-creation policy (shared by local map and simplemap)

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -1275,6 +1275,14 @@ private:
   // serial ordering so a newer clear cannot be overwritten by an older frame's lambda.
   mrpt::WorkerThreadsPool worker_viz_{1, mrpt::WorkerThreadsPool::POLICY_DROP_OLD, "worker_viz"};
 
+  /** Renders the local map for the gui. Same 1-thread POLICY_DROP_OLD rationale
+   *  as worker_viz_, but a pool of its own: with one thread, POLICY_DROP_OLD
+   *  caps the queue at a single pending task, so sharing worker_viz_ would let
+   *  the per-scan current-observation frames drop the (much rarer) local map
+   *  render before it ever runs, and would serialize the two renders. */
+  mrpt::WorkerThreadsPool worker_viz_local_map_{
+    1, mrpt::WorkerThreadsPool::POLICY_DROP_OLD, "worker_viz_map"};
+
   MethodState state_;
   const MethodState & state() const { return state_; }
   MethodState stateCopy() const { return state_; }
@@ -1324,9 +1332,9 @@ private:
   /// Guards the *contents* (layers) of MethodState::local_map.
   /// Rendering the map is O(map size) and would stall every other user of
   /// state_mtx_ (dataset reader, IMU worker, executor thread) if done under it,
-  /// so updateVisualizationLocalMap() temporarily releases state_mtx_ and takes
-  /// this one instead. Lock order: a thread that needs both must take
-  /// state_mtx_ first; it must never be held while acquiring state_mtx_.
+  /// so the render runs on worker_viz_local_map_ and takes only this one.
+  /// Lock order: a thread that needs both must take state_mtx_ first; it must
+  /// never be held while acquiring state_mtx_.
   mutable std::mutex local_map_content_mtx_;
 
   mutable std::mutex state_trajectory_mtx_;
@@ -1385,8 +1393,7 @@ private:
   void updatePipelineDynamicVariablesRobotPoseOnly();
 
   /// All these methods read state_, so the caller must own state_mtx_ and pass
-  /// its lock object down: it is momentarily released while rendering the
-  /// local map (see local_map_content_mtx_).
+  /// its lock object down, which they assert on entry.
   void updateVisualization(
     const mp2p_icp::metric_map_t & currentObservation,
     const mrpt::maps::CPointsMap::Ptr & deskewedCloud, std::unique_lock<std::mutex> & lckState);
@@ -1395,8 +1402,10 @@ private:
   void updateVisualizationCurrentObservation(
     const mp2p_icp::metric_map_t & currentObservation,
     const mrpt::maps::CPointsMap::Ptr & deskewedCloud);
-  void updateVisualizationLocalMap(
-    std::vector<std::function<void()>> & updateTasks, std::unique_lock<std::mutex> & lckState);
+  /// Only decides *whether* to refresh the local map view and snapshots what
+  /// that takes; the O(map size) render itself is enqueued on
+  /// worker_viz_local_map_ (see local_map_content_mtx_).
+  void updateVisualizationLocalMap();
   void updateVisualizationPath(std::vector<std::function<void()>> & updateTasks);
 
   /// Renders the /tf subtree below the configured root frame, as a child of

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -937,12 +937,15 @@ private:
     std::size_t drop_frames_stats_next_index = 0;
     // ------ ^^^ end of these flags are protected ^^^^      ---------
 
-    // All other fields are protected by state_mtx_
+    // All other fields are protected by state_mtx_, EXCEPT the ones marked
+    // below as protected by imu_state_mtx_ (the state the IMU worker thread
+    // feeds; see that mutex's docs for the full list and the lock order).
 
     // will be true after the first incoming LiDAR frame and re-localization is enabled and run
     bool initial_localization_done = false;
 
-    /// Used for pitch & roll initialization
+    /// Used for pitch & roll initialization.
+    /// Protected by imu_state_mtx_.
     std::optional<mola::imu::ImuInitialCalibrator> imu_initializer;
 
     /// Accumulates recent accelerometer readings and provides
@@ -982,6 +985,7 @@ private:
       std::optional<double> directionDispersionSigma(double max_age_seconds) const;
     };
 
+    /// Protected by imu_state_mtx_.
     GravityEstimator gravity_estimator;
 
 #if defined(MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR)
@@ -1006,6 +1010,7 @@ private:
       uint32_t intervals_since_solve = 0;
     };
 
+    /// Protected by imu_state_mtx_.
     MapGravityState map_gravity;
 #endif
 
@@ -1073,7 +1078,10 @@ private:
 
     std::optional<NavState> last_motion_model_output;
 
-    /// The source of "dynamic variables" in ICP pipelines:
+    /// The source of "dynamic variables" in ICP pipelines.
+    /// Protected by imu_state_mtx_: besides the variable map and the realize()
+    /// flags, it owns the localVelocityBuffer that IMU samples write and the
+    /// LiDAR deskew stage reads.
     mp2p_icp::ParameterSource parameter_source;
 
     // KISS-ICP-like adaptive threshold method:
@@ -1088,6 +1096,8 @@ private:
     std::optional<double> estimated_observation_radius;
     std::optional<double> instantaneous_observation_radius;
 
+    /// Invocations are protected by imu_state_mtx_: apply_generators() on an
+    /// IMU observation appends to parameter_source.localVelocityBuffer.
     mp2p_icp_filters::GeneratorSet obs_generators;
     mp2p_icp_filters::FilterPipeline pc_filterAdjustTimes;
     mp2p_icp_filters::FilterPipeline pc_prefilter;
@@ -1176,6 +1186,7 @@ private:
     std::map<std::string, mrpt::containers::circular_buffer<double>> recent_lidar_stamps;
 
     /// Used to estimate sensor rate
+    /// Protected by imu_state_mtx_.
     mrpt::containers::circular_buffer<double> recent_imu_stamps{1500};
 
     /// Used to estimate GNSS sensor rate
@@ -1328,6 +1339,30 @@ private:
   mutable std::mutex drop_stats_mtx_;
   mutable std::mutex state_flags_mtx_;
   mutable std::mutex state_mtx_;
+
+  /// Guards the state shared between the IMU worker thread and the LiDAR
+  /// worker thread, so the former no longer has to wait on state_mtx_, which
+  /// processLidarScan() holds for its whole body (filters, ICP, map update,
+  /// visualization). At 200 Hz IMU / 10 Hz LiDAR that made the IMU thread block
+  /// for essentially the entire duration of every scan, and since
+  /// releaseReadyLidarScansToWorker() runs at the end of onIMU(), that wait fed
+  /// straight back into scan submission latency.
+  ///
+  /// Covers, in MethodState: imu_initializer, gravity_estimator, map_gravity,
+  /// recent_imu_stamps, parameter_source (its variable map, the realize()
+  /// "evaluated" flags, and localVelocityBuffer), and any *invocation* of
+  /// obs_generators (which writes the velocity buffer and reads those flags).
+  ///
+  /// Lock order: state_mtx_ -> local_map_content_mtx_ -> imu_state_mtx_; never
+  /// the reverse. The IMU worker takes only this one (and never the local map),
+  /// so it cannot invert the order.
+  ///
+  /// Recursive because the accessors that take it compose (e.g.
+  /// updatePipelineDynamicVariables() -> updatePipelineTwistVariables(),
+  /// buildGravityPrior() -> effectiveGravitySigmaRad()); locking at accessor
+  /// granularity is what keeps the ownership rule above reviewable, rather than
+  /// threading a lock object through a dozen signatures.
+  mutable std::recursive_mutex imu_state_mtx_;
 
   /// Guards the *contents* (layers) of MethodState::local_map.
   /// Rendering the map is O(map size) and would stall every other user of

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -1290,7 +1290,16 @@ private:
    *  as worker_viz_, but a pool of its own: with one thread, POLICY_DROP_OLD
    *  caps the queue at a single pending task, so sharing worker_viz_ would let
    *  the per-scan current-observation frames drop the (much rarer) local map
-   *  render before it ever runs, and would serialize the two renders. */
+   *  render before it ever runs, and would serialize the two renders.
+   *
+   *  Its task holds raw pointers into `*this` (the profiler and
+   *  local_map_content_mtx_, both declared *after* this pool and therefore
+   *  destroyed *before* it). That is safe only because shutdownCleanup() calls
+   *  clear() on this pool, which joins its thread, and shutdownCleanup() runs
+   *  from the destructor body, i.e. before any member is destroyed. Keep it in
+   *  that list if the shutdown path is ever reworked.
+   *  A still-*pending* render is dropped there rather than waited for: it would
+   *  delay shutdown by a full render to draw a frame nobody will see. */
   mrpt::WorkerThreadsPool worker_viz_local_map_{
     1, mrpt::WorkerThreadsPool::POLICY_DROP_OLD, "worker_viz_map"};
 

--- a/module/src/LidarOdometry_AdaptiveVariables.cpp
+++ b/module/src/LidarOdometry_AdaptiveVariables.cpp
@@ -54,6 +54,8 @@ namespace mola
 
 void LidarOdometry::updatePipelineDynamicVariablesRobotPoseOnly()
 {
+  auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+
   const auto & p = state_.last_lidar_pose.mean;
   state_.parameter_source.updateVariable("robot_x", p.x());
   state_.parameter_source.updateVariable("robot_y", p.y());
@@ -65,6 +67,10 @@ void LidarOdometry::updatePipelineDynamicVariablesRobotPoseOnly()
 
 void LidarOdometry::updatePipelineDynamicVariables(const mrpt::Clock::time_point & stamp)
 {
+  // Writes the localVelocityBuffer the IMU thread also appends to, and ends
+  // with realize(), which flips the "evaluated" flags that thread reads:
+  auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+
   const auto stamp_s = mrpt::Clock::toDouble(stamp);
 
   // Set dynamic variables for twist usage within ICP pipelines
@@ -250,6 +256,8 @@ void LidarOdometry::doUpdateEstimatedObservationRadius(const mp2p_icp::metric_ma
 
 void LidarOdometry::updatePipelineTwistVariables(const mrpt::math::TTwist3D & tw)
 {
+  auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+
   state_.parameter_source.updateVariable("vx", tw.vx);
   state_.parameter_source.updateVariable("vy", tw.vy);
   state_.parameter_source.updateVariable("vz", tw.vz);

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -514,6 +514,50 @@ void doRecolorize(
   mrpt::obs::recolorize3Dpc(cloud, org_cloud, rp);
 };
 
+// A deep copy of `m`, cheap enough to make while holding
+// local_map_content_mtx_. It exists to keep that mutex OUT of the render:
+// get_visualization() costs ~6x this copy (167.9 ms vs 28.1 ms mean on an
+// Oxford Spires local map) and touches nothing but the copy, so holding the
+// map mutex across it stalled the LiDAR worker's own map insertion for
+// ~110 ms at a time.
+//
+// Point layers are copied into a plain CGenericPointsMap rather than cloned
+// through their own type: insertAnotherMap() carries every per-point field
+// over and skips non-finite slots, while the target has no spatial index to
+// build. Cloning e.g. mola::IncrementalPointCloud via its copy constructor
+// would instead bulk-build a k-d tree that the renderer never queries.
+// The copy sees, in addition to the live points, the storage slots that are
+// tombstoned but not reclaimed yet; that population measured <2% of storage
+// on Oxford Spires (live/storage 0.999 mean, 0.982 worst), i.e. visually
+// irrelevant, and it is the same trade-off doPublishUpdatedLocalMap() already
+// makes when copying layers out for ROS.
+mp2p_icp::metric_map_t cheapLayerSnapshot(const mp2p_icp::metric_map_t & m)
+{
+  // Shallow copy first, so any metadata this struct grows (id, label, lines,
+  // planes, georeferencing, ...) is carried over without enumerating it here:
+  mp2p_icp::metric_map_t out = m;
+
+  for (auto & [name, layer] : out.layers) {
+    if (!layer) {
+      continue;
+    }
+
+    if (const auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(layer); pts) {
+      auto copy = mrpt::maps::CGenericPointsMap::Create();
+      copy->insertAnotherMap(pts.get(), mrpt::poses::CPose3D::Identity());
+      // The renderer reads both of these off the layer:
+      copy->renderOptions = pts->renderOptions;
+      copy->genericMapParams = pts->genericMapParams;
+      layer = copy;
+    } else {
+      // Voxel maps and friends: the RTTI copy is what they support.
+      layer = std::dynamic_pointer_cast<mrpt::maps::CMetricMap>(layer->duplicateGetSmartPtr());
+    }
+  }
+
+  return out;
+}
+
 // Upserts a 3D object, optionally as a child of a movable scene frame node
 // (parentFrame). Falls back to a root insert when built against an older
 // mola_kernel that lacks the movable-frame API.
@@ -956,11 +1000,15 @@ void LidarOdometry::updateVisualizationLocalMap()
     (void)worker_viz_local_map_.enqueue([=]() {
       const ProfilerEntry tle3(*profilerPtr, "updateVisualization.update_local_map_thread");
 
-      mrpt::opengl::CSetOfObjects::Ptr glMap;
+      // Copy under the map mutex, render outside it: see cheapLayerSnapshot().
+      mp2p_icp::metric_map_t snapshot;
       {
+        const ProfilerEntry tleCopy(*profilerPtr, "updateVisualization.update_local_map_copy");
         auto lckMapContents = mrpt::lockHelper(*mapContentsMtx);
-        glMap = localMap->get_visualization(rp);
+        snapshot = cheapLayerSnapshot(*localMap);
       }
+
+      const auto glMap = snapshot.get_visualization(rp);
       vizUpsert3D(viz, "liodom/localmap", glMap, vizFrame);
     });
   }

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -56,21 +56,6 @@ namespace mola
 
 namespace
 {
-/** Temporarily releases an already-held lock, re-acquiring it on scope exit
- *  (including if the guarded code throws).
- */
-class ScopedUnlock
-{
-public:
-  explicit ScopedUnlock(std::unique_lock<std::mutex> & lck) : lck_(lck) { lck_.unlock(); }
-  ~ScopedUnlock() { lck_.lock(); }
-
-  ScopedUnlock(const ScopedUnlock &) = delete;
-  ScopedUnlock & operator=(const ScopedUnlock &) = delete;
-
-private:
-  std::unique_lock<std::mutex> & lck_;
-};
 #if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
 /** Splits "a, b ,c" into {"a","b","c"}, ignoring empty items. */
 std::set<std::string> splitCommaSeparated(const std::string & s)
@@ -750,13 +735,7 @@ void LidarOdometry::updateVisualizationAlways(std::unique_lock<std::mutex> & lck
   ASSERT_(lckState.owns_lock());
 
   // Local map: update whenever map content changed, independent of ICP quality.
-  {
-    std::vector<std::function<void()>> updateTasks;
-    updateVisualizationLocalMap(updateTasks, lckState);
-    for (const auto & ut : updateTasks) {
-      ut();
-    }
-  }
+  updateVisualizationLocalMap();
 
   // Sub-window with custom UI
   // -------------------------------------
@@ -923,11 +902,8 @@ void LidarOdometry::updateVisualizationCurrentObservation(
   (void)fut;
 }
 
-void LidarOdometry::updateVisualizationLocalMap(
-  std::vector<std::function<void()>> & updateTasks, std::unique_lock<std::mutex> & lckState)
+void LidarOdometry::updateVisualizationLocalMap()
 {
-  ASSERT_(lckState.owns_lock());
-
   const std::string vizFrame = vizParentFrame();
 
   bool decimationReached = false;
@@ -962,34 +938,41 @@ void LidarOdometry::updateVisualizationLocalMap(
     // local map: this recolors/renders every point currently in the map, an
     // O(map size) cost that keeps growing with it (e.g. under
     // mola::IncrementalPointCloud, whose local map never shrinks back below
-    // its eviction cube). Doing it under state_mtx_ stalls the dataset reader,
-    // IMU worker, and executor threads for the whole call once the local map
-    // gets large, so state_mtx_ is temporarily released here and the map
-    // contents are guarded by the finer-grained local_map_content_mtx_ instead.
-    // Note the strict order: state_mtx_ is released *before* acquiring the
-    // contents mutex, since holders of the latter may be waiting for the
-    // former (see the lock order documented in the class declaration).
-    mrpt::opengl::CSetOfObjects::Ptr glMap;
-    {
-      // Keep the map alive even if state_ is reset while unlocked:
-      const auto localMap = state_.local_map;
+    // its eviction cube), and it used to run right here, on the LiDAR worker
+    // thread: measured at ~55 ms mean / ~120 ms max on a GrandTour mission,
+    // which is what turned one onLidar in ~18 into a >100 ms spike and backed
+    // up the scan queue. So it is handed to a worker instead, where it takes
+    // only the finer-grained local_map_content_mtx_ (never state_mtx_, hence
+    // no inversion of the lock order documented in the class declaration).
+    //
+    // Snapshot all values the worker will need. Avoid any access to state_ or
+    // params_ from the lambda; keeping a shared_ptr to the map also means a
+    // concurrent reset() cannot drop the last reference mid-render.
+    const auto localMap = state_.local_map;
+    auto viz = visualizer_;
+    const auto * profilerPtr = &profiler_;
+    auto * mapContentsMtx = &local_map_content_mtx_;
 
-      const ScopedUnlock unlockState(lckState);
-      auto lckMapContents = mrpt::lockHelper(local_map_content_mtx_);
+    (void)worker_viz_local_map_.enqueue([=]() {
+      const ProfilerEntry tle3(*profilerPtr, "updateVisualization.update_local_map_thread");
 
-      glMap = localMap->get_visualization(rp);
-    }
-
-    updateTasks.emplace_back([visualizer = visualizer_, glMap, vizFrame]() {
-      vizUpsert3D(visualizer, "liodom/localmap", glMap, vizFrame);
+      mrpt::opengl::CSetOfObjects::Ptr glMap;
+      {
+        auto lckMapContents = mrpt::lockHelper(*mapContentsMtx);
+        glMap = localMap->get_visualization(rp);
+      }
+      vizUpsert3D(viz, "liodom/localmap", glMap, vizFrame);
     });
   }
 
   // Clear the local map if the user clicks on "hide it" at runtime:
   if (!params_.visualization.show_localmap) {
-    auto glMap = mrpt::opengl::CSetOfObjects::Create();
-    updateTasks.emplace_back([visualizer = visualizer_, glMap, vizFrame]() {
-      vizUpsert3D(visualizer, "liodom/localmap", glMap, vizFrame);
+    // Routed through the same worker so it is ordered after any render already
+    // enqueued above and cannot be overwritten by it.
+    auto viz = visualizer_;
+    (void)worker_viz_local_map_.enqueue([=]() {
+      auto glMap = mrpt::opengl::CSetOfObjects::Create();
+      vizUpsert3D(viz, "liodom/localmap", glMap, vizFrame);
     });
 
     // Force an immediate redraw the next time the local map is shown again,

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -1088,9 +1088,12 @@ void LidarOdometry::updateVisualizationGravityVector(
 
   const ProfilerEntry tle2(profiler_, "updateVisualization.update_gravity");
 
-  const auto gravityPR = state_.gravity_estimator.estimatedPitchRoll(
-    params_.imu_gravity_correction.averaging_samples,
-    params_.imu_gravity_correction.max_age_seconds);
+  const auto gravityPR = [this]() {
+    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+    return state_.gravity_estimator.estimatedPitchRoll(
+      params_.imu_gravity_correction.averaging_samples,
+      params_.imu_gravity_correction.max_age_seconds);
+  }();
 
   if (!gravityPR.has_value()) {
     return;
@@ -1126,6 +1129,8 @@ void LidarOdometry::updateVisualizationTextLabels()
     state_.adapt_thres_sigma, state_.last_icp_iterations));
 
   {
+    // recent_imu_stamps is appended by the IMU worker thread:
+    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
     const auto [rate_lidar, rate_imu, rate_gnss] = state_.get_sensor_rates();
     gui_.lbSensorRates->set(mrpt::format(
       "LiDAR=%6.02f Hz | IMU=%6.02f Hz | GNSS=%5.02f Hz", rate_lidar, rate_imu, rate_gnss));

--- a/module/src/LidarOdometry_InitialLocalization.cpp
+++ b/module/src/LidarOdometry_InitialLocalization.cpp
@@ -91,6 +91,9 @@ void LidarOdometry::handleInitialLocalization()
       // INITIALIZATION FROM IMU FOR PITCH & ROLL ONLY
       // ---------------------------------------------------
     case mola::InitLocalization::PitchAndRollFromIMU: {
+      // imu_initializer is created here but fed by the IMU worker thread:
+      auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+
       // Construct the IMU averager object:
       if (!state_.imu_initializer) {
         state_.imu_initializer = mola::imu::ImuInitialCalibrator();

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -59,6 +59,10 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
 
   {
     auto lckState = mrpt::lockHelper(state_mtx_);
+    // This block builds the generators/pipelines and attaches them to the
+    // parameter source, all of which the IMU worker thread reaches without
+    // state_mtx_ (sensors may already be feeding by now):
+    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
 
     // One-shot deprecation warning for the legacy *_sensor_* names. Aliases
     // are still honored (dynamic variables are double-published; the *_sensor_*

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -166,8 +166,7 @@ void LidarOdometry::spinOnce()
 
   if (visualizer_) {
     // updateVisualization() reads state_, so it must be called with state_mtx_
-    // held (it takes care of momentarily releasing it while rendering the
-    // potentially large local map):
+    // held:
     std::unique_lock<std::mutex> lckState(state_mtx_);
 
     if (

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -83,8 +83,9 @@ void LidarOdometry::onQuit() { shutdownCleanup(); }
 //
 // onQuit() is invoked by MolaLauncherApp::executor_thread() for every module,
 // before any module is destroyed (see ExecutableBase::onQuit() docs). This
-// matters because worker_lidar_/worker_others_/worker_viz_ may have an
-// in-flight task (e.g. onLidar()) that calls back into other modules, e.g.
+// matters because worker_lidar_/worker_others_/worker_viz_/
+// worker_viz_local_map_ may have an in-flight task (e.g. onLidar(), or the
+// local-map render) that calls back into other modules, e.g.
 // BridgeROS2's TF broadcaster via VizInterface/LocalizationSourceBase. If
 // that task is still running when another module's destructor runs (which
 // previously only happened from ~LidarOdometry(), after other modules may
@@ -113,6 +114,7 @@ void LidarOdometry::shutdownCleanup()
     worker_lidar_.clear();
     worker_others_.clear();
     worker_viz_.clear();
+    worker_viz_local_map_.clear();
 
     if (params_.simplemap.generate) {
       saveReconstructedMapToFile();
@@ -210,6 +212,10 @@ void LidarOdometry::reset()
   // state_mtx_ is a plain (non-recursive) mutex.
   {
     auto lck = mrpt::lockHelper(state_mtx_);
+    // Replacing state_ wholesale also destroys the parameter source, the
+    // gravity estimator and the rest of the IMU-fed state, which the IMU worker
+    // thread reaches without state_mtx_:
+    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
     state_ = MethodState();
   }
   initialize(lastInitConfig_);
@@ -674,7 +680,10 @@ void LidarOdometry::doWriteDebugTracesFile(const mrpt::Clock::time_point & scan_
 
   auto & of = debug_traces_of_.value();
 
-  auto vars = state_.parameter_source.getVariableValues();
+  auto vars = [this]() {
+    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+    return state_.parameter_source.getVariableValues();
+  }();
   vars["timestamp"] = mrpt::Clock::toDouble(scan_ref_time);
   vars["time_onLidar"] = profiler_.getLastTime("onLidar");
 

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -77,7 +77,9 @@ bool LidarOdometry::isPipelineUsingIMU_locked() const
 void LidarOdometry::closeMapGravityInterval(
   double timestamp, const mrpt::poses::CPose3D & pose, const mrpt::math::TTwist3D & twistLocal)
 {
-  // Caller holds state_mtx_.
+  // Caller holds state_mtx_; map_gravity is fed by the IMU thread too:
+  auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+
   auto & mg = state_.map_gravity;
 
   // Velocity in the MAP frame, which is the frame the estimator works in.
@@ -143,7 +145,11 @@ void LidarOdometry::closeMapGravityInterval(
 #if defined(MOLA_LO_HAS_MP2P_GRAVITY_PRIOR)
 std::optional<mp2p_icp::GravityPrior> LidarOdometry::buildGravityPrior() const
 {
-  // Caller holds state_mtx_.
+  // Caller holds state_mtx_; gravity_estimator and map_gravity are fed by the
+  // IMU thread. Held across the whole body so the reading and the map-frame
+  // reference it is combined with come from one consistent snapshot:
+  auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+
   const auto pr = state_.gravity_estimator.estimatedPitchRoll(
     params_.imu_gravity_correction.averaging_samples,
     params_.imu_gravity_correction.max_age_seconds);
@@ -214,7 +220,9 @@ std::optional<mp2p_icp::GravityPrior> LidarOdometry::buildGravityPrior() const
 
 void LidarOdometry::captureMapOriginVerticality(const mrpt::poses::CPose3D & poseAtCapture)
 {
-  // Caller holds state_mtx_.
+  // Caller holds state_mtx_; gravity_estimator is fed by the IMU thread:
+  auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+
   if (!params_.imu_gravity_correction.enabled || state_.gravity_calib_pitch_roll.has_value()) {
     return;
   }
@@ -245,7 +253,9 @@ void LidarOdometry::captureMapOriginVerticality(const mrpt::poses::CPose3D & pos
 
 double LidarOdometry::effectiveGravitySigmaRad() const
 {
-  // Caller holds state_mtx_.
+  // Caller holds state_mtx_; gravity_estimator is fed by the IMU thread:
+  auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+
   const double sigma0 = mrpt::DEG2RAD(params_.imu_gravity_correction.sigma_deg);
   if (!params_.imu_gravity_correction.adaptive_sigma) {
     return sigma0;
@@ -374,7 +384,10 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
   // Refresh dyn. variables used in the mp2p_icp pipelines:
   updatePipelineDynamicVariables(this_obs_tim);
 
-  MRPT_LOG_DEBUG_STREAM("Dynamic variables: " << state_.parameter_source.printVariableValues());
+  if (isLoggingLevelVisible(mrpt::system::LVL_DEBUG)) {
+    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+    MRPT_LOG_DEBUG_STREAM("Dynamic variables: " << state_.parameter_source.printVariableValues());
+  }
 
   // Extract points from observation:
   auto observation = observationFromRawSensor(sf);
@@ -398,7 +411,14 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 
   if (use_early_deskew) {
     ProfilerEntry tle1(profiler_, "onLidar.1.deskew_early");
-    mp2p_icp_filters::apply_filter_pipeline(state_.pc_deskew, *observation, profiler_);
+    {
+      // FilterDeskew snapshots the localVelocityBuffer that the IMU thread
+      // appends to (one collect_samples_around_reference_time() call; the
+      // per-point work afterwards runs on that private copy). The lock spans
+      // the pipeline because the snapshot happens inside the filter:
+      auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+      mp2p_icp_filters::apply_filter_pipeline(state_.pc_deskew, *observation, profiler_);
+    }
     // Now observation has a "deskewed" layer with the full cloud deskewed.
   } else {
     // Fallback:
@@ -462,8 +482,10 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
   // configured, e.g. MiddleIsZero -> mid-scan). Use it consistently for any
   // pose-time semantics (state fusion, trajectory, published stamps).
   // With no per-point time adjustment configured this equals obs->timestamp.
-  const double scan_ref_time_s =
-    state_.parameter_source.localVelocityBuffer.get_reference_zero_time();
+  const double scan_ref_time_s = [this]() {
+    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+    return state_.parameter_source.localVelocityBuffer.get_reference_zero_time();
+  }();
   const auto scan_ref_time =
     scan_ref_time_s > 0 ? mrpt::Clock::fromDouble(scan_ref_time_s) : this_obs_tim;
 
@@ -646,6 +668,10 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 
     // Legacy path: fold the gravity-derived pitch/roll into the SE(3) prior.
     if (params_.imu_gravity_correction.enabled && !params_.imu_gravity_correction.use_rank2_prior) {
+      // gravity_estimator is fed by the IMU thread; one consistent snapshot for
+      // the reading, its dispersion and the buffer size logged below:
+      auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+
       const auto gravityPR = state_.gravity_estimator.estimatedPitchRoll(
         params_.imu_gravity_correction.averaging_samples,
         params_.imu_gravity_correction.max_age_seconds);
@@ -865,7 +891,10 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
         // Update twist dynamic variables, then re-run pipelines:
         updatePipelineTwistVariables(tw);
         // Make all changes effective and evaluate the variables now:
-        state_.parameter_source.realize();
+        {
+          auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+          state_.parameter_source.realize();
+        }
 
         // and re-apply 2nd pass:
         ProfilerEntry tle1c(profiler_, "onLidar.1.filter_2nd");
@@ -978,10 +1007,13 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 #endif
 
     // Update for stats in CSV format:
-    state_.parameter_source.updateVariable("icp_iterations", out.icp_iterations);
-    state_.parameter_source.updateVariable(
-      "twistCorrectionCount", static_cast<double>(twistCorrectionCount));
-    state_.parameter_source.updateVariable("icp_quality", state_.last_icp_quality);
+    {
+      auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+      state_.parameter_source.updateVariable("icp_iterations", out.icp_iterations);
+      state_.parameter_source.updateVariable(
+        "twistCorrectionCount", static_cast<double>(twistCorrectionCount));
+      state_.parameter_source.updateVariable("icp_quality", state_.last_icp_quality);
+    }
 
     // Adaptive threshold method:
     // Only update on good ICP: a bad ICP may have converged to a local minimum
@@ -1222,7 +1254,10 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
     // in particular, [robot_x, ..., robot_roll]:
     updatePipelineDynamicVariablesRobotPoseOnly();
     // Make all changes effective and evaluate the variables now:
-    state_.parameter_source.realize();
+    {
+      auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+      state_.parameter_source.realize();
+    }
 
     // 3/4: Apply pipeline
     mp2p_icp_filters::apply_filter_pipeline(state_.obs2map_merge, *state_.local_map, profiler_);
@@ -1376,14 +1411,21 @@ mp2p_icp::metric_map_t::Ptr LidarOdometry::observationFromRawSensor(
     mp2p_icp::metric_map_t thisObs;
     mp2p_icp::metric_map_t * obsTrg = sf.size() == 1 ? observation.get() : &thisObs;
 
-    mp2p_icp_filters::apply_generators(state_.obs_generators, *o, *obsTrg);
+    {
+      // Shares obs_generators (and, through them, the localVelocityBuffer whose
+      // reference-zero time they set) with the IMU thread's own
+      // apply_generators() call, plus the realize() flags that thread reads:
+      auto lckImu = mrpt::lockHelper(imu_state_mtx_);
 
-    // Update relative timestamps for multiple lidars:
-    const double dt = mrpt::system::timeDifference(timeOfFirstSFObs, o->timestamp);
+      mp2p_icp_filters::apply_generators(state_.obs_generators, *o, *obsTrg);
 
-    state_.parameter_source.updateVariable("SENSOR_TIME_OFFSET", dt);
-    // Make all changes effective and evaluate the variables now:
-    state_.parameter_source.realize();
+      // Update relative timestamps for multiple lidars:
+      const double dt = mrpt::system::timeDifference(timeOfFirstSFObs, o->timestamp);
+
+      state_.parameter_source.updateVariable("SENSOR_TIME_OFFSET", dt);
+      // Make all changes effective and evaluate the variables now:
+      state_.parameter_source.realize();
+    }
 
     mp2p_icp_filters::apply_filter_pipeline(state_.pc_filterAdjustTimes, *obsTrg, profiler_);
 
@@ -1551,7 +1593,10 @@ void LidarOdometry::appendKeyframeMetadataObs(
 
   // Store local velocity buffer in the KF metadata so it is possible to deskew
   // the scan later on with precision.
-  kf_metadata["local_velocity_buffer"] = state_.parameter_source.localVelocityBuffer.toYAML();
+  kf_metadata["local_velocity_buffer"] = [this]() {
+    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+    return state_.parameter_source.localVelocityBuffer.toYAML();
+  }();
 
   // convert yaml to string:
   std::stringstream ss;

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -888,11 +888,15 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
                          << "old estimated twist:"
                          << state_.last_motion_model_output->twist.asString() << "\n");
 
-        // Update twist dynamic variables, then re-run pipelines:
-        updatePipelineTwistVariables(tw);
-        // Make all changes effective and evaluate the variables now:
+        // Update twist dynamic variables, then re-run pipelines.
+        // One lock for the update AND the realize(): the accessor takes
+        // imu_state_mtx_ itself (recursively), but releasing it in between
+        // would let the IMU thread run apply_generators() on variables that
+        // are updated but not realized yet.
         {
           auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+          updatePipelineTwistVariables(tw);
+          // Make all changes effective and evaluate the variables now:
           state_.parameter_source.realize();
         }
 
@@ -1252,10 +1256,11 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
 
     // 2/4: Make sure dynamic variables are up-to-date,
     // in particular, [robot_x, ..., robot_roll]:
-    updatePipelineDynamicVariablesRobotPoseOnly();
-    // Make all changes effective and evaluate the variables now:
+    // One lock for the update AND the realize(), see the twist update above:
     {
       auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+      updatePipelineDynamicVariablesRobotPoseOnly();
+      // Make all changes effective and evaluate the variables now:
       state_.parameter_source.realize();
     }
 

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -314,9 +314,15 @@ void LidarOdometry::onIMUImpl(const CObservation::ConstPtr & o)
   // 1) During special initialization to compensate for pitch/roll;
   // 2) Improved scan de-skewing.
 
+  // Everything this callback touches lives under imu_state_mtx_, NOT under
+  // state_mtx_: the latter is held by processLidarScan() for its whole body, so
+  // taking it here blocked this thread for the duration of every scan (see the
+  // mutex's docs). Only the fine-grained one is needed, and it is held by the
+  // LiDAR thread for short, well-defined windows.
+
   // 1) Initial pitch/roll estimation:
   {
-    auto lckState = mrpt::lockHelper(state_mtx_);
+    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
     if (state_.imu_initializer.has_value()) {
       state_.imu_initializer->add(imu);
     }
@@ -330,7 +336,7 @@ void LidarOdometry::onIMUImpl(const CObservation::ConstPtr & o)
   //    The LocalVelocityBuffer also needs velocity and orientation estimations, which are sent out
   //    in updatePipelineDynamicVariables()
   {
-    auto lckState = mrpt::lockHelper(state_mtx_);
+    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
     mp2p_icp::metric_map_t dummy_map;
     mp2p_icp_filters::apply_generators(state_.obs_generators, *imu, dummy_map);
   }
@@ -347,7 +353,7 @@ void LidarOdometry::onIMUImpl(const CObservation::ConstPtr & o)
 
   // 3) Gravity estimation for ICP verticality correction:
   if (params_.imu_gravity_correction.enabled) {
-    auto lckState2 = mrpt::lockHelper(state_mtx_);
+    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
     state_.gravity_estimator.add(*imu, params_.imu_gravity_correction.averaging_samples);
 
 #if defined(MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR)
@@ -587,7 +593,7 @@ void LidarOdometry::MethodState::GravityEstimator::add(
 #if defined(MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR)
 void LidarOdometry::accumulateImuForMapGravity(const mrpt::obs::CObservationIMU & imu)
 {
-  // Caller holds state_mtx_.
+  // Caller holds imu_state_mtx_ (state_.map_gravity).
   using namespace mrpt::obs;
 
   if (

--- a/pipelines/extras/lidar3d-dual-map.yaml
+++ b/pipelines/extras/lidar3d-dual-map.yaml
@@ -77,7 +77,7 @@ params:
   # If run within a mola-cli container, and mola_viz is present, use these options
   # to show live progress:
   visualization:
-    map_update_decimation: 20
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|20}
     show_trajectory: true
     #current_pose_corner_size: 1.5
     #sensor_poses_corner_size: 0.5  # XYZ corner for each LiDAR sensor pose; 0 to disable

--- a/pipelines/extras/lidar3d-edges.yaml
+++ b/pipelines/extras/lidar3d-edges.yaml
@@ -87,7 +87,7 @@ params:
   # If run within a mola-cli container, and mola_viz is present, use these options
   # to show live progress:
   visualization:
-    map_update_decimation: 20
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|20}
     show_trajectory: true
     #current_pose_corner_size: 1.5
     #sensor_poses_corner_size: 0.5  # XYZ corner for each LiDAR sensor pose; 0 to disable

--- a/pipelines/extras/lidar3d-hybrid-pw.yaml
+++ b/pipelines/extras/lidar3d-hybrid-pw.yaml
@@ -119,7 +119,7 @@ params:
     output_file: ${MOLA_TUM_TRAJECTORY_OUTPUT|'estimated_trajectory.tum'}
 
   visualization:
-    map_update_decimation: 10
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|10}
     show_trajectory: ${MOLA_GUI_SHOW_TRAJECTORY|true}
     trajectory_rgba: [0.1, 0.1, 0.1, 1.0]
     camera_follows_vehicle: ${MOLA_GUI_CAMERA_FOLLOWS_VEHICLE|true}

--- a/pipelines/extras/lidar3d-kissicp-like.yaml
+++ b/pipelines/extras/lidar3d-kissicp-like.yaml
@@ -46,7 +46,7 @@ params:
   # If run within a mola-cli container, and mola_viz is present, use these options
   # to show live progress:
   visualization:
-    map_update_decimation: 20
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|20}
     show_trajectory: true
 
   # Profile the main steps of the odometry pipeline:

--- a/pipelines/extras/rgbd.yaml
+++ b/pipelines/extras/rgbd.yaml
@@ -106,7 +106,7 @@ params:
   # If run within a mola-cli container, and mola_viz is present, use these options
   # to show live progress:
   visualization:
-    map_update_decimation: 20
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|20}
     show_trajectory: true
     #current_pose_corner_size: 1.5
     #sensor_poses_corner_size: 0.5  # XYZ corner for each LiDAR sensor pose; 0 to disable

--- a/pipelines/lidar2d.yaml
+++ b/pipelines/lidar2d.yaml
@@ -116,7 +116,7 @@ params:
   # If run within a mola-cli container, and mola_viz is present, use these options
   # to show live progress:
   visualization:
-    map_update_decimation: 40
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|40}
     show_trajectory: true
     show_current_observation: true # shows "live raw" LiDAR points
     #current_pose_corner_size: 1.5

--- a/pipelines/lidar3d-default-voxelavg.yaml
+++ b/pipelines/lidar3d-default-voxelavg.yaml
@@ -217,7 +217,7 @@ params:
   # If run within a mola-cli container, and mola_viz is present, use these options
   # to show live progress:
   visualization:
-    map_update_decimation: 10
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|10}
     show_trajectory: ${MOLA_GUI_SHOW_TRAJECTORY|true}
     trajectory_rgba: [0.1, 0.1, 0.1, 1.0]
 

--- a/pipelines/lidar3d-dlio-like-only-downsample-voxelavg.yaml
+++ b/pipelines/lidar3d-dlio-like-only-downsample-voxelavg.yaml
@@ -239,7 +239,7 @@ params:
   # If run within a mola-cli container, and mola_viz is present, use these options
   # to show live progress:
   visualization:
-    map_update_decimation: 10
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|10}
     show_trajectory: ${MOLA_GUI_SHOW_TRAJECTORY|true}
     trajectory_rgba: [0.1, 0.1, 0.1, 1.0]
 

--- a/pipelines/lidar3d-dlio-like-only-downsample.yaml
+++ b/pipelines/lidar3d-dlio-like-only-downsample.yaml
@@ -228,7 +228,7 @@ params:
   # If run within a mola-cli container, and mola_viz is present, use these options
   # to show live progress:
   visualization:
-    map_update_decimation: 10
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|10}
     show_trajectory: ${MOLA_GUI_SHOW_TRAJECTORY|true}
     trajectory_rgba: [0.1, 0.1, 0.1, 1.0]
 

--- a/pipelines/lidar3d-dlio-like-revert-downsample.yaml
+++ b/pipelines/lidar3d-dlio-like-revert-downsample.yaml
@@ -157,7 +157,7 @@ params:
     output_file: ${MOLA_TUM_TRAJECTORY_OUTPUT|'estimated_trajectory.tum'}
 
   visualization:
-    map_update_decimation: 10
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|10}
     show_trajectory: ${MOLA_GUI_SHOW_TRAJECTORY|true}
     trajectory_rgba: [0.1, 0.1, 0.1, 1.0]
     camera_follows_vehicle: ${MOLA_GUI_CAMERA_FOLLOWS_VEHICLE|true}

--- a/pipelines/lidar3d-dlio-like-revert-keyframe.yaml
+++ b/pipelines/lidar3d-dlio-like-revert-keyframe.yaml
@@ -153,7 +153,7 @@ params:
     output_file: ${MOLA_TUM_TRAJECTORY_OUTPUT|'estimated_trajectory.tum'}
 
   visualization:
-    map_update_decimation: 10
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|10}
     show_trajectory: ${MOLA_GUI_SHOW_TRAJECTORY|true}
     trajectory_rgba: [0.1, 0.1, 0.1, 1.0]
     camera_follows_vehicle: ${MOLA_GUI_CAMERA_FOLLOWS_VEHICLE|true}

--- a/pipelines/lidar3d-dlio-like-worldframe-decimate.yaml
+++ b/pipelines/lidar3d-dlio-like-worldframe-decimate.yaml
@@ -195,7 +195,7 @@ params:
     output_file: ${MOLA_TUM_TRAJECTORY_OUTPUT|'estimated_trajectory.tum'}
 
   visualization:
-    map_update_decimation: 10
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|10}
     show_trajectory: ${MOLA_GUI_SHOW_TRAJECTORY|true}
     trajectory_rgba: [0.1, 0.1, 0.1, 1.0]
     camera_follows_vehicle: ${MOLA_GUI_CAMERA_FOLLOWS_VEHICLE|true}

--- a/pipelines/lidar3d-dlio-like.yaml
+++ b/pipelines/lidar3d-dlio-like.yaml
@@ -155,7 +155,7 @@ params:
     output_file: ${MOLA_TUM_TRAJECTORY_OUTPUT|'estimated_trajectory.tum'}
 
   visualization:
-    map_update_decimation: 10
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|10}
     show_trajectory: ${MOLA_GUI_SHOW_TRAJECTORY|true}
     trajectory_rgba: [0.1, 0.1, 0.1, 1.0]
     camera_follows_vehicle: ${MOLA_GUI_CAMERA_FOLLOWS_VEHICLE|true}

--- a/pipelines/lidar3d-gicp-optimize-twist.yaml
+++ b/pipelines/lidar3d-gicp-optimize-twist.yaml
@@ -145,7 +145,7 @@ params:
   # If run within a mola-cli container, and mola_viz is present, use these options
   # to show live progress:
   visualization:
-    map_update_decimation: 10
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|10}
     show_trajectory: true
     trajectory_rgba: [0.1, 0.1, 0.1, 1.0]
     show_current_observation: false # shows "live deskewed" LiDAR points

--- a/pipelines/lidar3d-gicp-single-filter.yaml
+++ b/pipelines/lidar3d-gicp-single-filter.yaml
@@ -233,7 +233,7 @@ params:
   # If run within a mola-cli container, and mola_viz is present, use these options
   # to show live progress:
   visualization:
-    map_update_decimation: 10
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|10}
     show_trajectory: ${MOLA_GUI_SHOW_TRAJECTORY|true}
     trajectory_rgba: [0.1, 0.1, 0.1, 1.0]
 

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -211,7 +211,7 @@ params:
   # If run within a mola-cli container, and mola_viz is present, use these options
   # to show live progress:
   visualization:
-    map_update_decimation: 10
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|10}
     show_trajectory: ${MOLA_GUI_SHOW_TRAJECTORY|true}
     trajectory_rgba: [0.1, 0.1, 0.1, 1.0]
 

--- a/pipelines/lidar3d-icp.yaml
+++ b/pipelines/lidar3d-icp.yaml
@@ -142,7 +142,7 @@ params:
   # If run within a mola-cli container, and mola_viz is present, use these options
   # to show live progress:
   visualization:
-    map_update_decimation: 10
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|10}
     show_trajectory: true
     show_current_observation: false # shows "live deskewed" LiDAR points
     show_last_deskewed_observations_decay: true # shows "live deskewed" LiDAR points over time

--- a/pipelines/lidar3d-ndt.yaml
+++ b/pipelines/lidar3d-ndt.yaml
@@ -136,7 +136,7 @@ params:
   # If run within a mola-cli container, and mola_viz is present, use these options
   # to show live progress:
   visualization:
-    map_update_decimation: 10
+    map_update_decimation: ${MOLA_GUI_MAP_UPDATE_DECIMATION|10}
     show_trajectory: true
     show_current_observation: false # shows "live raw" LiDAR points
     show_ground_grid: true


### PR DESCRIPTION
Three independent causes of `onLidar` latency, found by profiling `MOLA_LOCALMAP_CLASS=mola::IncrementalPointCloud`. Neither is the incremental k-d tree.

---

## 1. The local-map render ran inline on the LiDAR worker thread

`updateVisualizationLocalMap()` called `state_.local_map->get_visualization()` **inline, inside `onLidar`**. That render recolorizes every point in the map, and under `IncrementalPointCloud` the local map is one flat cloud holding everything inside the eviction cube, so it cost ~55 ms mean / ~120 ms max on GrandTour. It fires only when the map changed and `map_update_decimation` is reached, which is exactly the observed "spike once every N scans".

**Change:** the decimation decision and parameter snapshot stay inline; the render is enqueued on a new `worker_viz_local_map_`, where it takes only `local_map_content_mtx_` and never `state_mtx_`, so the documented lock order still holds.

- A pool of its own rather than the existing `worker_viz_`: with one thread, `POLICY_DROP_OLD` caps the queue at a single pending task, so sharing it would let the per-scan current-observation frames drop the much rarer local-map render before it ever ran.
- The "hide the local map" clear is routed through the same worker so an in-flight render cannot overtake it.
- `worker_viz_local_map_` is drained in `shutdownCleanup()` like the other pools (its task calls back into the visualizer).
- `map_update_decimation` is exposed as `MOLA_GUI_MAP_UPDATE_DECIMATION` in all 18 pipelines (defaults unchanged).

**Measured** (GrandTour `2024-10-01-11-47-44`, 75 s, same 42 renders before and after, so nothing is starved):

| | before | after |
|---|---|---|
| `onLidar` mean / **max** | 33.5 / **155.4 ms** | 31.4 / **66.1 ms** |
| `onLidar.6.updateVisualization` max | 121.4 ms | **3.4 ms** |
| `update_local_map` (inline) mean | 54.8 ms | **5.2 us** |
| `delay_onNewObs_to_process` mean / max | 662 us / 62.7 ms | 30.8 us / 834 us |
| `lidar_queue_length` max | **18** | **1** |
| `.3.run_icp` mean | 10.5 ms | 10.8 ms |
| `.4.update_local_map.insert` mean | 11.6 ms | 12.8 ms |

ICP and local-map insertion are unchanged, confirming the incremental k-d tree's async rebuild was never the bottleneck.

---

## 2. The IMU worker was serialized behind every scan

`processLidarScan()` holds `state_mtx_` across filters, ICP, map update and visualization, while `onIMU()` took the same mutex three times per sample on a single FIFO worker. At 200-400 Hz IMU vs 10 Hz LiDAR the IMU thread was blocked for essentially the whole duration of every scan - its total time tracked `onLidar`'s almost exactly (33.1 s vs 32.7 s). And since `releaseReadyLidarScansToWorker()` is the last statement of `onIMU()`, that wait fed back into scan-submission latency.

**Change:** a new `imu_state_mtx_` guards exactly the state the two threads share - `imu_initializer`, `gravity_estimator`, `map_gravity`, `recent_imu_stamps`, `parameter_source` (variable map, `realize()` flags, and the `localVelocityBuffer` that IMU samples write and the deskew stage reads), and any *invocation* of `obs_generators`. `onIMU()` now takes only this mutex; the LiDAR thread takes it in short windows on top of `state_mtx_`.

It is recursive because those accessors compose (`updatePipelineDynamicVariables` -> `updatePipelineTwistVariables`, `buildGravityPrior` -> `effectiveGravitySigmaRad`); locking at accessor granularity is what keeps the ownership rule reviewable rather than threading a lock object through a dozen signatures.

Lock order: `state_mtx_` -> `local_map_content_mtx_` -> `imu_state_mtx_`. The IMU worker takes only the last and never the local map, so it cannot invert it. `reset()` and `initialize()` replace/rebuild this state wholesale and now take both mutexes.

**Measured** (oxford-spires `2024-03-13-observatory-quarter-01`, 90 s - GrandTour is not usable here, it runs with deskew off; both runs already include change 1):

| | before | after |
|---|---|---|
| `onIMU` mean | 957.1 us | **349.2 us** |
| `onIMU` **max** | 138.6 ms | **9.7 ms** |
| `onIMU` total | 33.1 s | **12.4 s** |
| `onLidar` mean | 37.7 ms | 37.2 ms (unchanged) |
| `spinOnce` mean / max | 13.3 ms / 143.7 ms | 5.7 ms / 109.0 ms |
| `.3.run_icp` mean | 18.6 ms | 17.7 ms |

---

---

## 3. The render held the map mutex for its whole duration

With (1) the render was off the LiDAR thread, but it still held `local_map_content_mtx_` across all of `get_visualization()`, so a scan that had to insert into the map meanwhile waited for it. That wait, not the insertion, set `onLidar`'s max: `onLidar.4.update_local_map` peaked at 179 ms while the insertion it wraps peaked at 59 ms.

**Change:** the render needs a consistent *view* of the map, not access to the live one. `cheapLayerSnapshot()` deep-copies the layers under the mutex, and the recolorize/OpenGL build then runs on that private copy, unlocked. The copy is ~6x cheaper than the render it replaces in the critical section.

Point layers are copied into a plain `CGenericPointsMap` rather than cloned through their own type: `insertAnotherMap()` calls `registerPointFieldsFrom()` (every per-point field survives) and skips non-finite points (the slots `IncrementalPointCloud` blanks on eviction are dropped), and the target has no spatial index to build. Cloning an `IncrementalPointCloud` through its own copy constructor would instead `resetIndex()` — an O(N log N) k-d tree bulk build the renderer never queries. The copy does pick up storage slots that are tombstoned but not reclaimed yet; measured with `MOLA_INCREMENTAL_MAP_DEBUG_STATS` at under 2% of storage (live/storage 0.999 mean, 0.982 worst), and it is the same trade-off `doPublishUpdatedLocalMap()` already makes.

**Measured**, back-to-back on an idle machine, same sequence:

| | before | after |
|---|---|---|
| `onLidar` **max** | **216.1 ms** | **106.7 ms** |
| `onLidar` mean | 38.7 ms | 36.5 ms |
| `.4.update_local_map` max | 179.3 ms | 59.7 ms |
| `.4.update_local_map.insert` max | 58.6 ms | 59.7 ms |
| **implied lock wait (max)** | **~121 ms** | **~0 ms** |
| `update_local_map_copy` (the locked part) | - | 27.2 ms mean |
| `.3.run_icp` mean | 18.2 ms | 17.8 ms |
| `onIMU` mean | 357.5 us | 353.6 us |

`.4.update_local_map` is now equal to the insertion it wraps, i.e. the lock wait is gone. ICP and `onIMU` are unchanged. The render worker pays ~20 ms more per render for the extra copy step, which is off the critical path by construction.

---

## Known residuals

- **The remaining 12.4 s of `onIMU`** is accounted for almost exactly by the two stages that genuinely share those objects - `apply_generators` (3.0 ms/scan) and `deskew_early` (3.8 ms/scan) - plus ~176 us of real per-sample work. Removing it means making `mola::imu::LocalVelocityBuffer` internally thread-safe (it has no mutex today), so `FilterDeskew`'s single `collect_samples_around_reference_time()` snapshot could run concurrently with IMU appends. That is a `mola_imu_preintegration` change; happy to open it as a companion PR.
- **Render decimation was considered and dropped.** It would cut viz-thread CPU, but not the lock hold: the copy is what is under the mutex, and decimating can only be applied *after* a compacted copy exists. It does not address `onLidar`'s max. Easy to add separately if the viz thread ever needs to be cheaper.
- **`onLidar` max is now set by the local-map insertion itself** (`FilterMerge`, ~60 ms max on Spires), with no lock wait left to remove. `MOLA_GUI_MAP_UPDATE_DECIMATION` still lowers how often the render (and its copy) runs at all.

## Testing

- 37/37 package tests pass.
- Both sequences run clean: no errors, no exceptions, identical warning profile before/after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Local-map visualization now renders asynchronously from snapshots, keeping the interface more responsive during map updates.
  - Map rendering preserves update and clear ordering while supporting efficient layer handling.
  - Visualization update frequency can be configured with the `MOLA_GUI_MAP_UPDATE_DECIMATION` environment variable.

- **Bug Fixes**
  - Improved synchronization between LiDAR processing, IMU updates, and visualization.
  - Reduced lock contention during sensor processing and rendering.
  - Improved shutdown handling to ensure background visualization work completes cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->