### PR TITLE
Initial IMU attitude: a time window in seconds, and gate it on dispersion

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -587,11 +587,42 @@ public:
       // becomes the max of the two when both are set).
       uint32_t additional_map_freeze_after_reloc_how_many_timesteps = 0;
 
-      /// Number of IMU (accelerometer) samples to accumulate while stationary to estimate Pitch & Roll:
+      /// Seconds of accelerometer data to average while stationary to estimate Pitch & Roll.
+      /// This is the knob that actually determines accuracy: the error is dominated by platform
+      /// motion during the window, not by sensor noise, so what matters is the DURATION and not
+      /// how many samples the sensor happens to deliver in it.
+      double imu_initial_calibration_window_seconds = 1.0;
+
+      /// Minimum number of samples inside the window above. A sanity floor to reject a
+      /// degenerate handful of samples; it is not what sets the averaging time.
+      uint32_t imu_initial_calibration_min_samples = 20;
+
+      /// Maximum RMS angular dispersion [deg] of the accelerometer directions in the window for
+      /// it to be accepted as measuring gravity. While it is exceeded, initialization is
+      /// deferred and retried with a fresher window, instead of freezing an attitude taken while
+      /// the platform was being jostled. 0 disables the gate.
+      double imu_initial_calibration_max_dispersion_deg = 1.5;
+
+      /// How long [s] the dispersion gate above may defer initialization before accepting the
+      /// most recent window anyway, so a permanently dynamic start still initializes.
+      /// 0 waits indefinitely for a quiet window.
+      double imu_initial_calibration_dispersion_timeout = 5.0;
+
+      /// DEPRECATED, use imu_initial_calibration_window_seconds instead.
+      /// Number of IMU (accelerometer) samples to accumulate to estimate Pitch & Roll. Couples
+      /// the averaging time to the sensor rate, and cannot be satisfied at all by a low-rate IMU
+      /// if the samples do not fit within imu_initial_calibration_max_age. Only honored when it
+      /// is set in the YAML and imu_initial_calibration_window_seconds is not.
       uint32_t imu_initial_calibration_sample_count = 50;
 
-      /// Maximum time span (in seconds) for the "imu_initial_calibration_sample_count" IMU samples:
+      /// Maximum time span (in seconds) for the "imu_initial_calibration_sample_count" IMU
+      /// samples. Only used by that deprecated path: in time-window mode the buffer horizon is
+      /// the window itself.
       double imu_initial_calibration_max_age = 0.75;
+
+      /// Set by initialize() when only the deprecated sample-count parameter is present in the
+      /// YAML, in which case the legacy readiness rule is preserved as-is.
+      bool imu_initial_calibration_legacy_mode = false;
 
       /// If provided by the IMU, prefer gravity-aligned orientation from the sensor instead of accelerometer data.
       bool use_imu_orientation = true;
@@ -667,6 +698,18 @@ public:
       /// Maximum age [seconds] for accelerometer samples used in averaging.
       /// Samples older than this are discarded. 0 = no age limit.
       double max_age_seconds = 2.0;
+
+      /// Maximum RMS angular dispersion [deg] of the buffered accelerometer directions for the
+      /// one-shot map-origin verticality capture to be accepted. The capture decides the map's
+      /// vertical reference for the whole run, so while this is exceeded it is deferred and
+      /// retried at the next scan rather than freezing a reading taken during a footfall.
+      /// 0 disables the gate.
+      double map_origin_max_dispersion_deg = 1.0;
+
+      /// How long [s] the capture may be deferred by the gate above before it is taken anyway.
+      /// Measured from the first scan at which accelerometer data was available.
+      /// 0 defers indefinitely until a quiet reading shows up.
+      double map_origin_capture_timeout = 3.0;
 
       /// Estimate the map-frame gravity direction online, instead of freezing
       /// it from one accelerometer average at the first keyframe.
@@ -1049,6 +1092,10 @@ private:
     /// offset is required to correctly re-express later absolute IMU tilt
     /// readings relative to the (possibly non-level) map frame.
     std::optional<std::pair<double, double>> gravity_calib_pitch_roll;
+
+    /// Sensor timestamp of the first scan at which an accelerometer average was available for
+    /// the map-origin verticality capture, so the dispersion gate's timeout can be measured.
+    std::optional<double> gravity_calib_first_available_time;
 
     /// Vehicle pose at the instant `gravity_calib_pitch_roll` was captured.
     /// The capture is attempted at the first keyframe, but the accelerometer

--- a/module/src/LidarOdometry_InitialLocalization.cpp
+++ b/module/src/LidarOdometry_InitialLocalization.cpp
@@ -185,6 +185,7 @@ void LidarOdometry::handleInitialLocalization()
           }
           state_.gravity_calib_pitch_roll.reset();  // new map origin: recapture at next first KF
           state_.gravity_calib_pose.reset();
