### PR TITLE
Bound how long a LiDAR scan waits for IMU data, in sensor time

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -287,9 +287,30 @@ offline runs produce identical trajectories. `mola_state_estimation_simple`
 buffers IMU readings the same way for the same reason.
 
 Limits: the gate only engages after the first IMU reading, so scans preceding it
-are processed straight away; and if the IMU stops, waiting scans are dropped by
-`params_.max_lidar_queue_before_drop` as before. Reproducibility also assumes no
-scan is dropped for overload, which is the offline case.
+are processed straight away. Reproducibility also assumes no scan is dropped for
+overload, which is the offline case.
+
+**The wait is bounded** (`params_.max_time_to_wait_for_imu`, default 0.5 s). An
+IMU that stops mid-run freezes `latest_imu_time_`, so without a bound every later
+scan waits for data that never comes and the odometry stalls permanently and
+silently (`max_lidar_queue_before_drop` then merely recycles the wait list).
+`imu_scan_release_time()` (`ImuScanSync.h`) therefore also releases scans whose
+coverage end is older than `latest_obs_time_ - max_time_to_wait_for_imu`: the
+odometry degrades to LiDAR-only and picks the IMU back up by itself when it
+returns. Set the parameter to 0 to wait indefinitely.
+
+The bound is in **sensor time** (`latest_obs_time_`, the newest timestamp on any
+input), never the wall clock. That is what keeps it reproducible: a wall-clock
+timeout would make the released set depend on machine load, reintroducing the
+nondeterminism this design exists to remove, and it would buy nothing, since a
+run whose inputs have all gone silent has nothing to process anyway.
+
+Releasing a scan without its IMU means the pipeline moves past instants whose
+readings may still arrive (also possible when an input interleaves the two
+streams out of order). `PendingImuBuffer` keeps a watermark of the newest
+consumed instant and rejects anything at or below it, so IMU data is never
+applied out of chronological order; `clear()` resets it, a reset being a new
+session.
 
 **End of input.** The last scans of a run are parked waiting for IMU that the
 dataset no longer contains, so they must be flushed explicitly or they are lost:

--- a/module/include/mola_lidar_odometry/ImuScanSync.h
+++ b/module/include/mola_lidar_odometry/ImuScanSync.h
@@ -22,6 +22,8 @@
 #include <mrpt/obs/CObservation.h>
 #include <mrpt/obs/CObservationIMU.h>
 
+#include <algorithm>
+#include <limits>
 #include <map>
 #include <vector>
 
@@ -43,17 +45,28 @@ public:
    *  relative to the newest sample held.
    *  A multimap, so that two readings sharing a timestamp are both kept: which
    *  of them is "the" reading for that instant is undecidable, and dropping one
-   *  would silently discard data the previous code did use. */
-  void add(double timestamp, const mrpt::obs::CObservationIMU::ConstPtr & imu, double maxAge)
+   *  would silently discard data the previous code did use.
+   *
+   *  A reading that is not newer than what has already been consumed is
+   *  discarded: the pipeline has moved past that instant, so feeding it now
+   *  would apply IMU data out of chronological order. \return whether it was
+   *  stored. */
+  bool add(double timestamp, const mrpt::obs::CObservationIMU::ConstPtr & imu, double maxAge)
   {
+    if (timestamp <= consumed_up_to_) {
+      return false;
+    }
+
     samples_.emplace(timestamp, imu);
 
     const double oldestToKeep = samples_.rbegin()->first - maxAge;
     samples_.erase(samples_.begin(), samples_.lower_bound(oldestToKeep));
+    return true;
   }
 
   /** Removes and returns every sample with a timestamp not newer than
-   *  `upToTime`, in timestamp order. */
+   *  `upToTime`, in timestamp order. Everything up to `upToTime` counts as
+   *  consumed afterwards, including samples that arrive later (see add()). */
   std::vector<mrpt::obs::CObservationIMU::ConstPtr> take_up_to(double upToTime)
   {
     const auto itEnd = samples_.upper_bound(upToTime);
@@ -64,15 +77,24 @@ public:
       ret.push_back(it->second);
     }
     samples_.erase(samples_.begin(), itEnd);
+
+    consumed_up_to_ = std::max(consumed_up_to_, upToTime);
     return ret;
   }
 
-  void clear() { samples_.clear(); }
+  void clear()
+  {
+    samples_.clear();
+    consumed_up_to_ = -std::numeric_limits<double>::infinity();
+  }
 
   std::size_t size() const { return samples_.size(); }
 
 private:
   std::multimap<double /*timestamp*/, mrpt::obs::CObservationIMU::ConstPtr> samples_;
