### PR TITLE
ci: re-enable Rolling and Lyrical stable in CI matrix

### DIFF
--- a/.github/workflows/build-ros.yml
+++ b/.github/workflows/build-ros.yml
@@ -120,9 +120,11 @@ jobs:
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
             http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
             | tee /etc/apt/sources.list.d/ros2.list > /dev/null
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
-            http://packages.ros.org/ros2-testing/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
-            | tee /etc/apt/sources.list.d/ros2-testing.list > /dev/null
+          if [ "${{ matrix.use_ros_testing }}" = "true" ]; then
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
+              http://packages.ros.org/ros2-testing/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
+              | tee /etc/apt/sources.list.d/ros2-testing.list > /dev/null
+          fi
           apt-get update
 
       - name: setup ROS environment

--- a/.github/workflows/build-ros.yml
+++ b/.github/workflows/build-ros.yml
@@ -3,9 +3,9 @@ name: CI Build colcon
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: ["develop"]
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened]
 
 # Minimal GITHUB_TOKEN permissions (principle of least privilege)
 permissions:
@@ -30,15 +30,15 @@ jobs:
       matrix:
         include:
           # Humble Hawksbill (May 2022 - May 2027)
-          #- name: humble stable
+          - name: humble stable
+            docker_image: ros:humble
+            ros_distribution: humble
+            use_ros_testing: false
+
+          #- name: humble testing
           #  docker_image: ubuntu:jammy
           #  ros_distribution: humble
-          #  use_ros_testing: false
-
-          - name: humble testing
-            docker_image: ubuntu:jammy
-            ros_distribution: humble
-            use_ros_testing: true
+          #  use_ros_testing: true
 
           # Jazzy Jalisco (May 2024 - May 2029)
           - name: jazzy stable
@@ -52,12 +52,13 @@ jobs:
             use_ros_testing: true
             coverage_run: true
           # Rolling Ridley (No End-Of-Life)
-          # TODO: migrate to ubuntu:resolute once rolling packages are published there.
+          # ros:rolling tracks whatever Ubuntu base upstream currently targets,
+          # so this does not need to be re-pinned as that migrates over time.
           # Track: https://discourse.openrobotics.org/t/preparing-for-rolling-sync-2026-04-23/54223
-          #- name: rolling stable
-          #  docker_image: ubuntu:noble
-          #  ros_distribution: rolling
-          #  use_ros_testing: false
+          - name: rolling stable
+            docker_image: ros:rolling
+            ros_distribution: rolling
+            use_ros_testing: false
 
           #- name: rolling testing
           #  docker_image: ubuntu:noble
@@ -70,14 +71,11 @@ jobs:
           #  use_ros_testing: true
           #  coverage_run: true
 
-          # Lyrical Luth (May 2026 - May 2031, LTS)
-          # Beta packages available on resolute; GA release expected May 22, 2026.
-          # allow_failure until GA is released.
-          #- name: lyrical testing (allow failure)
-          #  docker_image: ubuntu:resolute
-          #  ros_distribution: lyrical
-          #  use_ros_testing: true
-          #  allow_failure: true
+          # Lyrical Luth (May 2026 - May 2031, LTS), GA released May 22, 2026.
+          - name: lyrical stable
+            docker_image: ubuntu:resolute
+            ros_distribution: lyrical
+            use_ros_testing: false
 
     container:
       image: ${{ matrix.docker_image }}
@@ -225,7 +223,7 @@ jobs:
     if: >
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [ self-hosted, Linux, ARM64 ]
+    runs-on: [self-hosted, Linux, ARM64]
     env:
       DEBIAN_FRONTEND: noninteractive
 

--- a/agents.md
+++ b/agents.md
@@ -528,7 +528,11 @@ We use colcon, the ROS2 build tool, and mola_common with utility cmake helpers.
 
 - **Framework**: CMake + GTest
 - Each package has `tests/` with its own `CMakeLists.txt`