+          state_.gravity_calib_first_available_time.reset();
           ASSERT_(state_.local_map->empty());
           {
             auto lckSM = mrpt::lockHelper(state_simplemap_mtx_);

--- a/module/src/LidarOdometry_InitialLocalization.cpp
+++ b/module/src/LidarOdometry_InitialLocalization.cpp
@@ -97,18 +97,66 @@ void LidarOdometry::handleInitialLocalization()
       // Construct the IMU averager object:
       if (!state_.imu_initializer) {
         state_.imu_initializer = mola::imu::ImuInitialCalibrator();
-        state_.imu_initializer->parameters.max_samples_age = il.imu_initial_calibration_max_age;
-        state_.imu_initializer->parameters.required_samples =
-          il.imu_initial_calibration_sample_count;
+        auto & ip = state_.imu_initializer->parameters;
+
+        ip.max_samples_age = il.imu_initial_calibration_max_age;
+        ip.required_samples = il.imu_initial_calibration_sample_count;
 #if defined(MOLA_IMU_PREINT_HAS_USE_IMU_ORIENT_PARAM)  // Remove in a few months from Dec 2025
-        state_.imu_initializer->parameters.use_imu_orientation = il.use_imu_orientation;
+        ip.use_imu_orientation = il.use_imu_orientation;
+#endif
+
+#if defined(MOLA_IMU_PREINT_HAS_INIT_TIME_WINDOW)
+        if (il.imu_initial_calibration_legacy_mode) {
+          MRPT_LOG_WARN_FMT(
+            "initial_localization.imu_initial_calibration_sample_count is deprecated: it ties the "
+            "averaging time to the IMU rate (%u samples is %.2f s at 400 Hz but %.2f s at 100 Hz) "
+            "and cannot be reached at all below ~%.0f Hz within "
+            "imu_initial_calibration_max_age=%.1f s. Use "
+            "imu_initial_calibration_window_seconds instead.",
+            static_cast<unsigned>(il.imu_initial_calibration_sample_count),
+            il.imu_initial_calibration_sample_count / 400.0,
+            il.imu_initial_calibration_sample_count / 100.0,
+            il.imu_initial_calibration_sample_count / il.imu_initial_calibration_max_age,
+            il.imu_initial_calibration_max_age);
+        } else {
+          ip.window_seconds = il.imu_initial_calibration_window_seconds;
+          ip.required_samples = il.imu_initial_calibration_min_samples;
+          ip.max_direction_dispersion =
+            mrpt::DEG2RAD(il.imu_initial_calibration_max_dispersion_deg);
+          ip.dispersion_timeout = il.imu_initial_calibration_dispersion_timeout;
+        }
+#else
+        if (!il.imu_initial_calibration_legacy_mode) {
+          MRPT_LOG_WARN_FMT(
+            "Built against a mola_imu_preintegration without time-window support: "
+            "imu_initial_calibration_window_seconds is ignored and %u samples are used instead.",
+            static_cast<unsigned>(il.imu_initial_calibration_sample_count));
+        }
 #endif
       }
+
+#if defined(MOLA_IMU_PREINT_HAS_INIT_TIME_WINDOW)
+      const auto imuReadiness = state_.imu_initializer->readiness();
+      const bool imuIsReady = imuReadiness.ready;
+#else
+      const bool imuIsReady = state_.imu_initializer->isReady();
+#endif
+
       // Already collected enough samples?
-      if (state_.imu_initializer->isReady()) {
+      if (imuIsReady) {
         // Get the average pitch & roll:
         const auto & imu_calib_opt = state_.imu_initializer->getCalibration();
         ASSERT_(imu_calib_opt);
+
+#if defined(MOLA_IMU_PREINT_HAS_INIT_TIME_WINDOW)
+        MRPT_LOG_INFO_FMT(
+          "IMU initial attitude averaged over %.3f s (%zu samples, dispersion %.2f deg)%s",
+          imuReadiness.span, imuReadiness.samples,
+          mrpt::RAD2DEG(imuReadiness.dispersion.value_or(0.0)),
+          imuReadiness.timed_out ? ", accepted on gate timeout: the platform never became still, "
+                                   "so this attitude includes its motion"
+                                 : "");
+#endif
 
         MRPT_LOG_INFO_STREAM("IMU automatic calibration done: " << imu_calib_opt->asString());
 
@@ -148,8 +196,17 @@ void LidarOdometry::handleInitialLocalization()
         state_.imu_initializer.reset();  // no longer needed
 
       } else {
+#if defined(MOLA_IMU_PREINT_HAS_INIT_TIME_WINDOW)
+        MRPT_LOG_THROTTLE_INFO_FMT(
+          5.0,
+          "Waiting to initialize pitch & roll from the IMU: %s (%zu samples spanning %.3f s, "
+          "dispersion %.2f deg, %.1f s elapsed)",
+          imuReadiness.reason.c_str(), imuReadiness.samples, imuReadiness.span,
+          mrpt::RAD2DEG(imuReadiness.dispersion.value_or(0.0)), imuReadiness.elapsed);
+#else
         MRPT_LOG_THROTTLE_INFO(
           5.0, "Waiting for enough IMU samples to initialize pitch & roll while stationary...");
+#endif
       }
     } break;
 

--- a/module/src/LidarOdometry_MapServer.cpp
+++ b/module/src/LidarOdometry_MapServer.cpp
@@ -97,6 +97,7 @@ MapServer::ReturnStatus LidarOdometry::map_load_impl(const std::string & path)
     state_.local_map->clear();
     state_.gravity_calib_pitch_roll.reset();  // new map origin: recapture at next first KF
     state_.gravity_calib_pose.reset();
+    state_.gravity_calib_first_available_time.reset();
 
     // Mark for GUI / publishing even if we fail to load (so the map is shown
     // as empty rather than stale):

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -304,8 +304,21 @@ void LidarOdometry::Parameters::InitialLocalizationOptions::initialize(const Yam
 
   YAML_LOAD_OPT(additional_uncertainty_after_reloc_how_many_timesteps, uint32_t);
   YAML_LOAD_OPT(additional_map_freeze_after_reloc_how_many_timesteps, uint32_t);
+  YAML_LOAD_OPT(imu_initial_calibration_window_seconds, double);
+  YAML_LOAD_OPT(imu_initial_calibration_min_samples, uint32_t);
+  YAML_LOAD_OPT(imu_initial_calibration_max_dispersion_deg, double);
+  YAML_LOAD_OPT(imu_initial_calibration_dispersion_timeout, double);
   YAML_LOAD_OPT(imu_initial_calibration_sample_count, uint32_t);
   YAML_LOAD_OPT(imu_initial_calibration_max_age, double);
+
+  // Backwards compatibility: a configuration written for the sample-count knob alone keeps its
+  // exact former behavior, so upgrading does not silently change what it averages. As soon as
+  // the time window is named in the YAML, it is the one in charge and the sample count is
+  // ignored (a fixed sample count cannot be met inside a fixed window at an arbitrary rate).
+  imu_initial_calibration_legacy_mode = cfg.has("imu_initial_calibration_sample_count") &&
+                                        !cfg.has("imu_initial_calibration_window_seconds");
+
+  ASSERT_(imu_initial_calibration_window_seconds > 0 || imu_initial_calibration_legacy_mode);
   YAML_LOAD_OPT(use_imu_orientation, bool);
   YAML_LOAD_OPT(from_state_estimator_max_position_sigma, double);
   YAML_LOAD_OPT(from_state_estimator_max_orientation_sigma_deg, double);
@@ -340,6 +353,8 @@ void LidarOdometry::Parameters::IMUGravityCorrection::initialize(const Yaml & cf
   YAML_LOAD_OPT(sigma_deg, double);
   YAML_LOAD_OPT(averaging_samples, uint32_t);
   YAML_LOAD_OPT(max_age_seconds, double);
+  YAML_LOAD_OPT(map_origin_max_dispersion_deg, double);
+  YAML_LOAD_OPT(map_origin_capture_timeout, double);
 
   if (enabled) {
     ASSERTMSG_(

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -1267,6 +1267,7 @@ void LidarOdometry::processLidarScan(  // NOLINT
     state_.estimated_trajectory.clear();
     state_.gravity_calib_pitch_roll.reset();  // new map origin: recapture at next first KF
     state_.gravity_calib_pose.reset();
+    state_.gravity_calib_first_available_time.reset();
     updateLocalMap = false;
     state_.last_icp_was_good = true;
 

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -236,6 +236,47 @@ void LidarOdometry::captureMapOriginVerticality(const mrpt::poses::CPose3D & pos
     return;
   }
 
+  // The data is there, but is it gravity? This one reading defines the map's vertical for the
+  // whole run, so defer it while the buffered directions disagree too much, the same way the
+  // capture is already retried when there is no data at all. Deferring forever is not an
+  // option either: a platform that is never still still needs a reference, so after a timeout
+  // the reading is taken as-is.
+  const double maxDisp =
+    mrpt::DEG2RAD(params_.imu_gravity_correction.map_origin_max_dispersion_deg);
+  bool takenOnTimeout = false;
+
+  if (maxDisp > 0) {
+    const auto disp = state_.gravity_estimator.directionDispersionSigma(
+      params_.imu_gravity_correction.max_age_seconds);
+
+    if (disp.has_value() && *disp > maxDisp) {
+      const double now = state_.last_obs_timestamp.has_value()
+                           ? mrpt::Clock::toDouble(*state_.last_obs_timestamp)
+                           : 0.0;
+
+      if (!state_.gravity_calib_first_available_time.has_value()) {
+        state_.gravity_calib_first_available_time = now;
+      }
+      const double waited = now - *state_.gravity_calib_first_available_time;
+      const double timeout = params_.imu_gravity_correction.map_origin_capture_timeout;
+
+      if (timeout <= 0 || waited < timeout) {
+        MRPT_LOG_THROTTLE_INFO_FMT(
+          2.0,
+          "Deferring the map-origin verticality capture: accelerometer dispersion %.2f deg > "
+          "%.2f deg (waited %.1f s)",
+          mrpt::RAD2DEG(*disp), mrpt::RAD2DEG(maxDisp), waited);
+        return;
+      }
+      takenOnTimeout = true;
+      MRPT_LOG_WARN_FMT(
+        "Taking the map-origin verticality reference after %.1f s with an accelerometer "
+        "dispersion of %.2f deg (> %.2f deg): the platform never became still, so the map's "
+        "vertical carries that motion.",
+        waited, mrpt::RAD2DEG(*disp), mrpt::RAD2DEG(maxDisp));
+    }
+  }
+
   state_.gravity_calib_pitch_roll = pr;
   state_.gravity_calib_pose = poseAtCapture;
 
@@ -244,9 +285,9 @@ void LidarOdometry::captureMapOriginVerticality(const mrpt::poses::CPose3D & pos
   // tilt behavior is questioned later starts here.
   const auto [p0, r0] = *pr;
   MRPT_LOG_INFO_FMT(
-    "Map-origin verticality reference captured from the accelerometer: "
+    "Map-origin verticality reference captured from the accelerometer%s: "
     "pitch=%.3f roll=%.3f deg (tilt %.3f deg), at pose [%s]",
-    mrpt::RAD2DEG(p0), mrpt::RAD2DEG(r0),
+    takenOnTimeout ? " (on dispersion-gate timeout)" : "", mrpt::RAD2DEG(p0), mrpt::RAD2DEG(r0),
     mrpt::RAD2DEG(std::acos(std::clamp(std::cos(p0) * std::cos(r0), -1.0, 1.0))),
     poseAtCapture.asString().c_str());
 }

--- a/pipelines/extras/lidar3d-hybrid-pw.yaml
+++ b/pipelines/extras/lidar3d-hybrid-pw.yaml
@@ -59,6 +59,12 @@ params:
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
     max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}
+    # The one-shot map-origin verticality capture defines the map's vertical
+    # for the whole run, so it is deferred to a later scan while the buffered
+    # accelerometer directions disagree by more than this (i.e. the reading is
+    # motion, not gravity), and taken as-is after the timeout.
+    map_origin_max_dispersion_deg: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_MAX_DISPERSION|1.0}
+    map_origin_capture_timeout: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_TIMEOUT|3.0}
 
   publish_reference_frame: "${MOLA_LO_PUBLISH_REF_FRAME|odom}"
   publish_vehicle_frame: "${MOLA_LO_PUBLISH_VEHICLE_FRAME|base_link}"
@@ -170,8 +176,19 @@ initial_localization:
   method: "${MOLA_LO_INITIAL_LOCALIZATION_METHOD|InitLocalization::FixedPose}"
   fixed_initial_pose:
     ["${MOLA_INITIAL_X|0.0}", "${MOLA_INITIAL_Y|0.0}", "${MOLA_INITIAL_Z|0.0}", "${MOLA_INITIAL_YAW|0.0}", "${MOLA_INITIAL_PITCH|0.0}", "${MOLA_INITIAL_ROLL|0.0}"]
-  imu_initial_calibration_sample_count: "${MOLA_LO_INITIAL_IMU_SAMPLES|400}"
-  imu_initial_calibration_max_age: 5.0
+  # Seconds of accelerometer data to average for the initial pitch & roll.
+  # A duration, not a sample count: what limits accuracy is platform motion
+  # during the window, so the same setting must mean the same averaging time
+  # on a 100 Hz and on a 400 Hz IMU.
+  imu_initial_calibration_window_seconds: "${MOLA_LO_INITIAL_IMU_WINDOW|1.0}"
+  # Sanity floor only, to reject a degenerate handful of samples:
+  imu_initial_calibration_min_samples: "${MOLA_LO_INITIAL_IMU_MIN_SAMPLES|20}"
+  # Defer initialization while the accelerometer directions in the window
+  # disagree by more than this: such a window is measuring platform motion,
+  # not gravity. After the timeout it is accepted anyway, so a start that is
+  # never still still initializes.
+  imu_initial_calibration_max_dispersion_deg: "${MOLA_LO_INITIAL_IMU_MAX_DISPERSION|1.5}"
+  imu_initial_calibration_dispersion_timeout: "${MOLA_LO_INITIAL_IMU_DISPERSION_TIMEOUT|5.0}"
   use_imu_orientation: "${MOLA_LO_INITIAL_IMU_USE_ORIENTATION|true}"
   additional_map_freeze_after_reloc_how_many_timesteps: "${MOLA_LO_INIT_MAP_FREEZE_STEPS|0}"
   from_state_estimator_max_position_sigma: "${MOLA_LO_INIT_SE_MAX_POS_SIGMA|0.5}"

--- a/pipelines/lidar3d-default-voxelavg.yaml
+++ b/pipelines/lidar3d-default-voxelavg.yaml
@@ -61,6 +61,12 @@ params:
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
     max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}
+    # The one-shot map-origin verticality capture defines the map's vertical
+    # for the whole run, so it is deferred to a later scan while the buffered
+    # accelerometer directions disagree by more than this (i.e. the reading is
+    # motion, not gravity), and taken as-is after the timeout.
+    map_origin_max_dispersion_deg: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_MAX_DISPERSION|1.0}
+    map_origin_capture_timeout: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_TIMEOUT|3.0}
     # NOTE: averaging_samples must fit inside max_age_seconds at the actual IMU
     # rate, or estimatedPitchRoll() returns nothing and the constraint is
     # silently inactive (at 400 Hz, 2.0 s holds only ~800 samples).
