### PR TITLE
Added mola_bridge_ros2 as runtime dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -65,6 +65,7 @@
   <!-- Needed by the mola-lo-* scripts: -->
   <exec_depend>mola_launcher</exec_depend>
   <exec_depend>mola_viz</exec_depend>
+  <exec_depend>mola_bridge_ros2</exec_depend>
 
   <!-- Test datasets to run on them: -->
   <test_depend>mola_test_datasets</test_depend>


### PR DESCRIPTION
I tried the `mola-cli-launchs/lidar_odometry_ros2.yaml` runtime configuration, and it loads `mola::BridgeROS2`, but `mola_bridge_ros2` is not declared in `package.xml`. As a result, `rosdep install` does not install the bridge
and `mola-cli` fails at startup.

I added `mola_bridge_ros2` as an `exec_depend`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the ROS 2 bridge execution dependency required for the package to run correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->