### PR TITLE
Process the LiDAR scans still waiting for IMU at the end of the input

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -291,6 +291,16 @@ are processed straight away; and if the IMU stops, waiting scans are dropped by
 `params_.max_lidar_queue_before_drop` as before. Reproducibility also assumes no
 scan is dropped for overload, which is the offline case.
 
+**End of input.** The last scans of a run are parked waiting for IMU that the
+dataset no longer contains, so they must be flushed explicitly or they are lost:
+`flushPendingLidarScans()` releases them regardless of coverage and blocks until
+the worker is idle. `shutdownCleanup()` calls it, which covers everything going
+through `onQuit()`; `mola-lidar-odometry-cli` calls it directly after the replay
+loop, because it reads `estimatedTrajectory()` before that point. Note that
+`isBusy()` deliberately does **not** count the wait list: callers poll it between
+observations, and a parked scan is only released by a later observation, so
+counting it there would deadlock.
+
 ## `imu_state_mtx_`: the sensor input no longer waits on the LiDAR worker
 
 `processLidarScan()` holds `state_mtx_` for its whole body, so an `onIMU()` that

--- a/apps/mola-lidar-odometry-cli.cpp
+++ b/apps/mola-lidar-odometry-cli.cpp
@@ -936,6 +936,11 @@ int main_odometry(Cli & cli)
     }
   }
 
+  // The dataset is over, so scans still waiting for IMU data covering their
+  // time span will never get it. Process them now, before reading the results
+  // below, or the tail of the trajectory is lost:
+  liodom->flushPendingLidarScans();
+
   if (cli.arg_outPath.isSet()) {
     const auto fil = cli.arg_outPath.getValue();
     std::cout << "\nSaving estimated path in TUM format to: " << fil

--- a/apps/mola-lidar-odometry-cli.cpp
+++ b/apps/mola-lidar-odometry-cli.cpp
@@ -777,6 +777,9 @@ int main_odometry(Cli & cli)
   if (cli.arg_outTwist.isSet()) {
     outTwist.emplace();
   }
+  /// Timestamp of the last observation fed, to stamp the twist of the state the
+  /// end-of-input flush may still produce:
+  std::optional<mrpt::Clock::time_point> lastObsTimestamp;
 
   // Save GT, if available:
   if (cli.arg_outPath.isSet() && dataset->hasGroundTruthTrajectory()) {
@@ -933,6 +936,7 @@ int main_odometry(Cli & cli)
         outTwist->insert(
           obs->timestamp, mrpt::math::TPose3D(tw.vx, tw.vy, tw.vz, tw.wz, tw.wy, tw.wx));
       }
+      lastObsTimestamp = obs->timestamp;
     }
   }
 
@@ -940,6 +944,16 @@ int main_odometry(Cli & cli)
   // time span will never get it. Process them now, before reading the results
   // below, or the tail of the trajectory is lost:
   liodom->flushPendingLidarScans();