@@ -293,8 +299,19 @@ initial_localization:
   # Format: x(m) y(m) z(m) yaw(deg) pitch(deg) roll(deg)
   fixed_initial_pose:
     ["${MOLA_INITIAL_X|0.0}", "${MOLA_INITIAL_Y|0.0}", "${MOLA_INITIAL_Z|0.0}", "${MOLA_INITIAL_YAW|0.0}", "${MOLA_INITIAL_PITCH|0.0}", "${MOLA_INITIAL_ROLL|0.0}"]
-  imu_initial_calibration_sample_count: "${MOLA_LO_INITIAL_IMU_SAMPLES|400}"
-  imu_initial_calibration_max_age: 5.0
+  # Seconds of accelerometer data to average for the initial pitch & roll.
+  # A duration, not a sample count: what limits accuracy is platform motion
+  # during the window, so the same setting must mean the same averaging time
+  # on a 100 Hz and on a 400 Hz IMU.
+  imu_initial_calibration_window_seconds: "${MOLA_LO_INITIAL_IMU_WINDOW|1.0}"
+  # Sanity floor only, to reject a degenerate handful of samples:
+  imu_initial_calibration_min_samples: "${MOLA_LO_INITIAL_IMU_MIN_SAMPLES|20}"
+  # Defer initialization while the accelerometer directions in the window
+  # disagree by more than this: such a window is measuring platform motion,
+  # not gravity. After the timeout it is accepted anyway, so a start that is
+  # never still still initializes.
+  imu_initial_calibration_max_dispersion_deg: "${MOLA_LO_INITIAL_IMU_MAX_DISPERSION|1.5}"
+  imu_initial_calibration_dispersion_timeout: "${MOLA_LO_INITIAL_IMU_DISPERSION_TIMEOUT|5.0}"
   use_imu_orientation: "${MOLA_LO_INITIAL_IMU_USE_ORIENTATION|true}"
   # Right after a re-localization (or initial localization), also hold off
   # local map / simplemap updates for this many timesteps (shares the same