-- CI/CD: `.github/workflows/` — builds on ROS 2 Humble, Jazzy, Kilted, Rolling
+- CI/CD: `.github/workflows/build-ros.yml` — builds on ROS 2 Humble, Jazzy, Rolling,
+  Lyrical (stable channel; "testing" variants exist commented-out per distro).
+  "Stable" entries on GitHub-hosted runners need a prebuilt `ros:<distro>` image
+  (or the manual `ubuntu:resolute` setup for pre-buildfarm distros like Lyrical):
+  the `setup ROS environment` step only runs when `use_ros_testing: true`.
 - Style: enforced with `.clang-format` and `.clang-tidy`
 
 ## Code style

--- a/agents.md
+++ b/agents.md
@@ -528,11 +528,14 @@ We use colcon, the ROS2 build tool, and mola_common with utility cmake helpers.
 
 - **Framework**: CMake + GTest
 - Each package has `tests/` with its own `CMakeLists.txt`
-- CI/CD: `.github/workflows/build-ros.yml` — builds on ROS 2 Humble, Jazzy, Rolling,
-  Lyrical (stable channel; "testing" variants exist commented-out per distro).
-  "Stable" entries on GitHub-hosted runners need a prebuilt `ros:<distro>` image
-  (or the manual `ubuntu:resolute` setup for pre-buildfarm distros like Lyrical):
-  the `setup ROS environment` step only runs when `use_ros_testing: true`.
+- CI/CD: `.github/workflows/build-ros.yml` has two matrices. GitHub-hosted
+  (x86_64) runs Humble/Jazzy/Rolling/Lyrical stable plus Jazzy testing+coverage;
+  Humble and Rolling testing entries exist commented-out, Lyrical has none.
+  There, `setup ROS environment` only runs for testing entries, so stable ones
+  need a prebuilt `ros:<distro>` image (or the manual `ubuntu:resolute` setup
+  used for pre-buildfarm distros like Lyrical). Self-hosted (arm64) only covers
+  Humble/Jazzy, each stable + testing, and runs `setup ROS environment`
+  unconditionally for both.
 - Style: enforced with `.clang-format` and `.clang-tidy`
 
 ## Code style


### PR DESCRIPTION
## Summary
- Re-enable `rolling stable` and add `lyrical stable` (Lyrical Luth GA shipped May 22, 2026) to the GitHub-hosted CI matrix, using `ros:rolling` and `ubuntu:resolute` respectively.
- Fix a latent bug found while wiring this up: the `setup ROS environment` step only runs `if: matrix.use_ros_testing == true`, so a "stable" entry on a raw `ubuntu:*` image never gets ROS installed at all. `humble stable` (just switched from `humble testing`) hit this gap; switched it to the prebuilt `ros:humble` image, same pattern already used for `jazzy stable`. `rolling stable` gets the same treatment via `ros:rolling`.
- `lyrical stable` stays on `ubuntu:resolute` with the existing manual apt-based ROS setup (the `ros-tooling/setup-ros` action calls `apt-key`, which is gone on Ubuntu 26.04).
- Synced `agents.md`'s CI distro list with the actual matrix (it referenced Kilted, never in this workflow, and predated Rolling/Lyrical/the stable-vs-testing split).

## Test plan
- [ ] CI matrix run (`x86_64 / humble stable`, `x86_64 / jazzy stable`, `x86_64 / rolling stable`, `x86_64 / lyrical stable`) all install ROS successfully and pass tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated ROS 2 build coverage for supported stable and testing distributions, including Rolling and Lyrical.
  * Improved ARM64 and x86_64 runner configuration.
  * Refined ROS testing environment setup for applicable build scenarios.

* **Documentation**
  * Clarified supported ROS 2 distributions and build matrices.
  * Documented stable and testing image requirements, including prebuilt ROS and manual Ubuntu environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->