+
+  /// Newest instant already handed out by take_up_to().
+  double consumed_up_to_ = -std::numeric_limits<double>::infinity();
 };
 
 /** Holds LiDAR scans back until the IMU covering their whole time span has been
@@ -131,5 +153,32 @@ public:
 private:
   std::multimap<double /*scan timestamp*/, Entry> list_;
 };
+
+/** Coverage time up to which waiting scans may be released.
+ *
+ *  Normally that is how far IMU data has been received, so a scan runs only
+ *  once every sample it will consume exists. If the IMU stops, that time stops
+ *  advancing and the scans behind it would wait for good, so the wait is
+ *  bounded: `maxWaitTime` seconds after a scan's coverage end has passed in
+ *  *sensor* time, the scan is released with whatever IMU data did arrive.
+ *
+ *  \param latestImuTime Newest IMU timestamp received [s].
+ *  \param latestObsTime Newest timestamp received on any input [s], i.e. "now"
+ *         in sensor time.
+ *  \param maxWaitTime Bound on the wait [s]; 0 disables it (wait forever).
+ *
+ *  Deliberately a function of timestamps only: using the wall clock here would
+ *  make the released set depend on machine load, which is what the whole
+ *  timestamp-driven synchronization exists to avoid.
+ *
+ * \ingroup mola_lidar_odometry_grp
+ */
+inline double imu_scan_release_time(double latestImuTime, double latestObsTime, double maxWaitTime)
+{
+  if (maxWaitTime <= 0) {
+    return latestImuTime;
+  }
+  return std::max(latestImuTime, latestObsTime - maxWaitTime);
+}
 
 }  // namespace mola

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -734,6 +734,18 @@ public:
      *  the oldest are dropped. */
     uint32_t max_lidar_queue_before_drop = 15;
 
+    /** How long [s] a LiDAR scan may be held waiting for the IMU data covering
+     *  its time span before it is processed without it. Measured in *sensor*
+     *  time: the newest timestamp received on any input, not the wall clock,
+     *  so a given input always yields the same trajectory whatever the machine
+     *  load, offline or online.
+     *
+     *  Without this bound, an IMU that stops mid-run stalls the odometry
+     *  permanently, since the scans behind it never become ready. With it, the
+     *  odometry degrades to LiDAR-only after the timeout and recovers by itself
+     *  when IMU data comes back. Set to 0 to disable and wait indefinitely. */
+    double max_time_to_wait_for_imu = 0.5;
+
     uint32_t gnss_queue_max_size = 100;
 
     ///  Minimum inverse covariance in (X,Y,Z) for a valid motion model
@@ -1240,6 +1252,13 @@ private:
   /// be drained (see releaseReadyLidarScansToWorker) from the sensor-input
   /// thread too, without waiting for the LiDAR worker to become free.
   std::atomic<double> latest_imu_time_{0};
+
+  /// Newest timestamp (seconds, sensor clock) seen on *any* input: the system's
+  /// notion of "now" in sensor time. It is what bounds how long a scan may wait
+  /// for IMU data (params_.max_time_to_wait_for_imu). Taking it from the
+  /// observation stream instead of the wall clock is what keeps the outcome
+  /// reproducible: the same input always leads to the same decisions.
+  std::atomic<double> latest_obs_time_{0};
 
   /// IMU observations received but not consumed yet. They are consumed by
   /// consumePendingImu(), from the LiDAR worker thread, right before the scan

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -188,6 +188,7 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
     YAML_LOAD_OPT(params_, start_active, bool);
 
     YAML_LOAD_OPT(params_, max_lidar_queue_before_drop, uint32_t);
+    YAML_LOAD_OPT(params_, max_time_to_wait_for_imu, double);
     YAML_LOAD_OPT(params_, gnss_queue_max_size, uint32_t);
     YAML_LOAD_OPT(params_, min_motion_model_xyz_cov_inv, double);
 

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -224,6 +224,7 @@ void LidarOdometry::reset()
     state_ = MethodState();
     pending_imu_.clear();
     latest_imu_time_ = 0;
+    latest_obs_time_ = 0;
   }
   {
     // Scans still waiting for IMU belong to the pre-reset session:

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -78,6 +78,17 @@ void LidarOdometry::onNewObservation(const CObservation::ConstPtr & o)
     }
   }
 