--- a/pipelines/lidar3d-dlio-like-only-downsample-voxelavg.yaml
+++ b/pipelines/lidar3d-dlio-like-only-downsample-voxelavg.yaml
@@ -83,6 +83,12 @@ params:
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
     max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}
+    # The one-shot map-origin verticality capture defines the map's vertical
+    # for the whole run, so it is deferred to a later scan while the buffered
+    # accelerometer directions disagree by more than this (i.e. the reading is
+    # motion, not gravity), and taken as-is after the timeout.
+    map_origin_max_dispersion_deg: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_MAX_DISPERSION|1.0}
+    map_origin_capture_timeout: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_TIMEOUT|3.0}
     # NOTE: averaging_samples must fit inside max_age_seconds at the actual IMU
     # rate, or estimatedPitchRoll() returns nothing and the constraint is
     # silently inactive (at 400 Hz, 2.0 s holds only ~800 samples).
@@ -315,8 +321,19 @@ initial_localization:
   # Format: x(m) y(m) z(m) yaw(deg) pitch(deg) roll(deg)
   fixed_initial_pose:
     ["${MOLA_INITIAL_X|0.0}", "${MOLA_INITIAL_Y|0.0}", "${MOLA_INITIAL_Z|0.0}", "${MOLA_INITIAL_YAW|0.0}", "${MOLA_INITIAL_PITCH|0.0}", "${MOLA_INITIAL_ROLL|0.0}"]
-  imu_initial_calibration_sample_count: "${MOLA_LO_INITIAL_IMU_SAMPLES|400}"
-  imu_initial_calibration_max_age: 5.0
+  # Seconds of accelerometer data to average for the initial pitch & roll.
+  # A duration, not a sample count: what limits accuracy is platform motion
+  # during the window, so the same setting must mean the same averaging time
+  # on a 100 Hz and on a 400 Hz IMU.
+  imu_initial_calibration_window_seconds: "${MOLA_LO_INITIAL_IMU_WINDOW|1.0}"
+  # Sanity floor only, to reject a degenerate handful of samples:
+  imu_initial_calibration_min_samples: "${MOLA_LO_INITIAL_IMU_MIN_SAMPLES|20}"
+  # Defer initialization while the accelerometer directions in the window
+  # disagree by more than this: such a window is measuring platform motion,
+  # not gravity. After the timeout it is accepted anyway, so a start that is
+  # never still still initializes.
+  imu_initial_calibration_max_dispersion_deg: "${MOLA_LO_INITIAL_IMU_MAX_DISPERSION|1.5}"
+  imu_initial_calibration_dispersion_timeout: "${MOLA_LO_INITIAL_IMU_DISPERSION_TIMEOUT|5.0}"
   use_imu_orientation: "${MOLA_LO_INITIAL_IMU_USE_ORIENTATION|true}"
   # Right after a re-localization (or initial localization), also hold off
   # local map / simplemap updates for this many timesteps (shares the same

--- a/pipelines/lidar3d-dlio-like-only-downsample.yaml
+++ b/pipelines/lidar3d-dlio-like-only-downsample.yaml
@@ -72,6 +72,12 @@ params:
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
     max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}
+    # The one-shot map-origin verticality capture defines the map's vertical
+    # for the whole run, so it is deferred to a later scan while the buffered
+    # accelerometer directions disagree by more than this (i.e. the reading is
+    # motion, not gravity), and taken as-is after the timeout.
+    map_origin_max_dispersion_deg: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_MAX_DISPERSION|1.0}
+    map_origin_capture_timeout: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_TIMEOUT|3.0}
     # NOTE: averaging_samples must fit inside max_age_seconds at the actual IMU
     # rate, or estimatedPitchRoll() returns nothing and the constraint is
     # silently inactive (at 400 Hz, 2.0 s holds only ~800 samples).
@@ -304,8 +310,19 @@ initial_localization:
   # Format: x(m) y(m) z(m) yaw(deg) pitch(deg) roll(deg)
   fixed_initial_pose:
     ["${MOLA_INITIAL_X|0.0}", "${MOLA_INITIAL_Y|0.0}", "${MOLA_INITIAL_Z|0.0}", "${MOLA_INITIAL_YAW|0.0}", "${MOLA_INITIAL_PITCH|0.0}", "${MOLA_INITIAL_ROLL|0.0}"]
-  imu_initial_calibration_sample_count: "${MOLA_LO_INITIAL_IMU_SAMPLES|400}"
-  imu_initial_calibration_max_age: 5.0
+  # Seconds of accelerometer data to average for the initial pitch & roll.
+  # A duration, not a sample count: what limits accuracy is platform motion
+  # during the window, so the same setting must mean the same averaging time
+  # on a 100 Hz and on a 400 Hz IMU.
+  imu_initial_calibration_window_seconds: "${MOLA_LO_INITIAL_IMU_WINDOW|1.0}"
+  # Sanity floor only, to reject a degenerate handful of samples:
+  imu_initial_calibration_min_samples: "${MOLA_LO_INITIAL_IMU_MIN_SAMPLES|20}"
+  # Defer initialization while the accelerometer directions in the window
+  # disagree by more than this: such a window is measuring platform motion,
+  # not gravity. After the timeout it is accepted anyway, so a start that is
+  # never still still initializes.
+  imu_initial_calibration_max_dispersion_deg: "${MOLA_LO_INITIAL_IMU_MAX_DISPERSION|1.5}"
+  imu_initial_calibration_dispersion_timeout: "${MOLA_LO_INITIAL_IMU_DISPERSION_TIMEOUT|5.0}"
   use_imu_orientation: "${MOLA_LO_INITIAL_IMU_USE_ORIENTATION|true}"
   # Right after a re-localization (or initial localization), also hold off
   # local map / simplemap updates for this many timesteps (shares the same