+
+  // The flush may have produced one more state, after the loop wrote its last
+  // twist entry:
+  if (outTwist && lastObsTimestamp) {
+    if (const auto optPoseAndTwist = liodom->lastEstimatedState(); optPoseAndTwist) {
+      const auto & [pose, tw] = optPoseAndTwist.value();
+      outTwist->insert(
+        *lastObsTimestamp, mrpt::math::TPose3D(tw.vx, tw.vy, tw.vz, tw.wz, tw.wy, tw.wx));
+    }
+  }
 
   if (cli.arg_outPath.isSet()) {
     const auto fil = cli.arg_outPath.getValue();

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -88,6 +88,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
+#include <future>
 #include <limits>
 #include <map>
 #include <memory>
@@ -1541,8 +1542,11 @@ private:
    *  policy itself: if the worker is idle the scan starts right away; if it is
    *  busy, this call replaces any older not-yet-started scan still queued
    *  behind it. This method only adds the drop-stats bookkeeping the pool
-   *  itself doesn't provide. Safe to call from any thread. */
-  void submitReadyLidarScanToWorker(
+   *  itself doesn't provide. Safe to call from any thread.
+   *  \return The enqueued task's future, so a caller that must not race the
+   *          worker (flushPendingLidarScans) can wait on this very scan rather
+   *          than on sampled busy counters. */
+  std::future<void> submitReadyLidarScanToWorker(
     const CObservation::ConstPtr & o, std::optional<double> imuCoverageEndTime);
   /// Number of LiDAR scans currently running or queued on worker_lidar_ (0, 1, or 2).
   int pendingLidarScanCount() const;
@@ -1560,8 +1564,9 @@ private:
   /** Common implementation of releaseReadyLidarScansToWorker() and
    *  flushPendingLidarScans(): releases every waiting scan whose IMU coverage
    *  end time is not beyond \a upToImuTime. Passing infinity releases them all,
-   *  which is what "no more input is coming" means. */
-  void releaseLidarScansToWorker(double upToImuTime);
+   *  which is what "no more input is coming" means.
+   *  \return The submitted scan's future, or an invalid future if none was. */
+  std::future<void> releaseLidarScansToWorker(double upToImuTime);
   mp2p_icp::metric_map_t::Ptr observationFromRawSensor(const mrpt::obs::CSensoryFrame & sf);
   mrpt::obs::CSensoryFrame collectRawObservations(const mrpt::obs::CObservation::ConstPtr & obs);
 

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -155,6 +155,19 @@ public:
      */
   void reset();
 
+  /** Processes the LiDAR scans still held back waiting for IMU data, using
+     *  whatever IMU samples did arrive, and blocks until the worker is idle.
+     *
+     *  Call it once the input is known to be over (end of a dataset, end of a
+     *  rosbag replay): those scans wait for IMU that will never arrive, and
+     *  without this they are silently discarded, losing the tail of the
+     *  estimated trajectory. shutdownCleanup() calls it as well, so pipelines
+     *  going through onQuit() need no explicit call.
+     *  As during normal operation, only the freshest pending scan is actually
+     *  processed; the older ones are accounted as dropped.
+     */
+  void flushPendingLidarScans();
+
   enum class AlignKind : uint8_t
   {
     RegularOdometry = 0,
@@ -1543,6 +1556,12 @@ private:
    *  the sensor-input thread while onLidar holds state_mtx_; this decouples scan
    *  release from IMU-worker processing latency. No-op for LO (empty wait list). */
   void releaseReadyLidarScansToWorker();
+
+  /** Common implementation of releaseReadyLidarScansToWorker() and
+   *  flushPendingLidarScans(): releases every waiting scan whose IMU coverage
+   *  end time is not beyond \a upToImuTime. Passing infinity releases them all,
+   *  which is what "no more input is coming" means. */
+  void releaseLidarScansToWorker(double upToImuTime);
   mp2p_icp::metric_map_t::Ptr observationFromRawSensor(const mrpt::obs::CSensoryFrame & sf);
   mrpt::obs::CSensoryFrame collectRawObservations(const mrpt::obs::CObservation::ConstPtr & obs);
 

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -239,8 +239,22 @@ void LidarOdometry::flushPendingLidarScans()
 
   // Infinity: release regardless of IMU coverage. The scans are waiting for
   // data that will never arrive, so the alternative is to discard them.
-  releaseLidarScansToWorker(std::numeric_limits<double>::infinity());
+  auto fut = releaseLidarScansToWorker(std::numeric_limits<double>::infinity());
 
+  // Wait on the scan's own task, not on the busy counters: onLidar() only
+  // raises worker_tasks_lidar once it is already running, so there is a window
+  // in which the task is dequeued but no counter shows it, and the caller could
+  // move on (and shutdownCleanup() set destructor_called_) before it starts.
+  if (fut.valid()) {
+    try {
+      fut.get();
+    } catch (const std::future_error &) {
+      // The pool discarded the task under its "keep freshest" policy, which
+      // breaks the promise. Nothing to wait for then.
+    }
+  }
+
+  // Anything else still in flight (e.g. a GNSS task) is covered by the counters:
   while (isBusy()) {
     std::this_thread::sleep_for(1ms);
   }

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -46,6 +46,7 @@
 
 // STD:
 #include <chrono>
+#include <limits>
 #include <mutex>
 #include <thread>
 
@@ -101,6 +102,10 @@ void LidarOdometry::shutdownCleanup()
 
   try  // must never throw
   {
+    // Before the workers are told to stop: no further input is coming, so any
+    // scan still waiting for IMU data must be processed now or be lost.
+    flushPendingLidarScans();
+
     {
       auto lck = mrpt::lockHelper(is_busy_mtx_);
       destructor_called_ = true;
@@ -226,6 +231,19 @@ void LidarOdometry::reset()
     worker_lidar_wait_for_imu_list_.trim_to(0);
   }
   initialize(lastInitConfig_);
+}
+
+void LidarOdometry::flushPendingLidarScans()
+{
+  using namespace std::chrono_literals;
+
+  // Infinity: release regardless of IMU coverage. The scans are waiting for
+  // data that will never arrive, so the alternative is to discard them.
+  releaseLidarScansToWorker(std::numeric_limits<double>::infinity());
+
+  while (isBusy()) {
+    std::this_thread::sleep_for(1ms);
+  }
 }
 
 bool LidarOdometry::isBusy() const

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -200,11 +200,16 @@ void LidarOdometry::releaseReadyLidarScansToWorker()
     return;  // no IMU received yet: nothing can be released
   }
 
+  releaseLidarScansToWorker(imuTime);
+}
+
+void LidarOdometry::releaseLidarScansToWorker(const double upToImuTime)
+{
   // Collect every waiting scan whose whole span is already covered by received
   // IMU data, in chronological order, then submit outside the wait-list lock:
   const std::vector<ScanImuWaitList::Entry> readyScans = [&]() {
     auto lck = mrpt::lockHelper(worker_lidar_wait_for_imu_list_mtx_);
-    return worker_lidar_wait_for_imu_list_.take_ready(imuTime);
+    return worker_lidar_wait_for_imu_list_.take_ready(upToImuTime);
   }();
 
   // On an IMU catch-up burst several scans can qualify at once, but only the

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -203,7 +203,7 @@ void LidarOdometry::releaseReadyLidarScansToWorker()
   releaseLidarScansToWorker(imuTime);
 }
 
-void LidarOdometry::releaseLidarScansToWorker(const double upToImuTime)
+std::future<void> LidarOdometry::releaseLidarScansToWorker(const double upToImuTime)
 {
   // Collect every waiting scan whose whole span is already covered by received
   // IMU data, in chronological order, then submit outside the wait-list lock:
@@ -215,16 +215,19 @@ void LidarOdometry::releaseLidarScansToWorker(const double upToImuTime)
   // On an IMU catch-up burst several scans can qualify at once, but only the
   // newest matters ("keep freshest"): drop-account the older ones directly
   // instead of submitting each only to have it superseded by the next.
-  if (!readyScans.empty()) {
-    for (std::size_t i = 0; i + 1 < readyScans.size(); i++) {
-      addDropStats(true);
-      profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
-    }
-    submitReadyLidarScanToWorker(readyScans.back().obs, readyScans.back().imu_coverage_end_time);
+  if (readyScans.empty()) {
+    return {};  // an invalid future: nothing was submitted
   }
+
+  for (std::size_t i = 0; i + 1 < readyScans.size(); i++) {
+    addDropStats(true);
+    profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
+  }
+  return submitReadyLidarScanToWorker(
+    readyScans.back().obs, readyScans.back().imu_coverage_end_time);
 }
 
-void LidarOdometry::submitReadyLidarScanToWorker(
+std::future<void> LidarOdometry::submitReadyLidarScanToWorker(
   const CObservation::ConstPtr & o, std::optional<double> imuCoverageEndTime)
 {
   // worker_lidar_ uses POLICY_DROP_OLD: with a single worker thread, enqueue()
@@ -241,9 +244,8 @@ void LidarOdometry::submitReadyLidarScanToWorker(
       getDropStats() * 100.0);
   }
 
-  auto fut = worker_lidar_.enqueue(
+  return worker_lidar_.enqueue(
     &LidarOdometry::onLidar, this, o, mrpt::Clock::nowDouble(), imuCoverageEndTime);
-  (void)fut;
 }
 
 void LidarOdometry::onLidar(

--- a/test/test_imu_scan_sync.cpp
+++ b/test/test_imu_scan_sync.cpp
@@ -23,6 +23,7 @@
 #include <mrpt/obs/CObservationPointCloud.h>
 
 #include <algorithm>
+#include <limits>
 #include <vector>
 
 namespace
@@ -167,6 +168,25 @@ TEST(ScanImuWaitList, TrimDropsTheOldest)
   EXPECT_NEAR(ready[1].imu_coverage_end_time, 1.5, 1e-9);
 
   EXPECT_EQ(list.trim_to(2), 0U);
+}
+
+// What flushPendingLidarScans() relies on at the end of the input: an infinite
+// coverage time releases every waiting scan, whatever IMU data did arrive.
+TEST(ScanImuWaitList, InfiniteCoverageReleasesEverything)
+{
+  mola::ScanImuWaitList list;
+  for (int i = 0; i < 4; i++) {
+    const double t = 1.0 + 0.1 * i;
+    list.add(t, {makeScan(t), t + 0.1});
+  }
+
+  // None of them is covered by the IMU data actually received:
+  EXPECT_TRUE(list.take_ready(0.5).empty());
+  EXPECT_EQ(list.size(), 4U);
+
+  const auto flushed = list.take_ready(std::numeric_limits<double>::infinity());
+  EXPECT_EQ(flushed.size(), 4U);
+  EXPECT_EQ(list.size(), 0U);
 }
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char ** argv)


### PR DESCRIPTION
## Problem

Since the timestamp-driven LiDAR/IMU gate landed (#129), a scan is held on the wait list until IMU data covering its whole time span arrives. At the end of a dataset that data never comes, so the last scans stay parked and are **silently discarded** — the tail of the estimated trajectory is lost. How much is lost depends on how far the IMU stream outlives the LiDAR one, which is a property of the recording rather than of the odometry.

Nothing flushed them: `isBusy()` counts only worker tasks, so both `mola-lidar-odometry-cli`'s `while (liodom->isBusy())` and `shutdownCleanup()`'s drain returned with scans still on the list.

## Fix

`flushPendingLidarScans()` releases every waiting scan regardless of IMU coverage, feeding it whatever samples did arrive, and blocks until the worker is idle. It is called from:

- `shutdownCleanup()`, before the workers are stopped — covers every pipeline going through `onQuit()`.
- `mola-lidar-odometry-cli`, right after the replay loop, because it reads `estimatedTrajectory()` before `onQuit()` runs.

As during normal operation, only the freshest pending scan is actually processed; older ones are accounted as dropped.

`isBusy()` deliberately keeps ignoring the wait list: callers poll it *between* observations, and a parked scan is only released by a later observation, so counting it there would deadlock the replay loop. This is noted in `agents.md`.

## Verification

- `oxford-spires-2024-03-12-keble-college-03`, offline CLI, `lidar3d-default` + `state-estimation-simple`: output byte-identical to `develop` across repeat runs (`69adf95d…`, 2867 poses), so releasing the tail does not perturb the run itself. On this particular sequence the IMU outlives the LiDAR, so no tail was pending to recover — the fix matters for recordings where it does not.
- Unit test added for the underlying `ScanImuWaitList` semantics (infinite coverage releases everything).
- 38/38 package tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured LiDAR scans waiting for trailing IMU data are processed before shutdown or CLI output generation.
  * Prevented final trajectory data from being omitted when input processing ends.
  * Improved handling of pending scans when no additional finite IMU timestamp is available.

* **Tests**
  * Added coverage for flushing all scans awaiting IMU data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->