+  // Advance the notion of "now" in sensor time. It bounds how long a scan may
+  // wait for IMU data, and it must be updated from every input so that a stalled
+  // IMU is detected by the data itself rather than by the wall clock.
+  // Monotonic, to be robust against out-of-order deliveries between sensors:
+  {
+    const double obsTim = mrpt::Clock::toDouble(o->getTimeStamp());
+    double prev = latest_obs_time_.load();
+    while (obsTim > prev && !latest_obs_time_.compare_exchange_weak(prev, obsTim)) {
+    }
+  }
+
   // Is it an IMU obs?
   if (
     params_.imu_sensor_label &&
@@ -200,7 +211,22 @@ void LidarOdometry::releaseReadyLidarScansToWorker()
     return;  // no IMU received yet: nothing can be released
   }
 
-  releaseLidarScansToWorker(imuTime);
+  // A scan is normally released once IMU data reaches its coverage end. If the
+  // IMU stops, that never happens and the odometry would stall for good, so the
+  // wait is bounded in sensor time (see imu_scan_release_time):
+  const double obsTime = latest_obs_time_.load();
+  const double releaseUpTo =
+    imu_scan_release_time(imuTime, obsTime, params_.max_time_to_wait_for_imu);
+
+  if (releaseUpTo > imuTime) {
+    MRPT_LOG_THROTTLE_WARN_FMT(
+      2.0,
+      "No IMU data since t=%.03f while sensor time is %.03f: processing LiDAR scans without it "
+      "(LiDAR-only odometry). Check the IMU sensor and its 'imu_sensor_label'.",
+      imuTime, obsTime);
+  }
+
+  releaseLidarScansToWorker(releaseUpTo);
 }
 
 std::future<void> LidarOdometry::releaseLidarScansToWorker(const double upToImuTime)
@@ -324,13 +350,22 @@ void LidarOdometry::onIMUImpl(const CObservation::ConstPtr & o)
   // happened to finish first, which is wall-clock dependent.
 
   const double imuTim = mrpt::Clock::toDouble(imu->timestamp);
+  bool stored = false;
   {
     auto lckImu = mrpt::lockHelper(imu_state_mtx_);
-    pending_imu_.add(imuTim, imu, kPendingImuMaxAge);
+    stored = pending_imu_.add(imuTim, imu, kPendingImuMaxAge);
 
     // Rate stats are pure instrumentation, so they are updated on arrival: they
     // must keep reporting a live IMU even while no scan is being processed.
     state_.append_imu_stamp(imu->timestamp, *this);
+  }
+
+  if (!stored) {
+    // Its instant was already consumed by a scan, which happens when a scan is
+    // released without waiting (see releaseReadyLidarScansToWorker) or when the
+    // input interleaves the two streams out of order:
+    MRPT_LOG_THROTTLE_WARN_FMT(
+      2.0, "Discarding IMU reading at t=%.03f: already past the last consumed instant.", imuTim);
   }
 
   // Mark how far IMU data has now been received, so a waiting scan is only

--- a/test/test_imu_scan_sync.cpp
+++ b/test/test_imu_scan_sync.cpp
@@ -189,6 +189,54 @@ TEST(ScanImuWaitList, InfiniteCoverageReleasesEverything)
   EXPECT_EQ(list.size(), 0U);
 }
 