--- a/pipelines/lidar3d-dlio-like-revert-downsample.yaml
+++ b/pipelines/lidar3d-dlio-like-revert-downsample.yaml
@@ -80,6 +80,12 @@ params:
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
     max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}
+    # The one-shot map-origin verticality capture defines the map's vertical
+    # for the whole run, so it is deferred to a later scan while the buffered
+    # accelerometer directions disagree by more than this (i.e. the reading is
+    # motion, not gravity), and taken as-is after the timeout.
+    map_origin_max_dispersion_deg: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_MAX_DISPERSION|1.0}
+    map_origin_capture_timeout: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_TIMEOUT|3.0}
     map_gravity:
       enabled: ${MOLA_IMU_MAP_GRAVITY|false}
       log_only: ${MOLA_IMU_MAP_GRAVITY_LOG_ONLY|false}
@@ -211,8 +217,19 @@ initial_localization:
   method: "${MOLA_LO_INITIAL_LOCALIZATION_METHOD|InitLocalization::FixedPose}"
   fixed_initial_pose:
     ["${MOLA_INITIAL_X|0.0}", "${MOLA_INITIAL_Y|0.0}", "${MOLA_INITIAL_Z|0.0}", "${MOLA_INITIAL_YAW|0.0}", "${MOLA_INITIAL_PITCH|0.0}", "${MOLA_INITIAL_ROLL|0.0}"]
-  imu_initial_calibration_sample_count: "${MOLA_LO_INITIAL_IMU_SAMPLES|400}"
-  imu_initial_calibration_max_age: 5.0
+  # Seconds of accelerometer data to average for the initial pitch & roll.
+  # A duration, not a sample count: what limits accuracy is platform motion
+  # during the window, so the same setting must mean the same averaging time
+  # on a 100 Hz and on a 400 Hz IMU.
+  imu_initial_calibration_window_seconds: "${MOLA_LO_INITIAL_IMU_WINDOW|1.0}"
+  # Sanity floor only, to reject a degenerate handful of samples:
+  imu_initial_calibration_min_samples: "${MOLA_LO_INITIAL_IMU_MIN_SAMPLES|20}"
+  # Defer initialization while the accelerometer directions in the window
+  # disagree by more than this: such a window is measuring platform motion,
+  # not gravity. After the timeout it is accepted anyway, so a start that is
+  # never still still initializes.
+  imu_initial_calibration_max_dispersion_deg: "${MOLA_LO_INITIAL_IMU_MAX_DISPERSION|1.5}"
+  imu_initial_calibration_dispersion_timeout: "${MOLA_LO_INITIAL_IMU_DISPERSION_TIMEOUT|5.0}"
   use_imu_orientation: "${MOLA_LO_INITIAL_IMU_USE_ORIENTATION|true}"
   additional_map_freeze_after_reloc_how_many_timesteps: "${MOLA_LO_INIT_MAP_FREEZE_STEPS|0}"
   from_state_estimator_max_position_sigma: "${MOLA_LO_INIT_SE_MAX_POS_SIGMA|0.5}"

--- a/pipelines/lidar3d-dlio-like-revert-keyframe.yaml
+++ b/pipelines/lidar3d-dlio-like-revert-keyframe.yaml
@@ -79,6 +79,12 @@ params:
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
     max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}
+    # The one-shot map-origin verticality capture defines the map's vertical
+    # for the whole run, so it is deferred to a later scan while the buffered
+    # accelerometer directions disagree by more than this (i.e. the reading is
+    # motion, not gravity), and taken as-is after the timeout.
+    map_origin_max_dispersion_deg: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_MAX_DISPERSION|1.0}
+    map_origin_capture_timeout: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_TIMEOUT|3.0}
     map_gravity:
       enabled: ${MOLA_IMU_MAP_GRAVITY|false}
       log_only: ${MOLA_IMU_MAP_GRAVITY_LOG_ONLY|false}
@@ -207,8 +213,19 @@ initial_localization:
   method: "${MOLA_LO_INITIAL_LOCALIZATION_METHOD|InitLocalization::FixedPose}"
   fixed_initial_pose:
     ["${MOLA_INITIAL_X|0.0}", "${MOLA_INITIAL_Y|0.0}", "${MOLA_INITIAL_Z|0.0}", "${MOLA_INITIAL_YAW|0.0}", "${MOLA_INITIAL_PITCH|0.0}", "${MOLA_INITIAL_ROLL|0.0}"]
-  imu_initial_calibration_sample_count: "${MOLA_LO_INITIAL_IMU_SAMPLES|400}"
-  imu_initial_calibration_max_age: 5.0
+  # Seconds of accelerometer data to average for the initial pitch & roll.
+  # A duration, not a sample count: what limits accuracy is platform motion
+  # during the window, so the same setting must mean the same averaging time
+  # on a 100 Hz and on a 400 Hz IMU.
+  imu_initial_calibration_window_seconds: "${MOLA_LO_INITIAL_IMU_WINDOW|1.0}"
+  # Sanity floor only, to reject a degenerate handful of samples:
+  imu_initial_calibration_min_samples: "${MOLA_LO_INITIAL_IMU_MIN_SAMPLES|20}"
+  # Defer initialization while the accelerometer directions in the window
+  # disagree by more than this: such a window is measuring platform motion,
+  # not gravity. After the timeout it is accepted anyway, so a start that is
+  # never still still initializes.
+  imu_initial_calibration_max_dispersion_deg: "${MOLA_LO_INITIAL_IMU_MAX_DISPERSION|1.5}"
+  imu_initial_calibration_dispersion_timeout: "${MOLA_LO_INITIAL_IMU_DISPERSION_TIMEOUT|5.0}"
   use_imu_orientation: "${MOLA_LO_INITIAL_IMU_USE_ORIENTATION|true}"
   additional_map_freeze_after_reloc_how_many_timesteps: "${MOLA_LO_INIT_MAP_FREEZE_STEPS|0}"
   from_state_estimator_max_position_sigma: "${MOLA_LO_INIT_SE_MAX_POS_SIGMA|0.5}"

--- a/pipelines/lidar3d-dlio-like-worldframe-decimate.yaml
+++ b/pipelines/lidar3d-dlio-like-worldframe-decimate.yaml
@@ -118,6 +118,12 @@ params:
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
     max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}
+    # The one-shot map-origin verticality capture defines the map's vertical
+    # for the whole run, so it is deferred to a later scan while the buffered
+    # accelerometer directions disagree by more than this (i.e. the reading is
+    # motion, not gravity), and taken as-is after the timeout.
+    map_origin_max_dispersion_deg: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_MAX_DISPERSION|1.0}
+    map_origin_capture_timeout: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_TIMEOUT|3.0}
     map_gravity:
       enabled: ${MOLA_IMU_MAP_GRAVITY|false}
       log_only: ${MOLA_IMU_MAP_GRAVITY_LOG_ONLY|false}
