### PR TITLE
Fuse IMU into a scan by timestamp, not by arrival order

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -177,11 +177,12 @@ Incoming LiDAR scans reach a single worker thread (`worker_lidar_`) via
 `onNewObservation` -> `sendLidarScanToProcessQueue`
 (`LidarOdometry_SensorCallbacks.cpp`). Two routes:
 
-- **LO (no IMU de-skew):** the scan is ready immediately and goes straight to
+- **No IMU received (yet):** the scan is ready immediately and goes straight to
   `submitReadyLidarScanToWorker()`.
-- **LIO (IMU de-skew):** the scan is parked on `worker_lidar_wait_for_imu_list_`
-  until IMU data covering its whole time span has arrived; `onIMUImpl` then
-  submits the now-ready scans via the same `submitReadyLidarScanToWorker()`.
+- **With IMU:** the scan is parked on `worker_lidar_wait_for_imu_list_` until IMU
+  data covering its whole time span has arrived; `onIMUImpl` then submits the
+  now-ready scans via the same `submitReadyLidarScanToWorker()`. See
+  "Timestamp-driven LiDAR/IMU synchronization" below.
 
 `submitReadyLidarScanToWorker()` implements a **"drop stale, keep freshest"**
 policy against a single pending slot (`worker_lidar_pending_fresh_scan_`): if the
@@ -268,7 +269,29 @@ it is the same trade-off `doPublishUpdatedLocalMap()` already makes.
 The render worker pays ~20 ms more per render for the extra copy step, which is
 fine: it is off the critical path by construction.
 
-## `imu_state_mtx_`: the IMU worker no longer waits on the LiDAR worker
+## Timestamp-driven LiDAR/IMU synchronization
+
+IMU readings are **not** consumed when they arrive. `onIMUImpl()` only appends
+them to `pending_imu_` (`PendingImuBuffer`, `ImuScanSync.h`) and updates
+`latest_imu_time_`, inline on the sensor-input thread. A scan is held on
+`worker_lidar_wait_for_imu_list_` (`ScanImuWaitList`) until `latest_imu_time_`
+reaches the scan's own coverage end (its timestamp plus the estimated scan
+period, frozen when the scan is parked). `processLidarScan()` then calls
+`consumePendingImu()`, which feeds every buffered sample up to that same time,
+in timestamp order, into the de-skew velocity buffer, the pitch/roll
+calibrator and the gravity estimators.
+
+The IMU samples a scan sees are therefore a function of the timestamps alone,
+never of how the sensor callbacks interleaved, which is what makes two identical
+offline runs produce identical trajectories. `mola_state_estimation_simple`
+buffers IMU readings the same way for the same reason.
+
+Limits: the gate only engages after the first IMU reading, so scans preceding it
+are processed straight away; and if the IMU stops, waiting scans are dropped by
+`params_.max_lidar_queue_before_drop` as before. Reproducibility also assumes no
+scan is dropped for overload, which is the offline case.
+
+## `imu_state_mtx_`: the sensor input no longer waits on the LiDAR worker
 
 `processLidarScan()` holds `state_mtx_` for its whole body, so an `onIMU()` that
 also took `state_mtx_` blocked for the duration of every scan. At 200-400 Hz IMU
@@ -278,8 +301,8 @@ exactly (33.1 s vs 32.7 s on Oxford Spires), and since
 straight back into scan-submission latency.
 
 `imu_state_mtx_` (recursive) now guards exactly the state the two threads share:
-`imu_initializer`, `gravity_estimator`, `map_gravity`, `recent_imu_stamps`,
-`parameter_source` (variable map, `realize()` flags, and the
+`pending_imu_`, `imu_initializer`, `gravity_estimator`, `map_gravity`,
+`recent_imu_stamps`, `parameter_source` (variable map, `realize()` flags, and the
 `localVelocityBuffer` that IMU samples write and the deskew stage reads), and
 any *invocation* of `obs_generators`. `onIMU()` takes only this mutex; the LiDAR
 thread takes it in short windows on top of `state_mtx_`. Result on the same
@@ -295,7 +318,7 @@ Removing it means making `mola::imu::LocalVelocityBuffer` internally thread-safe
 appends; that is a `mola_imu_preintegration` change, not one for this repo.
 
 Full lock order: `state_mtx_` -> `local_map_content_mtx_` -> `imu_state_mtx_`.
-Never the reverse. The IMU worker takes only `imu_state_mtx_` and the local-map
+Never the reverse. The sensor input takes only `imu_state_mtx_` and the local-map
 render worker only `local_map_content_mtx_`, so neither can invert it. Anything
 that replaces `state_` wholesale (`reset()`) or rebuilds the pipelines
 (`initialize()`) must hold `state_mtx_` **and** `imu_state_mtx_`.

--- a/module/include/mola_lidar_odometry/ImuScanSync.h
+++ b/module/include/mola_lidar_odometry/ImuScanSync.h
@@ -40,10 +40,13 @@ public:
   PendingImuBuffer() = default;
 
   /** Stores one observation, then drops everything older than `maxAge` seconds
-   *  relative to the newest sample held. */
+   *  relative to the newest sample held.
+   *  A multimap, so that two readings sharing a timestamp are both kept: which
+   *  of them is "the" reading for that instant is undecidable, and dropping one
+   *  would silently discard data the previous code did use. */
   void add(double timestamp, const mrpt::obs::CObservationIMU::ConstPtr & imu, double maxAge)
   {
-    samples_[timestamp] = imu;
+    samples_.emplace(timestamp, imu);
 
     const double oldestToKeep = samples_.rbegin()->first - maxAge;
     samples_.erase(samples_.begin(), samples_.lower_bound(oldestToKeep));
@@ -69,7 +72,7 @@ public:
   std::size_t size() const { return samples_.size(); }
 
 private:
-  std::map<double /*timestamp*/, mrpt::obs::CObservationIMU::ConstPtr> samples_;
+  std::multimap<double /*timestamp*/, mrpt::obs::CObservationIMU::ConstPtr> samples_;
 };
 
 /** Holds LiDAR scans back until the IMU covering their whole time span has been

--- a/module/include/mola_lidar_odometry/ImuScanSync.h
+++ b/module/include/mola_lidar_odometry/ImuScanSync.h
@@ -1,0 +1,132 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   ImuScanSync.h
+ * @brief  Timestamp-based synchronization between the LiDAR and IMU inputs
+ * @author Jose Luis Blanco Claraco
+ */
+#pragma once
+
+#include <mrpt/obs/CObservation.h>
+#include <mrpt/obs/CObservationIMU.h>
+
+#include <map>
+#include <vector>
+
+namespace mola
+{
+/** Holds IMU observations until the LiDAR scan that needs them is processed.
+ *
+ *  Which samples a scan gets is decided by their timestamps alone, so it does
+ *  not matter on which thread, or in which order, the samples were delivered.
+ *
+ * \ingroup mola_lidar_odometry_grp
+ */
+class PendingImuBuffer
+{
+public:
+  PendingImuBuffer() = default;
+
+  /** Stores one observation, then drops everything older than `maxAge` seconds
+   *  relative to the newest sample held. */
+  void add(double timestamp, const mrpt::obs::CObservationIMU::ConstPtr & imu, double maxAge)
+  {
+    samples_[timestamp] = imu;
+
+    const double oldestToKeep = samples_.rbegin()->first - maxAge;
+    samples_.erase(samples_.begin(), samples_.lower_bound(oldestToKeep));
+  }
+
+  /** Removes and returns every sample with a timestamp not newer than
+   *  `upToTime`, in timestamp order. */
+  std::vector<mrpt::obs::CObservationIMU::ConstPtr> take_up_to(double upToTime)
+  {
+    const auto itEnd = samples_.upper_bound(upToTime);
+
+    std::vector<mrpt::obs::CObservationIMU::ConstPtr> ret;
+    ret.reserve(static_cast<std::size_t>(std::distance(samples_.begin(), itEnd)));
+    for (auto it = samples_.begin(); it != itEnd; ++it) {
+      ret.push_back(it->second);
+    }
+    samples_.erase(samples_.begin(), itEnd);
+    return ret;
+  }
+
+  void clear() { samples_.clear(); }
+
+  std::size_t size() const { return samples_.size(); }
+
+private:
+  std::map<double /*timestamp*/, mrpt::obs::CObservationIMU::ConstPtr> samples_;
+};
+
+/** Holds LiDAR scans back until the IMU covering their whole time span has been
+ *  received, so a scan always runs against a fixed set of IMU samples.
+ *
+ *  Pure timestamp bookkeeping: no threads, no locks, no clocks.
+ *
+ * \ingroup mola_lidar_odometry_grp
+ */
+class ScanImuWaitList
+{
+public:
+  ScanImuWaitList() = default;
+
+  struct Entry
+  {
+    mrpt::obs::CObservation::ConstPtr obs;
+    /// Sensor time [s] up to which this scan needs IMU data, i.e. its estimated
+    /// end of sweep. Frozen when the scan enters the list, so release and
+    /// consumption always agree on the same window.
+    double imu_coverage_end_time = 0;
+  };
+
+  void add(double scanTimestamp, const Entry & e) { list_.emplace(scanTimestamp, e); }
+
+  /** Removes and returns, in timestamp order, every scan whose IMU window is
+   *  already covered by data received up to `latestImuTime`. */
+  std::vector<Entry> take_ready(double latestImuTime)
+  {
+    std::vector<Entry> ret;
+    for (auto it = list_.begin(); it != list_.end();) {
+      if (latestImuTime < it->second.imu_coverage_end_time) {
+        // The list is sorted by timestamp: no later scan can qualify either.
+        break;
+      }
+      ret.push_back(it->second);
+      it = list_.erase(it);
+    }
+    return ret;
+  }
+
+  /** Drops the oldest scans until at most `maxSize` remain.
+   *  \return How many were dropped. */
+  std::size_t trim_to(std::size_t maxSize)
+  {
+    std::size_t dropped = 0;
+    while (list_.size() > maxSize) {
+      list_.erase(list_.begin());
+      dropped++;
+    }
+    return dropped;
+  }
+
+  std::size_t size() const { return list_.size(); }
+
+private:
+  std::multimap<double /*scan timestamp*/, Entry> list_;
+};
+
+}  // namespace mola

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -53,6 +53,7 @@
  *  freezing it from a single accelerometer average at the first keyframe. */
 #define MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR 1
 #endif
+#include <mola_lidar_odometry/ImuScanSync.h>
 #include <mola_lidar_odometry/KeyframeDecider.h>
 
 // MP2P_ICP
@@ -938,8 +939,8 @@ private:
     // ------ ^^^ end of these flags are protected ^^^^      ---------
 
     // All other fields are protected by state_mtx_, EXCEPT the ones marked
-    // below as protected by imu_state_mtx_ (the state the IMU worker thread
-    // feeds; see that mutex's docs for the full list and the lock order).
+    // below as protected by imu_state_mtx_ (the IMU-derived state; see that
+    // mutex's docs for the full list and the lock order).
 
     // will be true after the first incoming LiDAR frame and re-localization is enabled and run
     bool initial_localization_done = false;
@@ -1215,19 +1216,23 @@ private:
   mrpt::WorkerThreadsPool worker_lidar_{
     1 /*num threads*/, mrpt::WorkerThreadsPool::POLICY_DROP_OLD, "worker_lidar"};
 
-  std::multimap<double /*timestamp*/, CObservation::ConstPtr> worker_lidar_wait_for_imu_list_;
+  ScanImuWaitList worker_lidar_wait_for_imu_list_;
   std::mutex worker_lidar_wait_for_imu_list_mtx_;
 
-  /// Timestamp (seconds, sensor clock) up to which IMU data has actually been
-  /// *fed* into the de-skew LocalVelocityBuffer (updated at the end of the IMU
-  /// feeding in onIMUImpl). A waiting scan may only be released to the worker
-  /// once this passes its own timestamp by one scan period, i.e. once the IMU
-  /// covering the scan's whole span is available for de-skew. Kept as an atomic
-  /// so the wait-list can be drained (see releaseReadyLidarScansToWorker) from
-  /// the sensor-input thread too, without waiting for the (FIFO, possibly
-  /// backed-up) IMU worker to run its own drain -- decoupling scan release from
-  /// IMU-processing latency.
-  std::atomic<double> latest_fed_imu_time_{0};
+  /// Newest timestamp (seconds, sensor clock) present in pending_imu_. A
+  /// waiting scan may only be released to the worker once this reaches the
+  /// scan's own IMU coverage end time, i.e. once every IMU sample the scan will
+  /// consume has actually been received. Kept as an atomic so the wait list can
+  /// be drained (see releaseReadyLidarScansToWorker) from the sensor-input
+  /// thread too, without waiting for the LiDAR worker to become free.
+  std::atomic<double> latest_imu_time_{0};
+
+  /// IMU observations received but not consumed yet. They are consumed by
+  /// consumePendingImu(), from the LiDAR worker thread, right before the scan
+  /// that needs them is processed, so which samples enter the IMU-derived state
+  /// depends on timestamps only and not on how the sensor callbacks interleave.
+  /// Protected by imu_state_mtx_.
+  PendingImuBuffer pending_imu_;
 
   /// Cached estimate of the LiDAR scan period [s], read lock-free by
   /// releaseReadyLidarScansToWorker(). Estimated from consecutive scan *arrival*
@@ -1349,22 +1354,24 @@ private:
   mutable std::mutex state_flags_mtx_;
   mutable std::mutex state_mtx_;
 
-  /// Guards the state shared between the IMU worker thread and the LiDAR
-  /// worker thread, so the former no longer has to wait on state_mtx_, which
+  /// Guards the IMU-derived state, which the sensor-input thread appends to
+  /// (pending_imu_, recent_imu_stamps) while the LiDAR worker thread consumes
+  /// it, so the former no longer has to wait on state_mtx_, which
   /// processLidarScan() holds for its whole body (filters, ICP, map update,
-  /// visualization). At 200 Hz IMU / 10 Hz LiDAR that made the IMU thread block
-  /// for essentially the entire duration of every scan, and since
+  /// visualization). At 200 Hz IMU / 10 Hz LiDAR that made the input thread
+  /// block for essentially the entire duration of every scan, and since
   /// releaseReadyLidarScansToWorker() runs at the end of onIMU(), that wait fed
   /// straight back into scan submission latency.
   ///
-  /// Covers, in MethodState: imu_initializer, gravity_estimator, map_gravity,
-  /// recent_imu_stamps, parameter_source (its variable map, the realize()
-  /// "evaluated" flags, and localVelocityBuffer), and any *invocation* of
-  /// obs_generators (which writes the velocity buffer and reads those flags).
+  /// Covers pending_imu_ and, in MethodState: imu_initializer,
+  /// gravity_estimator, map_gravity, recent_imu_stamps, parameter_source (its
+  /// variable map, the realize() "evaluated" flags, and localVelocityBuffer),
+  /// and any *invocation* of obs_generators (which writes the velocity buffer
+  /// and reads those flags).
   ///
   /// Lock order: state_mtx_ -> local_map_content_mtx_ -> imu_state_mtx_; never
-  /// the reverse. The IMU worker takes only this one (and never the local map),
-  /// so it cannot invert the order.
+  /// the reverse. The sensor-input thread takes only this one (and never the
+  /// local map), so it cannot invert the order.
   ///
   /// Recursive because the accessors that take it compose (e.g.
   /// updatePipelineDynamicVariables() -> updatePipelineTwistVariables(),
@@ -1375,7 +1382,7 @@ private:
 
   /// Guards the *contents* (layers) of MethodState::local_map.
   /// Rendering the map is O(map size) and would stall every other user of
-  /// state_mtx_ (dataset reader, IMU worker, executor thread) if done under it,
+  /// state_mtx_ (dataset reader, sensor input, executor thread) if done under it,
   /// so the render runs on worker_viz_local_map_ and takes only this one.
   /// Lock order: a thread that needs both must take state_mtx_ first; it must
   /// never be held while acquiring state_mtx_.
@@ -1414,11 +1421,21 @@ private:
   /// report the "delay_onNewObs_to_process" queueing-delay metric); it cannot
   /// be measured via profiler_.enter()/leave() here since worker_lidar_'s
   /// POLICY_DROP_OLD may discard a queued scan before it ever runs onLidar().
-  void onLidar(const CObservation::ConstPtr & o, double readyTimestamp);
-  void processLidarScan(const CObservation::ConstPtr & obs);
+  void onLidar(
+    const CObservation::ConstPtr & o, double readyTimestamp,
+    std::optional<double> imuCoverageEndTime);
+  void processLidarScan(
+    const CObservation::ConstPtr & obs, std::optional<double> imuCoverageEndTime);
 
   void onIMU(const CObservation::ConstPtr & o);
   void onIMUImpl(const CObservation::ConstPtr & o);
+
+  /** Feeds every pending IMU observation with a timestamp not newer than
+   *  `upToTime` into the IMU-derived state (de-skew velocity buffer, initial
+   *  pitch/roll calibrator, gravity estimators), in timestamp order, and drops
+   *  them from pending_imu_.
+   *  Caller must hold state_mtx_. */
+  void consumePendingImu(double upToTime);
 
   void onGPS(const CObservation::ConstPtr & o);
   void onGPSImpl(const CObservation::ConstPtr & o);
@@ -1512,14 +1529,15 @@ private:
    *  busy, this call replaces any older not-yet-started scan still queued
    *  behind it. This method only adds the drop-stats bookkeeping the pool
    *  itself doesn't provide. Safe to call from any thread. */
-  void submitReadyLidarScanToWorker(const CObservation::ConstPtr & o);
+  void submitReadyLidarScanToWorker(
+    const CObservation::ConstPtr & o, std::optional<double> imuCoverageEndTime);
   /// Number of LiDAR scans currently running or queued on worker_lidar_ (0, 1, or 2).
   int pendingLidarScanCount() const;
 
   /** Releases to the worker every LiDAR scan on worker_lidar_wait_for_imu_list_
-   *  whose whole time span is already covered by IMU data fed into the de-skew
-   *  buffer (i.e. latest_fed_imu_time_ is more than one scan period past the
-   *  scan timestamp). On an IMU catch-up burst several scans can qualify at
+   *  whose whole time span is already covered by received IMU data (i.e.
+   *  latest_imu_time_ has reached the scan's own IMU coverage end time).
+   *  On an IMU catch-up burst several scans can qualify at
    *  once; only the freshest is submitted (the pool would drop the rest anyway).
    *  Takes no heavy locks (only the wait-list mutex + atomics), so it can run on
    *  the sensor-input thread while onLidar holds state_mtx_; this decouples scan

--- a/module/src/LidarOdometry_GUI.cpp
+++ b/module/src/LidarOdometry_GUI.cpp
@@ -1177,7 +1177,7 @@ void LidarOdometry::updateVisualizationTextLabels()
     state_.adapt_thres_sigma, state_.last_icp_iterations));
 
   {
-    // recent_imu_stamps is appended by the IMU worker thread:
+    // recent_imu_stamps is appended by the sensor-input thread:
     auto lckImu = mrpt::lockHelper(imu_state_mtx_);
     const auto [rate_lidar, rate_imu, rate_gnss] = state_.get_sensor_rates();
     gui_.lbSensorRates->set(mrpt::format(

--- a/module/src/LidarOdometry_InitialLocalization.cpp
+++ b/module/src/LidarOdometry_InitialLocalization.cpp
@@ -91,7 +91,7 @@ void LidarOdometry::handleInitialLocalization()
       // INITIALIZATION FROM IMU FOR PITCH & ROLL ONLY
       // ---------------------------------------------------
     case mola::InitLocalization::PitchAndRollFromIMU: {
-      // imu_initializer is created here but fed by the IMU worker thread:
+      // imu_initializer is created here but fed from the LiDAR worker thread:
       auto lckImu = mrpt::lockHelper(imu_state_mtx_);
 
       // Construct the IMU averager object:

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -60,7 +60,7 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
   {
     auto lckState = mrpt::lockHelper(state_mtx_);
     // This block builds the generators/pipelines and attaches them to the
-    // parameter source, all of which the IMU worker thread reaches without
+    // parameter source, all of which the sensor-input thread reaches without
     // state_mtx_ (sensors may already be feeding by now):
     auto lckImu = mrpt::lockHelper(imu_state_mtx_);
 

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -213,10 +213,12 @@ void LidarOdometry::reset()
   {
     auto lck = mrpt::lockHelper(state_mtx_);
     // Replacing state_ wholesale also destroys the parameter source, the
-    // gravity estimator and the rest of the IMU-fed state, which the IMU worker
+    // gravity estimator and the rest of the IMU-derived state, which the input
     // thread reaches without state_mtx_:
     auto lckImu = mrpt::lockHelper(imu_state_mtx_);
     state_ = MethodState();
+    pending_imu_.clear();
+    latest_imu_time_ = 0;
   }
   initialize(lastInitConfig_);
 }

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -220,6 +220,11 @@ void LidarOdometry::reset()
     pending_imu_.clear();
     latest_imu_time_ = 0;
   }
+  {
+    // Scans still waiting for IMU belong to the pre-reset session:
+    auto lck = mrpt::lockHelper(worker_lidar_wait_for_imu_list_mtx_);
+    worker_lidar_wait_for_imu_list_.trim_to(0);
+  }
   initialize(lastInitConfig_);
 }
 

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -275,7 +275,8 @@ double LidarOdometry::effectiveGravitySigmaRad() const
 }
 
 // here happens the main stuff:
-void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOLINT
+void LidarOdometry::processLidarScan(  // NOLINT
+  const CObservation::ConstPtr & obs, const std::optional<double> imuCoverageEndTime)
 {
   using namespace std::string_literals;
 
@@ -320,6 +321,15 @@ void LidarOdometry::processLidarScan(const CObservation::ConstPtr & obs)  // NOL
   const auto this_obs_tim = obs->timestamp;
 
   std::unique_lock<std::mutex> lckState(state_mtx_);
+
+  // Feed all the IMU data belonging to this scan's time span into the
+  // IMU-derived state, in timestamp order, before anything reads it. The scan
+  // was held back until that data existed (see sendLidarScanToProcessQueue),
+  // so the set of samples consumed here is fixed by the timestamps alone:
+  if (imuCoverageEndTime) {
+    const ProfilerEntry tleImu(profiler_, "onLidar.0.consume_imu");
+    consumePendingImu(*imuCoverageEndTime);
+  }
 
   // for rate stats:
   state_.append_lidar_stamp(obs->sensorLabel, obs->timestamp, *this);

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -287,6 +287,11 @@ void LidarOdometry::processLidarScan(  // NOLINT
   // entry for this scan.
   struct OnLidarTimeMetricReporter
   {
+    // Deleting the copy/move members below makes this a non-aggregate, so it
+    // needs an explicit constructor for the brace initialization used at the
+    // end of the struct.
+    explicit OnLidarTimeMetricReporter(LidarOdometry * s) : self(s) {}
+
     OnLidarTimeMetricReporter(const OnLidarTimeMetricReporter &) = delete;
     OnLidarTimeMetricReporter & operator=(const OnLidarTimeMetricReporter &) = delete;
     OnLidarTimeMetricReporter(OnLidarTimeMetricReporter &&) = delete;

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -38,6 +38,14 @@
 namespace mola
 {
 
+namespace
+{
+/// Age [s], relative to the newest buffered reading, beyond which an unconsumed
+/// IMU observation is dropped. Only reached when no LiDAR scan is being
+/// processed, since each scan consumes everything up to its own end of sweep.
+constexpr double kPendingImuMaxAge = 2.0;
+}  // namespace
+
 void LidarOdometry::onNewObservation(const CObservation::ConstPtr & o)
 {
   MRPT_TRY_START
@@ -74,14 +82,12 @@ void LidarOdometry::onNewObservation(const CObservation::ConstPtr & o)
   if (
     params_.imu_sensor_label &&
     std::regex_match(o->sensorLabel, params_.imu_sensor_label.value())) {
-    {
-      auto lck = mrpt::lockHelper(is_busy_mtx_);
-      state_.worker_tasks_others++;
-    }
-
-    // Yes, it's an IMU obs:
-    auto fut = worker_others_.enqueue(&LidarOdometry::onIMU, this, o);
-    (void)fut;
+    // Yes, it's an IMU obs. Handled inline, not on a worker: onIMU() only
+    // buffers the reading, and doing so in the caller's thread is what keeps
+    // the buffer contents (and hence which scans are ready to run) a function
+    // of the input sequence alone. The costly part of using an IMU reading
+    // happens later, on the LiDAR worker thread, in consumePendingImu().
+    onIMU(o);
   }
 
   // Is it GNSS?
@@ -122,20 +128,28 @@ int LidarOdometry::pendingLidarScanCount() const
 
 void LidarOdometry::sendLidarScanToProcessQueue(const CObservation::ConstPtr & o)
 {
-  // Two routes to the single worker thread, depending on whether the pipeline
-  // needs IMU data for de-skew:
-  //  - No IMU needed: the scan is ready right away -> hand it to the worker.
-  //  - IMU needed:    park it on the wait list until IMU data covering the whole
-  //                   scan time span has arrived (see onIMUImpl), then submit.
+  // Two routes to the single worker thread, depending on whether an IMU is in
+  // use at all:
+  //  - No IMU: the scan is ready right away -> hand it to the worker.
+  //  - IMU:    park it on the wait list until IMU data covering the whole scan
+  //            time span has been received (see onIMUImpl), then submit.
+  // The gate is what makes the IMU-derived state a function of the observation
+  // timestamps alone: the scan consumes exactly the IMU samples within its own
+  // span (see consumePendingImu), and it only runs once all of them exist, so
+  // the result no longer depends on how the sensor callbacks interleave.
   // In both cases the worker pool (POLICY_DROP_OLD) applies a "drop stale, keep
   // freshest" policy, so under overload old scans are skipped and only the
   // newest ready one is processed, keeping latency low.
 
-  if (!isPipelineUsingIMU()) {
+  // The wait list only makes sense once IMU data is actually flowing in: with
+  // no IMU there is nothing to wait for, and holding scans back would stall the
+  // odometry altogether. IMU readings are buffered inline by onNewObservation(),
+  // so this test is decided by the input sequence, not by thread scheduling.
+  if (latest_imu_time_.load() <= 0) {
     profiler_.registerUserMeasure(
       "onNewObservation.lidar_queue_length", static_cast<double>(pendingLidarScanCount()));
 
-    submitReadyLidarScanToWorker(o);
+    submitReadyLidarScanToWorker(o, std::nullopt);
     return;
   }
 
@@ -144,7 +158,6 @@ void LidarOdometry::sendLidarScanToProcessQueue(const CObservation::ConstPtr & o
   size_t waitListSize = 0;
   {
     auto lck = mrpt::lockHelper(worker_lidar_wait_for_imu_list_mtx_);
-    worker_lidar_wait_for_imu_list_.emplace(thisStamp, o);
 
     // Estimate the scan period from consecutive *arrival* timestamps (EMA), so
     // it reflects the true sensor rate even while scans are being dropped:
@@ -157,20 +170,23 @@ void LidarOdometry::sendLidarScanToProcessQueue(const CObservation::ConstPtr & o
     }
     last_lidar_arrival_stamp_ = thisStamp;
 
+    // The scan's IMU window ends at its estimated end of sweep:
+    worker_lidar_wait_for_imu_list_.add(thisStamp, {o, thisStamp + lidar_scan_period_.load()});
+
     // Safety cap: if IMU data lags badly, keep the wait list from growing without
     // bound by dropping the oldest still-waiting scans (they would be the most
     // stale ones anyway):
-    while (worker_lidar_wait_for_imu_list_.size() > params_.max_lidar_queue_before_drop) {
-      worker_lidar_wait_for_imu_list_.erase(worker_lidar_wait_for_imu_list_.begin());
+    const auto nDropped =
+      worker_lidar_wait_for_imu_list_.trim_to(params_.max_lidar_queue_before_drop);
+    for (std::size_t i = 0; i < nDropped; i++) {
       addDropStats(true);
       profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
     }
     waitListSize = worker_lidar_wait_for_imu_list_.size();
   }
 
-  // The IMU covering this or an earlier scan may already have been fed to the
-  // de-skew buffer, so try to release now instead of waiting for the next IMU
-  // callback (which may be stuck behind onLidar on the IMU worker thread):
+  // The IMU covering this or an earlier scan may already have been received,
+  // so try to release now instead of waiting for the next IMU callback:
   releaseReadyLidarScansToWorker();
 
   const int queued = pendingLidarScanCount() + static_cast<int>(waitListSize);
@@ -179,30 +195,17 @@ void LidarOdometry::sendLidarScanToProcessQueue(const CObservation::ConstPtr & o
 
 void LidarOdometry::releaseReadyLidarScansToWorker()
 {
-  const double fedImuTime = latest_fed_imu_time_.load();
-  if (fedImuTime <= 0) {
-    return;  // no IMU fed yet: nothing can be de-skewed/released
+  const double imuTime = latest_imu_time_.load();
+  if (imuTime <= 0) {
+    return;  // no IMU received yet: nothing can be released
   }
-  const double lidar_scan_period = lidar_scan_period_.load();
 
-  // Collect every waiting scan whose whole span is already covered by fed IMU
-  // data (fedImuTime more than one scan period past the scan timestamp), in
-  // chronological order, then submit outside the wait-list lock:
-  std::vector<CObservation::ConstPtr> readyScans;
-  {
+  // Collect every waiting scan whose whole span is already covered by received
+  // IMU data, in chronological order, then submit outside the wait-list lock:
+  const std::vector<ScanImuWaitList::Entry> readyScans = [&]() {
     auto lck = mrpt::lockHelper(worker_lidar_wait_for_imu_list_mtx_);
-    for (auto it = worker_lidar_wait_for_imu_list_.begin();
-         it != worker_lidar_wait_for_imu_list_.end();) {
-      const auto [lidarTim, lidarObs] = *it;
-      if (fedImuTime - lidarTim > lidar_scan_period) {
-        readyScans.push_back(lidarObs);
-        it = worker_lidar_wait_for_imu_list_.erase(it);
-      } else {
-        // The list is sorted by timestamp: no later scan can qualify either.
-        break;
-      }
-    }
-  }
+    return worker_lidar_wait_for_imu_list_.take_ready(imuTime);
+  }();
 
   // On an IMU catch-up burst several scans can qualify at once, but only the
   // newest matters ("keep freshest"): drop-account the older ones directly
@@ -212,11 +215,12 @@ void LidarOdometry::releaseReadyLidarScansToWorker()
       addDropStats(true);
       profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
     }
-    submitReadyLidarScanToWorker(readyScans.back());
+    submitReadyLidarScanToWorker(readyScans.back().obs, readyScans.back().imu_coverage_end_time);
   }
 }
 
-void LidarOdometry::submitReadyLidarScanToWorker(const CObservation::ConstPtr & o)
+void LidarOdometry::submitReadyLidarScanToWorker(
+  const CObservation::ConstPtr & o, std::optional<double> imuCoverageEndTime)
 {
   // worker_lidar_ uses POLICY_DROP_OLD: with a single worker thread, enqueue()
   // itself discards any older, not-yet-started scan once one is already queued
@@ -232,11 +236,14 @@ void LidarOdometry::submitReadyLidarScanToWorker(const CObservation::ConstPtr & 
       getDropStats() * 100.0);
   }
 
-  auto fut = worker_lidar_.enqueue(&LidarOdometry::onLidar, this, o, mrpt::Clock::nowDouble());
+  auto fut = worker_lidar_.enqueue(
+    &LidarOdometry::onLidar, this, o, mrpt::Clock::nowDouble(), imuCoverageEndTime);
   (void)fut;
 }
 
-void LidarOdometry::onLidar(const CObservation::ConstPtr & o, const double readyTimestamp)
+void LidarOdometry::onLidar(
+  const CObservation::ConstPtr & o, const double readyTimestamp,
+  const std::optional<double> imuCoverageEndTime)
 {
   const bool abort_running = [this]() {
     auto lck = mrpt::lockHelper(is_busy_mtx_);
@@ -259,7 +266,7 @@ void LidarOdometry::onLidar(const CObservation::ConstPtr & o, const double ready
   // top-level try-catch:
   try {
     addDropStats(false);
-    processLidarScan(o);
+    processLidarScan(o, imuCoverageEndTime);
   } catch (const std::exception & e) {
     MRPT_LOG_ERROR_STREAM("Exception:\n" << mrpt::exception_to_str(e));
     auto lckStateFlags = mrpt::lockHelper(state_flags_mtx_);
@@ -274,19 +281,13 @@ void LidarOdometry::onLidar(const CObservation::ConstPtr & o, const double ready
 
 void LidarOdometry::onIMU(const CObservation::ConstPtr & o)
 {
-  // All methods that are enqueued into a thread pool should have its own
-  // top-level try-catch:
+  // Keep a top-level try-catch, as for the methods running on a thread pool:
   try {
     onIMUImpl(o);
   } catch (const std::exception & e) {
     MRPT_LOG_ERROR_STREAM("Exception:\n" << mrpt::exception_to_str(e));
     auto lckStateFlags = mrpt::lockHelper(state_flags_mtx_);
     state_.fatal_error = true;
-  }
-
-  {
-    auto lck = mrpt::lockHelper(is_busy_mtx_);
-    state_.worker_tasks_others--;
   }
 }
 
@@ -310,65 +311,69 @@ void LidarOdometry::onIMUImpl(const CObservation::ConstPtr & o)
   // But since March-2025, state estimators actively subscribe to sensor inputs and it is not
   // our responsibility to forward IMU to them.
 
-  // Uses of IMU in MOLA-LO (this class):
-  // 1) During special initialization to compensate for pitch/roll;
-  // 2) Improved scan de-skewing.
+  // This callback only buffers: the reading is consumed later, by the LiDAR
+  // worker thread, in consumePendingImu(). Consuming it here instead would make
+  // the IMU-derived state seen by a scan depend on how many IMU callbacks
+  // happened to finish first, which is wall-clock dependent.
 
-  // Everything this callback touches lives under imu_state_mtx_, NOT under
-  // state_mtx_: the latter is held by processLidarScan() for its whole body, so
-  // taking it here blocked this thread for the duration of every scan (see the
-  // mutex's docs). Only the fine-grained one is needed, and it is held by the
-  // LiDAR thread for short, well-defined windows.
-
-  // 1) Initial pitch/roll estimation:
+  const double imuTim = mrpt::Clock::toDouble(imu->timestamp);
   {
     auto lckImu = mrpt::lockHelper(imu_state_mtx_);
-    if (state_.imu_initializer.has_value()) {
-      state_.imu_initializer->add(imu);
-    }
+    pending_imu_.add(imuTim, imu, kPendingImuMaxAge);
 
-    // and for rate stats:
+    // Rate stats are pure instrumentation, so they are updated on arrival: they
+    // must keep reporting a live IMU even while no scan is being processed.
     state_.append_imu_stamp(imu->timestamp, *this);
   }
 
-  // 2) Precise scan de-skewing is done via Generator, which in turns passes the IMU data to the
-  //    LocalVelocityBuffer inside the ParameterSource.
-  //    The LocalVelocityBuffer also needs velocity and orientation estimations, which are sent out
-  //    in updatePipelineDynamicVariables()
-  {
-    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
-    mp2p_icp::metric_map_t dummy_map;
-    mp2p_icp_filters::apply_generators(state_.obs_generators, *imu, dummy_map);
-  }
-
-  // Mark how far IMU data has now been fed into the de-skew buffer, so a waiting
-  // scan is only released once the IMU covering its whole span is available.
+  // Mark how far IMU data has now been received, so a waiting scan is only
+  // released once the IMU covering its whole span is available.
   // Monotonic update, to be robust against out-of-order IMU timestamps:
   {
-    const double imuTim = mrpt::Clock::toDouble(imu->timestamp);
-    double prev = latest_fed_imu_time_.load();
-    while (imuTim > prev && !latest_fed_imu_time_.compare_exchange_weak(prev, imuTim)) {
+    double prev = latest_imu_time_.load();
+    while (imuTim > prev && !latest_imu_time_.compare_exchange_weak(prev, imuTim)) {
     }
   }
 
-  // 3) Gravity estimation for ICP verticality correction:
-  if (params_.imu_gravity_correction.enabled) {
-    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
-    state_.gravity_estimator.add(*imu, params_.imu_gravity_correction.averaging_samples);
+  // Finally, release any waiting LiDAR scan now fully covered by received IMU data:
+  releaseReadyLidarScansToWorker();
+}
+
+void LidarOdometry::consumePendingImu(const double upToTime)
+{
+  auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+
+  for (const auto & imuPtr : pending_imu_.take_up_to(upToTime)) {
+    const auto & imu = *imuPtr;
+
+    // 1) Initial pitch/roll estimation:
+    if (state_.imu_initializer.has_value()) {
+      state_.imu_initializer->add(imuPtr);
+    }
+
+    // 2) Precise scan de-skewing is done via Generator, which in turns passes the IMU data to the
+    //    LocalVelocityBuffer inside the ParameterSource.
+    //    The LocalVelocityBuffer also needs velocity and orientation estimations, which are sent
+    //    out in updatePipelineDynamicVariables()
+    {
+      mp2p_icp::metric_map_t dummy_map;
+      mp2p_icp_filters::apply_generators(state_.obs_generators, imu, dummy_map);
+    }
+
+    // 3) Gravity estimation for ICP verticality correction:
+    if (params_.imu_gravity_correction.enabled) {
+      state_.gravity_estimator.add(imu, params_.imu_gravity_correction.averaging_samples);
 
 #if defined(MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR)
-    // 3b) Preintegrate for the map-frame gravity estimator. Unlike the
-    //     accelerometer average above, this consumes EVERY sample and does not
-    //     require the platform to be quasi-static.
-    if (params_.imu_gravity_correction.map_gravity.enabled) {
-      accumulateImuForMapGravity(*imu);
-    }
+      // 3b) Preintegrate for the map-frame gravity estimator. Unlike the
+      //     accelerometer average above, this consumes EVERY sample and does not
+      //     require the platform to be quasi-static.
+      if (params_.imu_gravity_correction.map_gravity.enabled) {
+        accumulateImuForMapGravity(imu);
+      }
 #endif
+    }
   }
-
-  // Finally, release any waiting LiDAR scan now fully covered by fed IMU data.
-  // No-op for LO (the wait list is only populated by IMU-de-skew pipelines):
-  releaseReadyLidarScansToWorker();
 }
 
 void LidarOdometry::onGPS(const CObservation::ConstPtr & o)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,9 @@ target_link_libraries(test_gravity_map_aligner mola::mola_lidar_odometry)
 ament_add_gtest(test_keyframe_decider test_keyframe_decider.cpp)
 target_link_libraries(test_keyframe_decider mola::mola_lidar_odometry)
 
+ament_add_gtest(test_imu_scan_sync test_imu_scan_sync.cpp)
+target_link_libraries(test_imu_scan_sync mola::mola_lidar_odometry mrpt::obs)
+
 # -----------------------------------------------------------------------
 # Data-dependent integration tests (require optional packages):
 # -----------------------------------------------------------------------
@@ -82,6 +85,7 @@ target_link_libraries(test_lidar_odometry_mulran
   mola::mola_lidar_odometry
   mola::mola_state_estimation_simple
 )
+
 endif()
 
 # Test: from rosbag2 file, RSLIDAR data with XYZIRT channels

--- a/test/test_imu_scan_sync.cpp
+++ b/test/test_imu_scan_sync.cpp
@@ -96,6 +96,20 @@ TEST(PendingImuBuffer, ConsumesEachSampleOnce)
   EXPECT_EQ(buf.size(), 0U);
 }
 
+// Two readings sharing a timestamp are both kept: dropping one would silently
+// discard data that used to be fused.
+TEST(PendingImuBuffer, KeepsReadingsSharingATimestamp)
+{
+  mola::PendingImuBuffer buf;
+  buf.add(1.0, makeImu(1.0), 10.0);
+  buf.add(1.0, makeImu(1.0), 10.0);
+  buf.add(1.1, makeImu(1.1), 10.0);
+
+  EXPECT_EQ(buf.size(), 3U);
+  EXPECT_EQ(valuesOf(buf.take_up_to(1.0)), (std::vector<double>{1.0, 1.0}));
+  EXPECT_EQ(buf.size(), 1U);
+}
+
 TEST(PendingImuBuffer, DropsSamplesOlderThanMaxAge)
 {
   mola::PendingImuBuffer buf;

--- a/test/test_imu_scan_sync.cpp
+++ b/test/test_imu_scan_sync.cpp
@@ -1,0 +1,162 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   test_imu_scan_sync.cpp
+ * @brief  Unit tests for PendingImuBuffer and ScanImuWaitList
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include <gtest/gtest.h>
+#include <mola_lidar_odometry/ImuScanSync.h>
+#include <mrpt/obs/CObservationPointCloud.h>
+
+#include <algorithm>
+#include <vector>
+
+namespace
+{
+mrpt::obs::CObservationIMU::Ptr makeImu(double t)
+{
+  auto o = mrpt::obs::CObservationIMU::Create();
+  o->timestamp = mrpt::Clock::fromDouble(t);
+  o->set(mrpt::obs::IMU_WZ, t);  // a value that identifies the sample
+  return o;
+}
+
+mrpt::obs::CObservation::Ptr makeScan(double t)
+{
+  auto o = mrpt::obs::CObservationPointCloud::Create();
+  o->timestamp = mrpt::Clock::fromDouble(t);
+  return o;
+}
+
+std::vector<double> valuesOf(const std::vector<mrpt::obs::CObservationIMU::ConstPtr> & v)
+{
+  std::vector<double> ret;
+  for (const auto & o : v) {
+    ret.push_back(o->get(mrpt::obs::IMU_WZ));
+  }
+  return ret;
+}
+}  // namespace
+
+// The samples a given time window yields must not depend on the order in which
+// they were handed to the buffer.
+TEST(PendingImuBuffer, WindowIsIndependentOfInsertionOrder)
+{
+  const std::vector<double> times = {1.0, 1.1, 1.2, 1.3, 1.4};
+
+  const auto fill = [&](const std::vector<double> & order) {
+    mola::PendingImuBuffer buf;
+    for (const double t : order) {
+      buf.add(t, makeImu(t), 10.0);
+    }
+    return buf;
+  };
+
+  auto reversed = times;
+  std::reverse(reversed.begin(), reversed.end());
+
+  const std::vector<double> expected = {1.0, 1.1, 1.2};
+
+  auto inOrder = fill(times);
+  auto outOfOrder = fill(reversed);
+
+  EXPECT_EQ(valuesOf(inOrder.take_up_to(1.25)), expected);
+  EXPECT_EQ(valuesOf(outOfOrder.take_up_to(1.25)), expected);
+
+  // ...and the samples past the window are still there, for the next scan:
+  EXPECT_EQ(inOrder.size(), 2U);
+  EXPECT_EQ(outOfOrder.size(), 2U);
+}
+
+// A sample is consumed exactly once, and the boundary is inclusive.
+TEST(PendingImuBuffer, ConsumesEachSampleOnce)
+{
+  mola::PendingImuBuffer buf;
+  for (const double t : {1.0, 1.1, 1.2, 1.3}) {
+    buf.add(t, makeImu(t), 10.0);
+  }
+
+  EXPECT_EQ(valuesOf(buf.take_up_to(1.1)), (std::vector<double>{1.0, 1.1}));
+  EXPECT_EQ(valuesOf(buf.take_up_to(1.3)), (std::vector<double>{1.2, 1.3}));
+  EXPECT_TRUE(buf.take_up_to(1.3).empty());
+  EXPECT_EQ(buf.size(), 0U);
+}
+
+TEST(PendingImuBuffer, DropsSamplesOlderThanMaxAge)
+{
+  mola::PendingImuBuffer buf;
+  for (const double t : {1.0, 1.5, 2.0, 2.5, 3.0}) {
+    buf.add(t, makeImu(t), 1.0);
+  }
+
+  // Only those within 1 s of the newest one survive:
+  EXPECT_EQ(valuesOf(buf.take_up_to(10.0)), (std::vector<double>{2.0, 2.5, 3.0}));
+}
+
+// A scan is released only once IMU data reaches its own coverage end time, and
+// that decision never depends on anything but timestamps.
+TEST(ScanImuWaitList, ReleasesOnlyFullyCoveredScans)
+{
+  mola::ScanImuWaitList list;
+  list.add(1.0, {makeScan(1.0), 1.1});
+  list.add(1.1, {makeScan(1.1), 1.2});
+  list.add(1.2, {makeScan(1.2), 1.3});
+
+  EXPECT_TRUE(list.take_ready(1.05).empty());
+  EXPECT_EQ(list.size(), 3U);
+
+  // Exact coverage is enough:
+  const auto first = list.take_ready(1.1);
+  ASSERT_EQ(first.size(), 1U);
+  EXPECT_EQ(first[0].imu_coverage_end_time, 1.1);
+  EXPECT_EQ(list.size(), 2U);
+
+  // A catch-up burst releases several at once, oldest first:
+  const auto burst = list.take_ready(5.0);
+  ASSERT_EQ(burst.size(), 2U);
+  EXPECT_EQ(burst[0].imu_coverage_end_time, 1.2);
+  EXPECT_EQ(burst[1].imu_coverage_end_time, 1.3);
+  EXPECT_EQ(list.size(), 0U);
+}
+
+// A scan whose coverage end is beyond the newest IMU data blocks only itself;
+// the ones before it are still released (they are older, hence covered first).
+TEST(ScanImuWaitList, TrimDropsTheOldest)
+{
+  mola::ScanImuWaitList list;
+  for (int i = 0; i < 5; i++) {
+    const double t = 1.0 + 0.1 * i;
+    list.add(t, {makeScan(t), t + 0.1});
+  }
+
+  EXPECT_EQ(list.trim_to(2), 3U);
+  EXPECT_EQ(list.size(), 2U);
+
+  const auto ready = list.take_ready(10.0);
+  ASSERT_EQ(ready.size(), 2U);
+  // The two newest ones are the survivors:
+  EXPECT_NEAR(ready[0].imu_coverage_end_time, 1.4, 1e-9);
+  EXPECT_NEAR(ready[1].imu_coverage_end_time, 1.5, 1e-9);
+
+  EXPECT_EQ(list.trim_to(2), 0U);
+}
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Problem

`mola-lidar-odometry-cli` run offline is not bit-reproducible when an IMU is
used: two runs of the same sequence, same binary, same arguments, produce
different trajectories. With the IMU input omitted, the same two runs are
byte-identical, so the divergence enters through the IMU.

`onNewObservation()` dispatched IMU observations to `worker_others_` and LiDAR
scans to `worker_lidar_`, two independent pools. Each IMU callback then applied
its reading immediately into the de-skew velocity buffer, the initial pitch/roll
calibrator and the gravity estimators. Which readings had been applied when a
scan started processing was therefore decided by thread scheduling, so the same
input gave a different ICP prior, a different gravity prior, and a different
trajectory on every run.

## The fix

Make the IMU data a scan sees a function of the observation timestamps alone.
This is the same shape already used by the two reference ports in this
workspace, `fast_lio2_core` (`tryProcessPending()` / `sync_packages()`) and
`dlio_core` (`imuMeasFromTimeRange()` plus its deferred/dropped outcome): both
inputs only append, a scan runs only once IMU covers its whole span, and it then
consumes exactly the samples inside that span.

1. **Buffer, do not consume.** `onIMUImpl()` appends the reading to a
   timestamp-ordered buffer and records how far IMU data has been received.
   It no longer touches the velocity buffer, the calibrator or the gravity
   estimators.
2. **Buffer inline.** IMU observations are no longer enqueued on
   `worker_others_`; they are buffered on the sensor-input thread. Buffering is
   a map insert, and doing it in the caller's thread is what makes the buffer
   contents, and hence which scans are ready to run, independent of scheduling.
   The costly per-sample work moved to the LiDAR worker thread.
3. **Gate on coverage.** A scan is held on the wait list until IMU data reaches
   its own coverage end time (its timestamp plus the estimated scan period),
   frozen when the scan is parked so that release and consumption always agree
   on the same window. This gate already existed, but only for pipelines that
   need IMU for de-skew; it now applies whenever IMU data is flowing, because
   the gravity estimators and the state estimator need the same guarantee.
4. **Consume the window.** `processLidarScan()` calls `consumePendingImu()`
   before anything reads IMU-derived state, feeding exactly the buffered samples
   up to that coverage end, in timestamp order.

The buffering and the wait list are in a new `ImuScanSync.h`
(`PendingImuBuffer`, `ScanImuWaitList`) so the logic can be unit tested on its
own, with no threads and no dataset.

### Why a timestamp gate and not a fixed delay

Introducing a fixed delay between the two streams was considered and rejected. A
delay only shrinks the window in which the race can be lost: whether it was
enough still depends on machine load, so runs stay irreproducible and the
failure becomes rarer and harder to diagnose. It also costs latency on the
online path, which the timestamp gate does not: the gate waits for the IMU
sample at the scan's end of sweep, and a rotating LiDAR publishes its scan
*after* that instant anyway, so in a real-time system that sample has normally
already arrived.

## Companion PR

This alone is not sufficient. The default state estimator subscribes to raw IMU
itself and used to overwrite its twist with the newest reading on arrival, so
the ICP prior stayed scheduling-dependent. Fixed in
MOLAorg/mola_state_estimation#53, which buffers IMU by timestamp the same
way. **Both are needed**: this PR guarantees the data has arrived, that one
guarantees arrival order does not matter.

## Evidence

Sequence: Oxford Spires `2024-03-12-keble-college-03`, full replay, default
pipeline, `state-estimation-simple`, `mp2p_icp` including the
`FilterDecimateAdaptive` per-thread voxel merge (MOLAorg/mp2p_icp#86, which
closes the ICP-side nondeterminism; without it even the IMU-free runs differ).

md5 of the output `.tum`, two runs each:

| configuration | run A | run B |
|---|---|---|
| before, with IMU | `7770ad95c06607d0972241bcf98769fa` | `c07c8005caf26faefe02432fa6732de0` |
| after, with IMU | `c2a3c952ac66dc459d9353ca046af8c7` | `c2a3c952ac66dc459d9353ca046af8c7` |
| after, no IMU (regression guard) | `a42c29b537c737a1089ba9dfc5b23e44` | `a42c29b537c737a1089ba9dfc5b23e44` |

The no-IMU md5 is unchanged from before this work, so the IMU-free path is
untouched. All runs process 2867 `onLidar` calls and emit 2867 poses, with no
dropped scans. (Before, we had also seen runs emitting only 2866 poses, one scan
mid-run failing to produce one; that no longer happens.)

Accuracy is essentially unchanged, as expected:

```
evo_ape ... --align --t_max_diff 0.01
before, with IMU:  RMSE 0.280 m / 0.303 m  (the two differing runs)
after,  with IMU:  RMSE 0.327 m
```

## Tests

New `test/test_imu_scan_sync.cpp` covering the new logic directly and
deterministically (no threads, no dataset, no ICP):

- the time window a scan gets is the same whether the samples were handed to the
  buffer in order or in reverse,
- each sample is consumed exactly once, and the window boundary is inclusive,
- samples older than the age cap are dropped,
- a scan is released only once IMU data reaches its coverage end, exact coverage
  counts, a catch-up burst releases several oldest-first,
- the overflow trim drops the oldest.

The existing suites of this package pass (KITTI, Mulran LIO, RSLidar rosbag2,
gravity map aligner, keyframe decider): 38 tests, 0 failures.

## Things I am not sure about / limitations

- **The gate engages only after the first IMU reading.** A configuration that
  never receives one behaves exactly as before, which is what keeps IMU-free
  datasets working (every pipeline yaml sets `imu_sensor_label` to a default of
  `imu`, so keying off the parameter alone would have stalled KITTI and every
  other IMU-less run). The cost is that scans arriving before the first IMU
  reading are processed ungated. That is a startup condition rather than a race
  (the input sequence decides it), but it does mean the very first scans are
  processed without IMU data.
- **If the IMU stops mid-run, waiting scans are dropped** by the pre-existing
  `max_lidar_queue_before_drop` cap and odometry stalls. This failure mode
  already existed for IMU-de-skew pipelines; this PR widens it to any
  IMU-carrying configuration. A wall-clock fallback would reintroduce exactly
  the nondeterminism being removed here, so I did not add one, but I am flagging
  it as the part of this change I am least comfortable with.
- **Reproducibility assumes no scan is dropped for overload.** Which scans the
  `POLICY_DROP_OLD` pool discards is inherently wall-clock dependent. That does
  not arise offline (the CLI waits for the worker between observations, and all
  2867 scans are processed), but it does bound what can be claimed online.
- I originally wrote an end-to-end test running the Mulran extract twice with
  the IMU delivered in two different arrival orders and comparing trajectories
  exactly. I dropped it: two LO instances in the *same process* do not reproduce
  each other even when given the identical input order, while the same two runs
  as separate CLI processes are byte-identical. So there is a further, unrelated
  in-process nondeterminism (most likely on the ICP side, cf. the
  `fix/deterministic-gauss-newton-reduce` work) that such a test would trip over.
  Worth chasing separately; it is not what this PR is about.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved LiDAR and IMU synchronization using sensor timestamps.
  - Scans now wait for sufficient IMU coverage before processing.
  - Added bounded buffering, duplicate-timestamp handling, and automatic cleanup for delayed IMU data.
  - Reset now fully clears pending synchronization data and waiting scans.

- **Bug Fixes**
  - Improved deterministic processing for out-of-order and delayed sensor inputs.
  - Ensured buffered IMU data is consumed consistently during scan processing.

- **Tests**
  - Added coverage for buffering, timestamp-based scan release, pruning, duplicate timestamps, catch-up processing, and queue limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->