+// Once a scan has consumed up to some instant, a reading for an earlier one is
+// of no use: applying it would feed IMU data out of chronological order. This
+// is what a scan released without its IMU (a stalled IMU that later resumes)
+// would otherwise cause.
+TEST(PendingImuBuffer, RejectsReadingsAlreadyConsumed)
+{
+  mola::PendingImuBuffer buf;
+
+  EXPECT_TRUE(buf.add(1.0, makeImu(1.0), 10.0));
+  EXPECT_TRUE(buf.add(1.1, makeImu(1.1), 10.0));
+
+  EXPECT_EQ(valuesOf(buf.take_up_to(1.2)), (std::vector<double>{1.0, 1.1}));
+
+  // Late arrivals for instants already passed:
+  EXPECT_FALSE(buf.add(1.05, makeImu(1.05), 10.0));
+  EXPECT_FALSE(buf.add(1.2, makeImu(1.2), 10.0));
+  EXPECT_EQ(buf.size(), 0U);
+
+  // Anything newer is still accepted as usual:
+  EXPECT_TRUE(buf.add(1.3, makeImu(1.3), 10.0));
+  EXPECT_EQ(valuesOf(buf.take_up_to(2.0)), (std::vector<double>{1.3}));
+
+  // clear() starts a fresh session, so the watermark must go with it:
+  buf.clear();
+  EXPECT_TRUE(buf.add(1.0, makeImu(1.0), 10.0));
+}
+
+// A healthy IMU decides the release time on its own; a stalled one hands over
+// to the bound, so scans keep flowing instead of the odometry stalling for good.
+TEST(ImuScanReleaseTime, BoundsTheWaitOnlyWhenTheImuFallsBehind)
+{
+  constexpr double maxWait = 0.5;
+
+  // IMU keeping up with the rest of the inputs: it alone decides.
+  EXPECT_EQ(mola::imu_scan_release_time(10.0, 10.02, maxWait), 10.0);
+  // Still within the tolerated lag:
+  EXPECT_EQ(mola::imu_scan_release_time(10.0, 10.4, maxWait), 10.0);
+  // Stopped: sensor time has moved on, so scans up to (now - maxWait) run
+  // without it. The released window keeps advancing as sensor time does.
+  EXPECT_EQ(mola::imu_scan_release_time(10.0, 11.0, maxWait), 10.5);
+  EXPECT_EQ(mola::imu_scan_release_time(10.0, 20.0, maxWait), 19.5);
+  // ...and the IMU coming back takes over again:
+  EXPECT_EQ(mola::imu_scan_release_time(21.0, 20.0, maxWait), 21.0);
+
+  // Disabled: wait indefinitely, whatever sensor time says.
+  EXPECT_EQ(mola::imu_scan_release_time(10.0, 99.0, 0.0), 10.0);
+}
+
 int main([[maybe_unused]] int argc, [[maybe_unused]] char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
> Stacked on #130 — the first two commits belong to that PR; review the last one here. Will rebase once #130 merges.

## Problem

With the timestamp-driven gate (#129), a scan waits until IMU data covers its whole time span. `latest_imu_time_` only ever advances on IMU arrival, so **an IMU that stops mid-run freezes it and no later scan is ever released**:

- Every subsequent scan parks on the wait list, and `trim_to(max_lidar_queue_before_drop)` then drops the oldest — the same end `take_ready()` would have consumed. Steady state: one drop in, one drop out, worker idle, **no pose ever emitted again**.
- Those drops only bump counters (`addDropStats`, a profiler measure). The `MRPT_LOG_THROTTLE_WARN` about dropping lives in `submitReadyLidarScanToWorker()`, which this path never reaches, so **the stall is completely silent** — the only symptom is the drop indicator drifting to 100%.

The same signature also appears without an outright stoppage, e.g. an IMU clock lagging the LiDAR clock by more than the queue absorbs.

## Fix

`imu_scan_release_time()` (`ImuScanSync.h`) bounds the wait: a scan whose coverage end is older than `latest_obs_time_ - max_time_to_wait_for_imu` is released with whatever IMU data did arrive. The odometry degrades to LiDAR-only and picks the IMU back up by itself when it returns. New parameter `max_time_to_wait_for_imu`, default 0.5 s; 0 restores the unbounded wait.

**The bound is in sensor time** — `latest_obs_time_`, the newest timestamp on any input — never the wall clock. That is the whole point: a wall-clock timeout would make the released set depend on machine load, reintroducing exactly the nondeterminism #129 removed. It also costs nothing to skip: a wall-clock bound would only ever differ when *every* input has gone silent, and then there is nothing to process anyway. A throttled warning now names the stalled IMU explicitly.

### Companion: a consumed-IMU watermark

Releasing a scan without its IMU means the pipeline moves past instants whose readings may still arrive (an input interleaving the two streams out of order can do this too). `PendingImuBuffer` now records the newest consumed instant and rejects anything at or below it, so IMU data is never applied out of chronological order into the de-skew buffer, the pitch/roll calibrator or the gravity estimators. `clear()` resets it, a reset being a new session.

## Verification

- `oxford-spires-2024-03-12-keble-college-03`, offline CLI, `lidar3d-default` + `state-estimation-simple`: **byte-identical to `develop`** (`69adf95d…`, 2867 poses) across repeat runs, and neither the bound nor the watermark ever engages on this stream — a healthy IMU is unaffected.
- The release policy is a free function precisely so it is unit tested without threads or a dataset (healthy IMU, stalled IMU, IMU returning, bound disabled), alongside watermark tests. 40/40 package tests pass.

## Not changed

Scans arriving *before* the first IMU reading are still processed ungated. The gate keys off IMU data actually flowing rather than off `imu_sensor_label`, since every pipeline YAML defaults that to `imu` and keying off the parameter would stall KITTI and every other IMU-less dataset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable timeout for LiDAR scans waiting for IMU data, defaulting to 0.5 seconds.
  * Scans can now continue with LiDAR-only processing when IMU coverage is delayed or unavailable.
  * Set the timeout to 0 to preserve indefinite waiting behavior.

* **Bug Fixes**
  * Prevented late or duplicate IMU readings from being reused.
  * Reset sensor synchronization state correctly between sessions.

* **Documentation**
  * Documented timeout behavior, late IMU rejection, and session reset handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->