@@ -249,8 +255,19 @@ initial_localization:
   method: "${MOLA_LO_INITIAL_LOCALIZATION_METHOD|InitLocalization::FixedPose}"
   fixed_initial_pose:
     ["${MOLA_INITIAL_X|0.0}", "${MOLA_INITIAL_Y|0.0}", "${MOLA_INITIAL_Z|0.0}", "${MOLA_INITIAL_YAW|0.0}", "${MOLA_INITIAL_PITCH|0.0}", "${MOLA_INITIAL_ROLL|0.0}"]
-  imu_initial_calibration_sample_count: "${MOLA_LO_INITIAL_IMU_SAMPLES|400}"
-  imu_initial_calibration_max_age: 5.0
+  # Seconds of accelerometer data to average for the initial pitch & roll.
+  # A duration, not a sample count: what limits accuracy is platform motion
+  # during the window, so the same setting must mean the same averaging time
+  # on a 100 Hz and on a 400 Hz IMU.
+  imu_initial_calibration_window_seconds: "${MOLA_LO_INITIAL_IMU_WINDOW|1.0}"
+  # Sanity floor only, to reject a degenerate handful of samples:
+  imu_initial_calibration_min_samples: "${MOLA_LO_INITIAL_IMU_MIN_SAMPLES|20}"
+  # Defer initialization while the accelerometer directions in the window
+  # disagree by more than this: such a window is measuring platform motion,
+  # not gravity. After the timeout it is accepted anyway, so a start that is
+  # never still still initializes.
+  imu_initial_calibration_max_dispersion_deg: "${MOLA_LO_INITIAL_IMU_MAX_DISPERSION|1.5}"
+  imu_initial_calibration_dispersion_timeout: "${MOLA_LO_INITIAL_IMU_DISPERSION_TIMEOUT|5.0}"
   use_imu_orientation: "${MOLA_LO_INITIAL_IMU_USE_ORIENTATION|true}"
   additional_map_freeze_after_reloc_how_many_timesteps: "${MOLA_LO_INIT_MAP_FREEZE_STEPS|0}"
   from_state_estimator_max_position_sigma: "${MOLA_LO_INIT_SE_MAX_POS_SIGMA|0.5}"

--- a/pipelines/lidar3d-dlio-like.yaml
+++ b/pipelines/lidar3d-dlio-like.yaml
@@ -78,6 +78,12 @@ params:
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
     max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}
+    # The one-shot map-origin verticality capture defines the map's vertical
+    # for the whole run, so it is deferred to a later scan while the buffered
+    # accelerometer directions disagree by more than this (i.e. the reading is
+    # motion, not gravity), and taken as-is after the timeout.
+    map_origin_max_dispersion_deg: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_MAX_DISPERSION|1.0}
+    map_origin_capture_timeout: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_TIMEOUT|3.0}
     map_gravity:
       enabled: ${MOLA_IMU_MAP_GRAVITY|false}
       log_only: ${MOLA_IMU_MAP_GRAVITY_LOG_ONLY|false}
@@ -209,8 +215,19 @@ initial_localization:
   method: "${MOLA_LO_INITIAL_LOCALIZATION_METHOD|InitLocalization::FixedPose}"
   fixed_initial_pose:
     ["${MOLA_INITIAL_X|0.0}", "${MOLA_INITIAL_Y|0.0}", "${MOLA_INITIAL_Z|0.0}", "${MOLA_INITIAL_YAW|0.0}", "${MOLA_INITIAL_PITCH|0.0}", "${MOLA_INITIAL_ROLL|0.0}"]
-  imu_initial_calibration_sample_count: "${MOLA_LO_INITIAL_IMU_SAMPLES|400}"
-  imu_initial_calibration_max_age: 5.0
+  # Seconds of accelerometer data to average for the initial pitch & roll.
+  # A duration, not a sample count: what limits accuracy is platform motion
+  # during the window, so the same setting must mean the same averaging time
+  # on a 100 Hz and on a 400 Hz IMU.
+  imu_initial_calibration_window_seconds: "${MOLA_LO_INITIAL_IMU_WINDOW|1.0}"
+  # Sanity floor only, to reject a degenerate handful of samples:
+  imu_initial_calibration_min_samples: "${MOLA_LO_INITIAL_IMU_MIN_SAMPLES|20}"
+  # Defer initialization while the accelerometer directions in the window
+  # disagree by more than this: such a window is measuring platform motion,
+  # not gravity. After the timeout it is accepted anyway, so a start that is
+  # never still still initializes.
+  imu_initial_calibration_max_dispersion_deg: "${MOLA_LO_INITIAL_IMU_MAX_DISPERSION|1.5}"
+  imu_initial_calibration_dispersion_timeout: "${MOLA_LO_INITIAL_IMU_DISPERSION_TIMEOUT|5.0}"
   use_imu_orientation: "${MOLA_LO_INITIAL_IMU_USE_ORIENTATION|true}"
   additional_map_freeze_after_reloc_how_many_timesteps: "${MOLA_LO_INIT_MAP_FREEZE_STEPS|0}"
   from_state_estimator_max_position_sigma: "${MOLA_LO_INIT_SE_MAX_POS_SIGMA|0.5}"

--- a/pipelines/lidar3d-gicp-optimize-twist.yaml
+++ b/pipelines/lidar3d-gicp-optimize-twist.yaml
@@ -209,8 +209,19 @@ initial_localization:
   # Format: x(m) y(m) z(m) yaw(deg) pitch(deg) roll(deg)
   fixed_initial_pose:
     ["${MOLA_INITIAL_X|0.0}", "${MOLA_INITIAL_Y|0.0}", "${MOLA_INITIAL_Z|0.0}", "${MOLA_INITIAL_YAW|0.0}", "${MOLA_INITIAL_PITCH|0.0}", "${MOLA_INITIAL_ROLL|0.0}"]
-  imu_initial_calibration_sample_count: "${MOLA_LO_INITIAL_IMU_SAMPLES|400}"
-  imu_initial_calibration_max_age: 5.0
+  # Seconds of accelerometer data to average for the initial pitch & roll.
+  # A duration, not a sample count: what limits accuracy is platform motion
+  # during the window, so the same setting must mean the same averaging time
+  # on a 100 Hz and on a 400 Hz IMU.
+  imu_initial_calibration_window_seconds: "${MOLA_LO_INITIAL_IMU_WINDOW|1.0}"
+  # Sanity floor only, to reject a degenerate handful of samples:
+  imu_initial_calibration_min_samples: "${MOLA_LO_INITIAL_IMU_MIN_SAMPLES|20}"
+  # Defer initialization while the accelerometer directions in the window
+  # disagree by more than this: such a window is measuring platform motion,
+  # not gravity. After the timeout it is accepted anyway, so a start that is
+  # never still still initializes.
+  imu_initial_calibration_max_dispersion_deg: "${MOLA_LO_INITIAL_IMU_MAX_DISPERSION|1.5}"
+  imu_initial_calibration_dispersion_timeout: "${MOLA_LO_INITIAL_IMU_DISPERSION_TIMEOUT|5.0}"
   use_imu_orientation: "${MOLA_LO_INITIAL_IMU_USE_ORIENTATION|true}"
 
 # If "icp_settings_without_vel" is not defined here, defaults to be the same than 'icp_settings_with_vel'

--- a/pipelines/lidar3d-gicp-single-filter.yaml
+++ b/pipelines/lidar3d-gicp-single-filter.yaml
@@ -77,6 +77,12 @@ params:
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
     max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}
+    # The one-shot map-origin verticality capture defines the map's vertical
+    # for the whole run, so it is deferred to a later scan while the buffered
+    # accelerometer directions disagree by more than this (i.e. the reading is
+    # motion, not gravity), and taken as-is after the timeout.
+    map_origin_max_dispersion_deg: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_MAX_DISPERSION|1.0}
+    map_origin_capture_timeout: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_TIMEOUT|3.0}
     # NOTE: averaging_samples must fit inside max_age_seconds at the actual IMU
     # rate, or estimatedPitchRoll() returns nothing and the constraint is
     # silently inactive (at 400 Hz, 2.0 s holds only ~800 samples).
@@ -309,8 +315,19 @@ initial_localization:
   # Format: x(m) y(m) z(m) yaw(deg) pitch(deg) roll(deg)
   fixed_initial_pose:
     ["${MOLA_INITIAL_X|0.0}", "${MOLA_INITIAL_Y|0.0}", "${MOLA_INITIAL_Z|0.0}", "${MOLA_INITIAL_YAW|0.0}", "${MOLA_INITIAL_PITCH|0.0}", "${MOLA_INITIAL_ROLL|0.0}"]
-  imu_initial_calibration_sample_count: "${MOLA_LO_INITIAL_IMU_SAMPLES|400}"
-  imu_initial_calibration_max_age: 5.0
+  # Seconds of accelerometer data to average for the initial pitch & roll.
+  # A duration, not a sample count: what limits accuracy is platform motion
+  # during the window, so the same setting must mean the same averaging time
+  # on a 100 Hz and on a 400 Hz IMU.
+  imu_initial_calibration_window_seconds: "${MOLA_LO_INITIAL_IMU_WINDOW|1.0}"
+  # Sanity floor only, to reject a degenerate handful of samples:
+  imu_initial_calibration_min_samples: "${MOLA_LO_INITIAL_IMU_MIN_SAMPLES|20}"
+  # Defer initialization while the accelerometer directions in the window
+  # disagree by more than this: such a window is measuring platform motion,
+  # not gravity. After the timeout it is accepted anyway, so a start that is
+  # never still still initializes.
+  imu_initial_calibration_max_dispersion_deg: "${MOLA_LO_INITIAL_IMU_MAX_DISPERSION|1.5}"
+  imu_initial_calibration_dispersion_timeout: "${MOLA_LO_INITIAL_IMU_DISPERSION_TIMEOUT|5.0}"
   use_imu_orientation: "${MOLA_LO_INITIAL_IMU_USE_ORIENTATION|true}"
   # Right after a re-localization (or initial localization), also hold off
   # local map / simplemap updates for this many timesteps (shares the same

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -55,6 +55,12 @@ params:
     sigma_deg: ${MOLA_IMU_GRAVITY_SIGMA_DEG|2.0}
     averaging_samples: ${MOLA_IMU_GRAVITY_AVG_SAMPLES|20}
     max_age_seconds: ${MOLA_IMU_GRAVITY_MAX_AGE|2.0}
+    # The one-shot map-origin verticality capture defines the map's vertical
+    # for the whole run, so it is deferred to a later scan while the buffered
+    # accelerometer directions disagree by more than this (i.e. the reading is
+    # motion, not gravity), and taken as-is after the timeout.
+    map_origin_max_dispersion_deg: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_MAX_DISPERSION|1.0}
+    map_origin_capture_timeout: ${MOLA_IMU_GRAVITY_MAP_ORIGIN_TIMEOUT|3.0}
     # NOTE: averaging_samples must fit inside max_age_seconds at the actual IMU
     # rate, or estimatedPitchRoll() returns nothing and the constraint is
     # silently inactive (at 400 Hz, 2.0 s holds only ~800 samples).
@@ -300,8 +306,19 @@ initial_localization:
   # Format: x(m) y(m) z(m) yaw(deg) pitch(deg) roll(deg)
   fixed_initial_pose:
     ["${MOLA_INITIAL_X|0.0}", "${MOLA_INITIAL_Y|0.0}", "${MOLA_INITIAL_Z|0.0}", "${MOLA_INITIAL_YAW|0.0}", "${MOLA_INITIAL_PITCH|0.0}", "${MOLA_INITIAL_ROLL|0.0}"]
-  imu_initial_calibration_sample_count: "${MOLA_LO_INITIAL_IMU_SAMPLES|400}"
-  imu_initial_calibration_max_age: 5.0
+  # Seconds of accelerometer data to average for the initial pitch & roll.
+  # A duration, not a sample count: what limits accuracy is platform motion
+  # during the window, so the same setting must mean the same averaging time
+  # on a 100 Hz and on a 400 Hz IMU.
+  imu_initial_calibration_window_seconds: "${MOLA_LO_INITIAL_IMU_WINDOW|1.0}"
+  # Sanity floor only, to reject a degenerate handful of samples:
+  imu_initial_calibration_min_samples: "${MOLA_LO_INITIAL_IMU_MIN_SAMPLES|20}"
+  # Defer initialization while the accelerometer directions in the window
+  # disagree by more than this: such a window is measuring platform motion,
+  # not gravity. After the timeout it is accepted anyway, so a start that is
+  # never still still initializes.
+  imu_initial_calibration_max_dispersion_deg: "${MOLA_LO_INITIAL_IMU_MAX_DISPERSION|1.5}"
+  imu_initial_calibration_dispersion_timeout: "${MOLA_LO_INITIAL_IMU_DISPERSION_TIMEOUT|5.0}"
   use_imu_orientation: "${MOLA_LO_INITIAL_IMU_USE_ORIENTATION|true}"
   # Right after a re-localization (or initial localization), also hold off
   # local map / simplemap updates for this many timesteps (shares the same


### PR DESCRIPTION
## What and why

`initial_localization.imu_initial_calibration_sample_count` (default **400**) sets how much
accelerometer data `InitLocalization::PitchAndRollFromIMU` averages, in **samples**. That
couples an accuracy choice to the sensor rate. Measured IMU rates across our evaluation
corpus: oxford-spires 399.5 Hz, botanic 400.0, conslam 400.2, citrus-farm 200.1, tiers
99.9 Hz. The same "400" therefore means 1.0 s, 1.0 s, 1.0 s, 2.0 s and 4.0 s.

Worse: below ~80 Hz, 400 samples can never fit inside `imu_initial_calibration_max_age`
(5.0 s), `isReady()` never returns true, initial localization never completes, and **the
run silently produces no trajectory at all**. tiers at 99.9 Hz already consumes 4.0 s of
its 5.0 s budget.

What determines accuracy is the **duration** averaged, because the error is dominated by
platform motion during the window rather than by sensor noise. Measured over 13 sequences
against gravity-aligned ground truth, median leveling error by window length: 1.11 deg at
0.1 s, 1.10 at 0.25 s, 1.34 at 0.5 s, 1.50 at 1.0 s, 1.97 at 3.0 s, 2.54 at 10.0 s.

## Changes

**A time window.** New `imu_initial_calibration_window_seconds` (default **1.0**), which is
exactly 400 samples at 400 Hz. `imu_initial_calibration_min_samples` (20) is only a sanity
floor against a degenerate handful of samples; it does not set the window.

**A dispersion gate.** A fixed window of any unit still freezes whatever the accelerometer
happened to say. Both places that freeze an attitude now defer while the buffered
accelerometer directions disperse too much to be gravity, and retry on the next scan:

- the initializer (`imu_initial_calibration_max_dispersion_deg` = 1.5,
  `imu_initial_calibration_dispersion_timeout` = 5.0 s);
- `captureMapOriginVerticality()` (`imu_gravity_correction.map_origin_max_dispersion_deg`
  = 1.0, `map_origin_capture_timeout` = 3.0 s). That function was already called from two
  places so it could retry when the data was missing; this extends the same retry to "the
  data is there but it is not gravity".

Both thresholds were picked by measuring dispersion against leveling error over all 13
sequences, not chosen by taste. Both have a timeout, because a platform that is never
still must still initialize; when the timeout fires, the log says so explicitly.

`InitLocalization::FixedPose` remains the default method. Nothing here changes which
initialization runs by default.

### Why a timeout that keeps the most recent window

Three fallback rules were simulated on the measured traces (13 sequences, 1 s window,
threshold 1.5 deg, timeout 5 s), reporting map-frame tilt at t0:

| fallback on timeout | median | p90 | max |
|---|---:|---:|---:|
| no gate (today) | 1.82 | 5.40 | 6.08 |
| **most recent window (chosen)** | **1.29** | **3.76** | **5.48** |
| the first window (i.e. never worse than today) | 1.52 | 5.40 | 6.08 |
| lowest-dispersion window seen so far | 1.13 | 4.22 | 6.60 |

"Lowest dispersion so far" wins on the median but loses on the tail, and needs extra state;
"most recent" is the only one that improves all three statistics at once.

## Backwards compatibility

`imu_initial_calibration_sample_count` is a documented public parameter, exposed as
`${MOLA_LO_INITIAL_IMU_SAMPLES|400}` in the shipped pipelines, so it is not removed:

- a configuration that names **`imu_initial_calibration_sample_count` and not** the new
  window keeps its **exact former behavior** (sample-count readiness, no gate) and gets a
  warning naming the equivalent window at 400 and 100 Hz and the rate below which it can
  never be satisfied;
- as soon as `imu_initial_calibration_window_seconds` is named, it is in charge and the
  sample count is ignored. Honoring both is not possible: a fixed sample count cannot be
  met inside a fixed window at an arbitrary rate, which is the deadlock being fixed.

The shipped pipelines were moved to the window, which is a **no-op for them at 400 Hz**.
This does retire the `MOLA_LO_INITIAL_IMU_SAMPLES` environment variable in those pipelines
in favour of `MOLA_LO_INITIAL_IMU_WINDOW`; users who overrode it need a one-line change,
and users with their own YAML are unaffected. Verified below to reproduce the previous
results.

## Behavior delta by IMU rate

| rate | before | after (default) |
|---|---|---|
| 400 Hz | 400 samples = 1.000 s | 1.0 s window = 400 samples. Averaging **identical**; only the gate is new: it deferred on 6 of 13 Oxford sequences, median 2.10 s of extra delay (max 4.08 s) |
| 200 Hz | 400 samples = 2.000 s | 1.0 s = ~200 samples: **half the averaging time**, which the measurements say is more accurate, not less |
| 100 Hz | 400 samples = 4.000 s, and **never ready at all** if `max_age` < ~4.1 s | 1.0 s = ~100 samples, ready at 1.0 s; cannot deadlock at any rate |

## Verification

**Oxford Spires, 13 sequences, `PitchAndRollFromIMU`, `MOLA_ASYNC_BACKEND=false`.** Map-frame
gravity misalignment at t0 over ~39 s runs (the mandatory 180 deg base-frame correction applied, since the
dataset's ground truth is in its `base` frame):

| arm | median tilt0 | median tilt at ~39 s | median APE | median z-APE |
|---|---:|---:|---:|---:|
| previously recorded baseline (400 samples) | 2.31 | - | - | - |
| deprecated path, this build | **2.32** | 2.08 | 0.01 m | 0.01 m |
| new default (1.0 s + gate) | **1.24** | 1.70 | 0.01 m | 0.01 m |

- The deprecated path reproduces the recorded baseline to within **0.036 deg** (0.000 median
  delta, exact on 11 of 13). The compatibility promise is measured, not asserted.
- The new default is better on **10 of 13** sequences, at no cost in APE. Since the
  averaging window at 400 Hz is identical (0.999 s / 400 samples in both arms), the entire
  2.32 -> 1.24 deg gain is the dispersion gate.
- The map-origin capture gate also fires: 15 deferrals across 6 sequences, 2 captures
  released by the timeout, the rest released by the data.

**TIERS indoor02, Ouster OS0 IMU at 99.98 Hz** (the case the current code cannot serve;
42.3 s bag, full run each):

| arm | averaged | initialized at | outcome |
|---|---|---|---|
| `sample_count = 400`, `max_age = 5.0` (today's shipped default) | 3.990 s, 400 samples, dispersion 11.19 deg | 3.998 s | works, but averages 4 s and the window is motion, not gravity |
| `sample_count = 400`, `max_age = 3.0` | - | **never** | **no trajectory at all**, 0 poses from the whole bag; buffer saturates at 301 samples / 3.000 s |
| `window_seconds = 1.0`, gate off | 0.990 s, 100 samples | 1.099 s | the requested window, delivered |
| `window_seconds = 1.0`, gate on (default) | 1.000 s, 101 samples, dispersion 23.06 deg | 5.099 s | gate ran to its timeout and said so: this rig never stops moving |

Honest caveat: on this sequence the gate's timeout landed on a window with *higher*
dispersion (23.06 deg) than the first one (2.58 deg), because the platform is in continuous
motion and the choice of window is then arbitrary. TIERS has no gravity-aligned survey
ground truth, so this cannot be scored as better or worse; the Oxford numbers above are
where the gate is actually measured.

Unit tests: `mola_imu_preintegration`, 18 cases, all pass.

---
Depends on MOLAorg/mola_imu_preintegration#14 (the `ImuInitialCalibrator` time window and
dispersion gate). Merge that first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added time-based IMU calibration with minimum sample requirements and accelerometer stability checks.
  * Added configurable safeguards for map-origin gravity capture, including motion-dispersion thresholds and timeout fallbacks.
  * Initialization now reports calibration progress, stability, elapsed time, and timeout conditions more clearly.

* **Compatibility**
  * Existing sample-count calibration remains available through legacy settings, with deprecation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->