### PR TITLE
Level the map frame once, from the map-frame gravity estimate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(LIB_SRCS
   module/src/GravityMapAligner.cpp
   module/src/KeyframeDecider.cpp
   module/src/LidarOdometry_Main.cpp
+  module/src/MapFrameRelevel.cpp
   module/src/LidarOdometry_Relocalization.cpp
   module/src/LidarOdometry_Parameters.cpp
   module/src/LidarOdometry_Initialize.cpp
@@ -53,6 +54,7 @@ set(LIB_SRCS
 set(LIB_PUBLIC_HDRS
   module/include/mola_lidar_odometry/LidarOdometry.h
   module/include/mola_lidar_odometry/GravityMapAligner.h
+  module/include/mola_lidar_odometry/MapFrameRelevel.h
 )
 
 mola_add_library(

--- a/agents.md
+++ b/agents.md
@@ -498,16 +498,55 @@ biases verticality for the whole run.
 `imu_gravity_correction.map_gravity.enabled` replaces it with
 `mola::imu::MapGravityEstimator`, which solves for gravity in the map frame from
 preintegrated IMU plus this odometry's own relative attitudes and velocities;
-its earned pitch/roll sigma is added in quadrature to the prior's, so a weak
-estimate silences itself. There is no quality threshold anywhere in that path,
-by design: the library reports every usable estimate with its sigma and the
-weighting decides (see `mola_imu_preintegration/agents.md`).
+its earned pitch/roll sigma is added in quadrature to the prior's. There is no
+quality threshold anywhere in that path, by design: the library reports every
+usable estimate with its sigma and the weighting decides (see
+`mola_imu_preintegration/agents.md`). Do NOT read those sigmas as a confidence
+gate, though: measured on a handheld dataset the error/sigma ratio is 8.4
+median and 19.0 worst, so "a weak estimate silences itself" is not established.
 
 `map_gravity.log_only` computes and logs the estimate without letting it reach
 the verticality reference, so the trajectory is identical to a disabled run.
 That is the mode to validate the estimator on a new dataset: with the feedback
 loop closed, the map frame being estimated is partly the estimator's own doing,
 and scoring it against ground truth would be self-referential.
+
+## Re-leveling the map frame (`map_gravity.relevel_map_frame`)
+
+All of the above corrects the per-scan *prior*; the map frame itself stays
+where it started, which is the initial body frame, tilt included. On a handheld
+dataset that is a median 8.7 deg lean (max 20.7) baked into every map product
+for the whole run. `relevel_map_frame` (default **false**) rotates the map
+frame once, about the map origin, by the estimator's `Result::correction`.
+
+It is a **gauge change**, not a state update, and must stay one:
+`MapFrameRelevel.h` applies `p -> b + p` to the local map, the simplemap, the
+trajectory; `KeyframeDecider`/`SearchablePoseList::transform_left_multiply()`
+move the keyframe-density bookkeeping with them; and
+`NavStateFilter::transform_frame()` does the same inside the state estimator.
+Anything expressed in the *vehicle* frame (twists, sensor extrinsics) is
+invariant and must not be touched. The decision is taken in
+`evaluateMapFrameRelevel()` and applied by `applyMapFrameRelevel()`, which runs
+outside `imu_state_mtx_` because the lock order forbids taking the local-map and
+simplemap mutexes under it. It fires before the scan reaches either map, and
+refuses outright once a map has been loaded or geo-referenced.
+
+Two things about the trigger that are easy to get wrong:
+
+- **It is not `min_intervals_for_convergence`.** That gates the per-scan prior,
+  where the later, settled estimate is the useful one. For leveling the map once
+  the estimate is at its *best* at the first solve (0.72 deg at ~5.6 s) and
+  degrades from there, so `relevel_min_intervals` is deliberately tiny (5 = the
+  first solve).
+- **The magnitude gate is load-bearing.** The correction's residual is the
+  estimator's own error (0.63 deg median, 1.43 p90, 1.75 worst at the firing
+  point), so on an already-level start it makes things worse. The gate tests the
+  estimate while the quantity that must be large is the truth, and they differ
+  by that error, hence `relevel_min_tilt_deg` ~ 2x the p90, not 1x.
+
+The applied rotation is logged once at INFO and written to the local map's
+`metadata` and to every later keyframe's metadata observation, since a run with
+a re-leveled map frame is not pose-comparable with one without it.
 
 ## Reproducible odometry evaluation
 

--- a/module/include/mola_lidar_odometry/KeyframeDecider.h
+++ b/module/include/mola_lidar_odometry/KeyframeDecider.h
@@ -146,6 +146,11 @@ public:
   /** Drops stored poses farther than the given distance (local map cleanup) */
   void removeAllFartherThan(const mrpt::poses::CPose3D & pose, double maxTranslation);
 
+  /** Re-expresses every stored keyframe pose in a new reference frame, i.e.
+   *  each stored `p` becomes `b + p`. Relative distances are preserved, so no
+   *  past decision changes; only the frame the poses live in moves. */
+  void transform_left_multiply(const mrpt::poses::CPose3D & b);
+
   /** Number of keyframes created so far (minus those dropped by
    *  removeAllFartherThan). This is what the GUI reports: under the temporal
    *  policy, keyframes that aged out of the window still count, since they

--- a/module/include/mola_lidar_odometry/KeyframeDecider.h
+++ b/module/include/mola_lidar_odometry/KeyframeDecider.h
@@ -148,8 +148,14 @@ public:
 
   /** Re-expresses every stored keyframe pose in a new reference frame, i.e.
    *  each stored `p` becomes `b + p`. Relative distances are preserved, so no
-   *  past decision changes; only the frame the poses live in moves. */
+   *  past decision changes; only the frame the poses live in moves.
+   *
+   *  Needs SearchablePoseList::transform_left_multiply(), so it is compiled
+   *  out against an older mola_pose_list. Callers must guard on
+   *  MOLA_POSE_LIST_HAS_TRANSFORM_LEFT_MULTIPLY. */
+#if defined(MOLA_POSE_LIST_HAS_TRANSFORM_LEFT_MULTIPLY)
   void transform_left_multiply(const mrpt::poses::CPose3D & b);
+#endif
 
   /** Number of keyframes created so far (minus those dropped by
    *  removeAllFartherThan). This is what the GUI reports: under the temporal

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -749,6 +749,45 @@ public:
         /// it, and keep it OFF in production.
         bool log_only = false;
 
+        /// Rotate the MAP FRAME itself, once, so that it becomes
+        /// gravity-aligned, instead of only feeding the per-scan verticality
+        /// prior. The map frame is the initial body frame, so on a platform
+        /// that starts tilted the whole map leans by that tilt for the rest of
+        /// the run, and no later mechanism removes it.
+        ///
+        /// This is a GAUGE change, not a state update: the local map, the
+        /// simplemap, the trajectory, the state estimator and the published
+        /// `odom` frame are all rotated together about the map origin, so
+        /// every relative quantity is preserved exactly. It happens at most
+        /// once per session, and never after a map has been loaded or
+        /// geo-referenced.
+        ///
+        /// Off by default: it changes the frame every product of the run is
+        /// expressed in.
+        bool relevel_map_frame = false;
+
+        /// Number of intervals the estimator must hold before its estimate is
+        /// used to re-level the map frame. Deliberately NOT
+        /// `min_intervals_for_convergence` (which gates the per-scan prior, a
+        /// different consumer with different needs): for leveling the map once,
+        /// the estimate is at its best at the FIRST solve and slowly degrades
+        /// afterwards, so waiting is harmful. The default corresponds to that
+        /// first solve under the shipped `solve_every_n`.
+        uint32_t relevel_min_intervals = 5;
+
+        /// Minimum estimated tilt [deg] for the re-level to be worth doing.
+        /// Mandatory, and not a formality: the estimate carries an error of its
+        /// own, so correcting a map frame that is already level replaces a
+        /// small error with a larger one.
+        ///
+        /// The gate is applied to the ESTIMATE, but the quantity that has to be
+        /// large is the TRUE tilt, and the two differ by that same error. So
+        /// the threshold is set at about twice the measured p90 error of the
+        /// estimate at its firing point, not at one times it. Below the
+        /// threshold the correction is permanently stood down (and logged),
+        /// rather than retried later.
+        double relevel_min_tilt_deg = 3.0;
+
         /// Options forwarded verbatim to mola::imu::MapGravityEstimator, so its
         /// parameters do not have to be mirrored here. Note that its own
         /// defaults are tuned for a different use: `window_size` in particular
@@ -1078,6 +1117,21 @@ private:
       mrpt::math::TVector3D open_v_from{0, 0, 0};
 
       uint32_t intervals_since_solve = 0;
+
+      /// Correction awaiting application to the map frame, set by the solve
+      /// loop and consumed (once) by applyMapFrameRelevel(). The solve runs
+      /// under imu_state_mtx_, while rotating the map needs the local-map and
+      /// simplemap mutexes, which the lock order forbids taking from there.
+      std::optional<mrpt::poses::CPose3D> pending_relevel;
+
+      /// Set once the re-level decision has been taken, whichever way it went:
+      /// the map frame is a gauge, and changing it more than once per session
+      /// would make the run's own output non-comparable with itself.
+      bool relevel_decided = false;
+
+      /// The rotation actually applied to the map frame, if any. Recorded in
+      /// the map and keyframe metadata so a run stays auditable.
+      std::optional<mrpt::poses::CPose3D> applied_relevel;
     };
 
     /// Protected by imu_state_mtx_.
@@ -1355,6 +1409,19 @@ private:
   /// re-solves. Caller must hold state_mtx_.
   void closeMapGravityInterval(
     double timestamp, const mrpt::poses::CPose3D & pose, const mrpt::math::TTwist3D & twistLocal);
+
+  /// Decides, at most once per session, whether the latest map-gravity
+  /// estimate should re-level the map frame, and if so leaves the rotation in
+  /// `map_gravity.pending_relevel`. Caller must hold state_mtx_ and
+  /// imu_state_mtx_.
+  void evaluateMapFrameRelevel(const mola::imu::MapGravityEstimator::Result & r);
+
+  /// Applies a pending map-frame re-level: rotates the local map, the
+  /// simplemap, the trajectory, the keyframe deciders, the state estimator and
+  /// the cached poses about the map origin, then resets the verticality
+  /// reference and the map-gravity estimator. No-op if nothing is pending.
+  /// Caller must hold state_mtx_ and NO other state mutex.
+  void applyMapFrameRelevel();
 
 #endif
 

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -55,6 +55,25 @@
 #endif
 #include <mola_lidar_odometry/ImuScanSync.h>
 #include <mola_lidar_odometry/KeyframeDecider.h>
+#include <mola_lidar_odometry/MapFrameRelevel.h>
+
+/** Feature macro: the one-off map-frame gauge change is available.
+ *
+ *  It needs three things at once, from three different packages, so it is
+ *  gated on all of them rather than on this package alone: the local helpers
+ *  here, SearchablePoseList::transform_left_multiply() from mola_pose_list
+ *  (to carry the keyframe bookkeeping across the change) and
+ *  NavStateFilter::transform_frame() from mola_kernel (to carry the estimator
+ *  state). Against an older set the whole feature compiles out and enabling it
+ *  at runtime stands down with a warning, which is deliberate: applying the
+ *  rotation to only some of the state would leave the session inconsistent,
+ *  which is worse than not applying it at all.
+ */
+#if defined(MOLA_LO_HAS_MAP_FRAME_RELEVEL) &&            \
+  defined(MOLA_POSE_LIST_HAS_TRANSFORM_LEFT_MULTIPLY) && \
+  defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_TRANSFORM_FRAME)
+#define MOLA_LO_CAN_RELEVEL_MAP_FRAME 1
+#endif
 
 // MP2P_ICP
 #include <mp2p_icp/ICP.h>

--- a/module/include/mola_lidar_odometry/MapFrameRelevel.h
+++ b/module/include/mola_lidar_odometry/MapFrameRelevel.h
@@ -1,0 +1,64 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+/**
+ * @file   MapFrameRelevel.h
+ * @brief  Re-expresses map-frame data in a new reference frame
+ * @author Jose Luis Blanco Claraco
+ */
+#pragma once
+
+#include <mp2p_icp/metricmap.h>
+#include <mrpt/maps/CSimpleMap.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/poses/CPose3DInterpolator.h>
+
+namespace mola
+{
+/** \defgroup mola_lo_map_frame_relevel Map-frame gauge change
+ *
+ *  A change of the map frame is a GAUGE change, not a state update: every
+ *  quantity expressed in the map frame is left-composed with the same rigid
+ *  transform `b`, so all relative poses, distances and angles between mapped
+ *  entities are preserved exactly. Quantities expressed in the vehicle's own
+ *  frame (body-frame twists, sensor extrinsics) are invariant and must NOT be
+ *  touched.
+ *
+ *  The overloads below apply `p -> b + p` to each of the containers the
+ *  odometry keeps in the map frame. They are free functions so that the
+ *  invariant above is testable without a running odometry instance.
+ *  @{ */
+
+/** Applies `p -> b + p` to every pose of a trajectory. */
+void transform_to_new_map_frame(
+  mrpt::poses::CPose3DInterpolator & trajectory, const mrpt::poses::CPose3D & b);
+
+/** Applies `p -> b + p` to every keyframe pose (mean and covariance) of a
+ *  simplemap. The per-keyframe twists are in the vehicle frame and are left
+ *  untouched.
+ */
+void transform_to_new_map_frame(mrpt::maps::CSimpleMap & sm, const mrpt::poses::CPose3D & b);
+
+/** Applies `p -> b + p` to every layer of a metric map.
+ *  \throw std::exception if any layer is of a type that cannot be transformed,
+ *         or if the map carries geo-referencing (which the transform would
+ *         silently invalidate).
+ */
+void transform_to_new_map_frame(mp2p_icp::metric_map_t & m, const mrpt::poses::CPose3D & b);
+
+/** @} */
+
+}  // namespace mola
+
+/** Feature macro: mola_lidar_odometry provides the map-frame gauge-change
+ *  helpers used by `imu_gravity_correction.map_gravity.relevel_map_frame`.
+ */
+#define MOLA_LO_HAS_MAP_FRAME_RELEVEL 1

--- a/module/src/KeyframeDecider.cpp
+++ b/module/src/KeyframeDecider.cpp
@@ -178,6 +178,7 @@ void KeyframeDecider::removeAllFartherThan(const mrpt::poses::CPose3D & pose, do
   recent_.swap(kept);
 }
 
+#if defined(MOLA_POSE_LIST_HAS_TRANSFORM_LEFT_MULTIPLY)
 void KeyframeDecider::transform_left_multiply(const mrpt::poses::CPose3D & b)
 {
   if (!temporal_) {
@@ -189,5 +190,6 @@ void KeyframeDecider::transform_left_multiply(const mrpt::poses::CPose3D & b)
     e.second = b + e.second;
   }
 }
+#endif
 
 }  // namespace mola

--- a/module/src/KeyframeDecider.cpp
+++ b/module/src/KeyframeDecider.cpp
@@ -178,4 +178,16 @@ void KeyframeDecider::removeAllFartherThan(const mrpt::poses::CPose3D & pose, do
   recent_.swap(kept);
 }
 
+void KeyframeDecider::transform_left_multiply(const mrpt::poses::CPose3D & b)
+{
+  if (!temporal_) {
+    poses_.transform_left_multiply(b);
+    return;
+  }
+
+  for (auto & e : recent_) {
+    e.second = b + e.second;
+  }
+}
+
 }  // namespace mola

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -378,6 +378,15 @@ void LidarOdometry::Parameters::IMUGravityCorrection::MapGravity::initialize(con
   YAML_LOAD_OPT(solve_every_n, uint32_t);
   ASSERT_(solve_every_n >= 1);
   YAML_LOAD_OPT(log_only, bool);
+  YAML_LOAD_OPT(relevel_map_frame, bool);
+  YAML_LOAD_OPT(relevel_min_intervals, uint32_t);
+  ASSERT_(relevel_min_intervals >= 1);
+  YAML_LOAD_OPT(relevel_min_tilt_deg, double);
+  ASSERTMSG_(
+    relevel_min_tilt_deg > 0,
+    mrpt::format(
+      "imu_gravity_correction.map_gravity.relevel_min_tilt_deg=%.4f must be > 0",
+      relevel_min_tilt_deg));
   YAML_LOAD_OPT(min_interval_seconds, double);
   ASSERTMSG_(
     min_interval_seconds > 0,
@@ -392,7 +401,8 @@ void LidarOdometry::Parameters::IMUGravityCorrection::MapGravity::initialize(con
     const auto key = k.as<std::string>();
     if (
       key == "enabled" || key == "solve_every_n" || key == "min_interval_seconds" ||
-      key == "log_only") {
+      key == "log_only" || key == "relevel_map_frame" || key == "relevel_min_intervals" ||
+      key == "relevel_min_tilt_deg") {
       continue;
     }
     estimator_params[key] = v;

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -144,6 +144,7 @@ void LidarOdometry::closeMapGravityInterval(
   }
 }
 
+#if defined(MOLA_LO_CAN_RELEVEL_MAP_FRAME)
 void LidarOdometry::evaluateMapFrameRelevel(const mola::imu::MapGravityEstimator::Result & r)
 {
   // Caller holds state_mtx_ and imu_state_mtx_.
@@ -300,6 +301,24 @@ void LidarOdometry::applyMapFrameRelevel()
     b.asString().c_str(),
     mrpt::RAD2DEG(mrpt::poses::Lie::SO<3>::log(b.getRotationMatrix()).norm()));
 }
+#else
+// Built against a mola/mola_pose_list/mola_kernel without the pieces the gauge
+// change needs. The feature stands down rather than rotating part of the state.
+void LidarOdometry::evaluateMapFrameRelevel(const mola::imu::MapGravityEstimator::Result &)
+{
+  auto & mg = state_.map_gravity;
+  if (!params_.imu_gravity_correction.map_gravity.relevel_map_frame || mg.relevel_decided) {
+    return;
+  }
+  mg.relevel_decided = true;
+  MRPT_LOG_WARN(
+    "map_gravity.relevel_map_frame is enabled but this build cannot apply it: it needs "
+    "SearchablePoseList::transform_left_multiply() and NavStateFilter::transform_frame(), "
+    "which this mola_pose_list / mola_kernel does not provide. Standing down; upgrade "
+    "those packages to use it.");
+}
+
+void LidarOdometry::applyMapFrameRelevel() {}
 #endif
 
 #if defined(MOLA_LO_HAS_MP2P_GRAVITY_PRIOR)
@@ -376,6 +395,7 @@ std::optional<mp2p_icp::GravityPrior> LidarOdometry::buildGravityPrior() const
   g.sigma_rad = std::sqrt(s * s + extraSigmaRad * extraSigmaRad);
   return g;
 }
+#endif
 #endif
 
 void LidarOdometry::captureMapOriginVerticality(const mrpt::poses::CPose3D & poseAtCapture)

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -320,7 +320,14 @@ void LidarOdometry::evaluateMapFrameRelevel(const mola::imu::MapGravityEstimator
 
 void LidarOdometry::applyMapFrameRelevel() {}
 #endif
+#endif  // MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR
 
+// Deliberately NOT inside the map-gravity block above: the rank-2 prior is a
+// mp2p_icp feature and stands on its own, using the map-frame gravity estimate
+// only when there is one (see the inner guard below). Its declaration and its
+// call site are gated on MOLA_LO_HAS_MP2P_GRAVITY_PRIOR alone, so gating the
+// definition on both leaves the symbol undefined whenever a build has the
+// newer mp2p_icp but the older mola_imu_preintegration.
 #if defined(MOLA_LO_HAS_MP2P_GRAVITY_PRIOR)
 std::optional<mp2p_icp::GravityPrior> LidarOdometry::buildGravityPrior() const
 {
@@ -395,8 +402,7 @@ std::optional<mp2p_icp::GravityPrior> LidarOdometry::buildGravityPrior() const
   g.sigma_rad = std::sqrt(s * s + extraSigmaRad * extraSigmaRad);
   return g;
 }
-#endif
-#endif
+#endif  // MOLA_LO_HAS_MP2P_GRAVITY_PRIOR
 
 void LidarOdometry::captureMapOriginVerticality(const mrpt::poses::CPose3D & poseAtCapture)
 {

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -21,6 +21,7 @@
 
 // This module:
 #include <mola_lidar_odometry/LidarOdometry.h>
+#include <mola_lidar_odometry/MapFrameRelevel.h>
 
 // mp2p_icp:
 #include <mp2p_icp_filters/FilterDeskew.h>
@@ -123,6 +124,8 @@ void LidarOdometry::closeMapGravityInterval(
             mrpt::RAD2DEG(r.roll_correction), mrpt::RAD2DEG(r.roll_sigma), r.bias_acc.x,
             r.bias_acc.y, r.bias_acc.z, r.bias_gyro.x, r.bias_gyro.y, r.bias_gyro.z,
             r.num_intervals);
+
+          evaluateMapFrameRelevel(r);
         }
       }
     } else {
@@ -139,6 +142,163 @@ void LidarOdometry::closeMapGravityInterval(
     mg.open_v_from = v_map;
     mg.preintegrator.reset_integration();
   }
+}
+
+void LidarOdometry::evaluateMapFrameRelevel(const mola::imu::MapGravityEstimator::Result & r)
+{
+  // Caller holds state_mtx_ and imu_state_mtx_.
+  const auto & p = params_.imu_gravity_correction.map_gravity;
+  auto & mg = state_.map_gravity;
+
+  if (!p.relevel_map_frame || p.log_only || mg.relevel_decided) {
+    return;
+  }
+
+  // Readiness is a data-quantity question, deliberately expressed as an
+  // interval count and not as the reported sigmas: those are measured to be
+  // roughly an order of magnitude more confident than the estimate is
+  // accurate, so gating on them would not mean what it says.
+  if (r.num_intervals < p.relevel_min_intervals) {
+    return;
+  }
+
+  // The map frame is the frame everything else is anchored to, so once
+  // anything external has been tied to it, moving it is no longer a private
+  // gauge choice:
+  if (
+    state_.map_has_been_loaded || state_.external_georef.has_value() ||
+    (state_.local_map && state_.local_map->georeferencing.has_value())) {
+    mg.relevel_decided = true;
+    MRPT_LOG_INFO(
+      "Map-frame re-leveling stood down: the map frame is already tied to a "
+      "loaded or geo-referenced map.");
+    return;
+  }
+
+  const double tiltDeg = mrpt::RAD2DEG(r.tilt);
+
+  // A tilt this large is not a leaning map, it is a broken estimate; refusing
+  // is cheaper than rotating the whole session by it.
+  constexpr double MAX_PLAUSIBLE_TILT_DEG = 45.0;
+  if (!std::isfinite(tiltDeg) || tiltDeg > MAX_PLAUSIBLE_TILT_DEG) {
+    mg.relevel_decided = true;
+    MRPT_LOG_WARN_FMT(
+      "Map-frame re-leveling stood down: implausible estimated tilt of %.2f deg.", tiltDeg);
+    return;
+  }
+
+  // The magnitude gate. The estimate carries an error of its own, so applying
+  // it to an already-level map frame replaces a small error with a larger one.
+  // Only fire when the tilt removed clearly exceeds the error introduced.
+  if (tiltDeg < p.relevel_min_tilt_deg) {
+    mg.relevel_decided = true;
+    MRPT_LOG_INFO_FMT(
+      "Map-frame re-leveling stood down: estimated tilt %.2f deg is below "
+      "relevel_min_tilt_deg=%.2f deg, so correcting it would not be a net gain "
+      "(%zu intervals, t=%.3f).",
+      tiltDeg, p.relevel_min_tilt_deg, r.num_intervals, r.timestamp);
+    return;
+  }
+
+  mg.relevel_decided = true;
+  mg.pending_relevel =
+    mrpt::poses::CPose3D::FromRotationAndTranslation(r.correction, mrpt::math::TVector3D(0, 0, 0));
+}
+
+void LidarOdometry::applyMapFrameRelevel()
+{
+  // Caller holds state_mtx_ only: the rotation below needs the local-map and
+  // simplemap mutexes, and the lock order forbids taking those while holding
+  // imu_state_mtx_ (which the solve loop that requested this does hold).
+  std::optional<mrpt::poses::CPose3D> pending;
+  {
+    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+    std::swap(pending, state_.map_gravity.pending_relevel);
+  }
+  if (!pending.has_value()) {
+    return;
+  }
+
+  const auto & b = *pending;
+  const ProfilerEntry tle(profiler_, "onLidar.map_frame_relevel");
+
+  // 1/6: the local map contents.
+  {
+    auto lckMapContents = mrpt::lockHelper(local_map_content_mtx_);
+    if (state_.local_map) {
+      transform_to_new_map_frame(*state_.local_map, b);
+      state_.local_map->metadata["map_frame_relevel_rotation"] = "'" + b.asString() + "'";
+    }
+  }
+  state_.mark_local_map_as_updated(true /*force_republish*/);
+
+  // 2/6: the keyframes already written to the simplemap.
+  {
+    auto lckSM = mrpt::lockHelper(state_simplemap_mtx_);
+    transform_to_new_map_frame(state_.reconstructed_simplemap, b);
+  }
+
+  // 3/6: the published trajectory.
+  {
+    auto lckTraj = mrpt::lockHelper(state_trajectory_mtx_);
+    transform_to_new_map_frame(state_.estimated_trajectory, b);
+  }
+
+  // 4/6: cached poses and the keyframe-density bookkeeping. The deciders hold
+  // map-frame poses, so leaving them behind would make the next distance check
+  // compare frames rather than positions.
+  state_.last_lidar_pose.changeCoordinatesReference(b);
+  if (state_.last_motion_model_output) {
+    state_.last_motion_model_output->pose.changeCoordinatesReference(b);
+    // `twist` is in the vehicle frame, hence invariant.
+  }
+  if (state_.kf_decider_local_map) {
+    state_.kf_decider_local_map->transform_left_multiply(b);
+  }
+  if (state_.kf_decider_simplemap) {
+    state_.kf_decider_simplemap->transform_left_multiply(b);
+  }
+  state_.last_deskewed_scan_for_publishing.reset();
+
+  // 5/6: the state estimator, whose stored poses are map-frame too.
+  if (state_.navstate_fuse) {
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_TRANSFORM_FRAME)
+    const bool ok = state_.navstate_fuse->transform_frame(b);
+#else
+    const bool ok = false;
+#endif
+    if (!ok) {
+      // Without frame support the only consistent option is to drop the
+      // estimator state: keeping poses in the old frame would feed the next
+      // ICP an initial guess off by the correction.
+      MRPT_LOG_WARN(
+        "The state estimator cannot re-express its state in a new frame; "
+        "resetting it instead. Expect one scan without a motion model.");
+      state_.navstate_fuse->reset();
+      state_.last_motion_model_output.reset();
+    }
+  }
+
+  // 6/6: the verticality reference is now level by construction, and the
+  // map-gravity estimator's window was expressed in the frame just rotated.
+  {
+    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+    state_.gravity_calib_pitch_roll = std::make_pair(0.0, 0.0);
+    state_.gravity_calib_pose = mrpt::poses::CPose3D::Identity();
+
+    auto & mg = state_.map_gravity;
+    mg.estimator.reset();
+    mg.preintegrator.reset_integration();
+    mg.open_t_from.reset();
+    mg.intervals_since_solve = 0;
+    mg.applied_relevel = b;
+  }
+
+  MRPT_LOG_INFO_FMT(
+    "Map frame re-leveled once, about the map origin, by [%s] (tilt %.3f deg). "
+    "All map products from here on are gravity-aligned.",
+    b.asString().c_str(),
+    mrpt::RAD2DEG(mrpt::poses::Lie::SO<3>::log(b.getRotationMatrix()).norm()));
 }
 #endif
 
@@ -1064,6 +1224,11 @@ void LidarOdometry::processLidarScan(  // NOLINT
         mrpt::Clock::toDouble(scan_ref_time), state_.last_lidar_pose.mean,
         state_.last_motion_model_output->twist);
     }
+
+    // If that solve asked for the map frame to be leveled, do it here: before
+    // this scan reaches the local map or the simplemap, so nothing is ever
+    // written in the frame that is about to be replaced.
+    applyMapFrameRelevel();
 #endif
 
     // Update for stats in CSV format:
@@ -1659,6 +1824,19 @@ void LidarOdometry::appendKeyframeMetadataObs(
     auto lckImu = mrpt::lockHelper(imu_state_mtx_);
     return state_.parameter_source.localVelocityBuffer.toYAML();
   }();
+
+#if defined(MOLA_LO_HAS_MAP_GRAVITY_ESTIMATOR)
+  // A map-frame gauge change makes the keyframe poses of this run
+  // non-comparable with those of a run without it, so record it where the
+  // poses themselves are stored.
+  {
+    auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+    if (state_.map_gravity.applied_relevel.has_value()) {
+      kf_metadata["map_frame_relevel_rotation"] =
+        "'"s + state_.map_gravity.applied_relevel->asString() + "'"s;
+    }
+  }
+#endif
 
   // convert yaml to string:
   std::stringstream ss;

--- a/module/src/MapFrameRelevel.cpp
+++ b/module/src/MapFrameRelevel.cpp
@@ -1,0 +1,70 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+/**
+ * @file   MapFrameRelevel.cpp
+ * @brief  Re-expresses map-frame data in a new reference frame
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include <mola_lidar_odometry/MapFrameRelevel.h>
+#include <mp2p_icp/MetricMapMergeCapable.h>
+#include <mrpt/maps/CPointsMap.h>
+
+namespace mola
+{
+
+void transform_to_new_map_frame(
+  mrpt::poses::CPose3DInterpolator & trajectory, const mrpt::poses::CPose3D & b)
+{
+  for (auto & [t, p] : trajectory) {
+    p = (b + mrpt::poses::CPose3D(p)).asTPose();
+  }
+}
+
+void transform_to_new_map_frame(mrpt::maps::CSimpleMap & sm, const mrpt::poses::CPose3D & b)
+{
+  for (auto & [pose, sf, twist] : sm) {
+    // Transforms both the mean and the covariance:
+    pose->changeCoordinatesReference(b);
+    // `twist` is in the vehicle frame, hence invariant: left as is.
+  }
+}
+
+void transform_to_new_map_frame(mp2p_icp::metric_map_t & m, const mrpt::poses::CPose3D & b)
+{
+  ASSERTMSG_(
+    !m.georeferencing.has_value(),
+    "Cannot change the map frame of a geo-referenced map: the georeferencing "
+    "transform would no longer describe it.");
+
+  // Only generic layers are used by the odometry; refuse silently dropping
+  // anything else:
+  ASSERTMSG_(
+    m.lines.empty() && m.planes.empty(),
+    "Cannot change the map frame of a map holding lines or planes.");
+
+  for (auto & [name, layer] : m.layers) {
+    if (auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(layer); pts) {
+      pts->changeCoordinatesReference(b);
+      continue;
+    }
+    if (auto mrg = std::dynamic_pointer_cast<mp2p_icp::MetricMapMergeCapable>(layer); mrg) {
+      mrg->transform_map_left_multiply(b);
+      continue;
+    }
+    THROW_EXCEPTION_FMT(
+      "Map layer '%s' (class '%s') does not support changing its reference frame.", name.c_str(),
+      layer->GetRuntimeClass()->className);
+  }
+}
+
+}  // namespace mola

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -78,19 +78,54 @@ params:
       # without its own feedback contaminating the map frame it is estimating.
       log_only: ${MOLA_IMU_MAP_GRAVITY_LOG_ONLY|false}
       solve_every_n: ${MOLA_IMU_MAP_GRAVITY_SOLVE_EVERY_N|5}
+      # Rotate the MAP FRAME itself, once, so it becomes gravity-aligned,
+      # instead of only feeding the per-scan verticality prior. The map frame is
+      # the initial body frame, so a platform that starts tilted produces a map
+      # that leans by that tilt forever: measured on a handheld dataset, a
+      # median of 8.7 deg (max 20.7). This is a gauge change - local map,
+      # simplemap, trajectory, state estimator and the published `odom` frame
+      # all rotate together about the map origin - so no relative quantity
+      # moves. OFF by default: it changes the frame every product of the run is
+      # expressed in.
+      relevel_map_frame: ${MOLA_IMU_MAP_GRAVITY_RELEVEL|false}
+      # Readiness for the re-level, as an interval count. Note this is NOT
+      # min_intervals_for_convergence below: that one gates the per-scan prior,
+      # where the later, more settled estimate is what matters. For leveling the
+      # map once, the estimate is at its BEST at the first solve (measured 0.72
+      # deg at ~5.6 s) and slowly degrades from there, so waiting costs accuracy.
+      # 5 intervals is the first solve under solve_every_n above.
+      relevel_min_intervals: ${MOLA_IMU_MAP_GRAVITY_RELEVEL_MIN_INTERVALS|5}
+      # Magnitude gate: only re-level when there is enough tilt that removing it
+      # beats the error of the estimate doing the removing. Measured at the
+      # firing point on a handheld dataset, that error is 0.63 deg median,
+      # 1.43 deg p90, 1.75 deg worst. Note the gate tests the ESTIMATE while the
+      # quantity that must be large is the TRUE tilt, and the two differ by
+      # exactly that error, so the threshold is ~2x the p90 rather than 1x:
+      # gating at 2 deg let one near-level sequence through (estimate 2.8 deg
+      # against a true 1.1 deg) and made it 0.7 deg worse. Below the threshold
+      # the re-level stands down permanently (and says so in the log) instead of
+      # retrying, which is what keeps an already-level dataset untouched.
+      relevel_min_tilt_deg: ${MOLA_IMU_MAP_GRAVITY_RELEVEL_MIN_TILT|3.0}
       # NOTE: there is deliberately no ACCURACY threshold here. The estimator
       # reports every usable estimate with its earned pitch/roll sigma, which is
-      # added in quadrature to the gravity prior's sigma, so a weak estimate
-      # silences itself instead of being discarded wholesale.
+      # added in quadrature to the gravity prior's sigma.
+      #
+      # CAUTION: "a weak estimate silences itself" is NOT established. A later
+      # measurement on a handheld dataset put the error/sigma ratio at 8.4
+      # median and 19.0 worst case, i.e. the reported sigma is roughly an order
+      # of magnitude tighter than the estimate is accurate, and no better
+      # calibrated after the interval gate below than before it. Do not use
+      # those sigmas as a confidence gate until that is understood; the
+      # re-level trigger above deliberately does not.
       #
       # There IS a data-quantity precondition, which is a different thing. Until
       # the window holds enough intervals the solution is pulled by the |g|
       # constraint and the bias priors, and that pull is a BIAS the linearized
       # covariance cannot see, so the estimate is not merely uncertain, it is
-      # confidently wrong: measured on Oxford Spires, error/sigma runs ~3.6 over
-      # the first 100 s and settles at ~1.2 once ~130 intervals have
-      # accumulated. Until then the accelerometer capture is the better
-      # reference, and this keeps LO on it.
+      # confidently wrong. Until then the accelerometer capture is the better
+      # reference, and this keeps LO on it. This gates the PER-SCAN PRIOR only:
+      # the one-off map-frame re-level above has the opposite need (its estimate
+      # is best at the first solve) and uses its own, much shorter, gate.
       min_intervals_for_convergence: ${MOLA_IMU_MAP_GRAVITY_MIN_INTERVALS|130}
       # Sliding-window length. The whole point is that verticality information
       # ACCUMULATES, so this wants to be much longer than the estimator default.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,9 @@ target_link_libraries(test_gravity_map_aligner mola::mola_lidar_odometry)
 ament_add_gtest(test_keyframe_decider test_keyframe_decider.cpp)
 target_link_libraries(test_keyframe_decider mola::mola_lidar_odometry)
 
+ament_add_gtest(test_map_frame_relevel test_map_frame_relevel.cpp)
+target_link_libraries(test_map_frame_relevel mola::mola_lidar_odometry mrpt::obs)
+
 ament_add_gtest(test_imu_scan_sync test_imu_scan_sync.cpp)
 target_link_libraries(test_imu_scan_sync mola::mola_lidar_odometry mrpt::obs)
 

--- a/test/test_map_frame_relevel.cpp
+++ b/test/test_map_frame_relevel.cpp
@@ -1,0 +1,244 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+/**
+ * @file   test_map_frame_relevel.cpp
+ * @brief  The map-frame change must be a pure gauge change
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include <gtest/gtest.h>
+#include <mola_imu_preintegration/MapGravityEstimator.h>
+#include <mola_lidar_odometry/KeyframeDecider.h>
+#include <mola_lidar_odometry/MapFrameRelevel.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/obs/CSensoryFrame.h>
+#include <mrpt/poses/Lie/SO.h>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace
+{
+/** A moderately curved walk with changing attitude, so that a bug that only
+ *  cancels on straight, level motion cannot hide. */
+std::vector<mrpt::poses::CPose3D> makeTrajectory()
+{
+  std::vector<mrpt::poses::CPose3D> out;
+  for (int i = 0; i < 25; i++) {
+    const double s = 0.1 * i;
+    out.push_back(mrpt::poses::CPose3D::FromXYZYawPitchRoll(
+      3.0 * s, 1.5 * s * s, 0.4 * std::sin(s), 0.3 * s, 0.05 * std::cos(s), -0.07 * s));
+  }
+  return out;
+}
+
+/** A tilt of ~9 deg with a roll component, i.e. the size of the map lean this
+ *  feature exists to remove. */
+mrpt::poses::CPose3D theCorrection()
+{
+  return mrpt::poses::CPose3D::FromYawPitchRoll(0.0, mrpt::DEG2RAD(7.0), mrpt::DEG2RAD(-5.5));
+}
+
+double rotAngle(const mrpt::poses::CPose3D & p)
+{
+  return mrpt::poses::Lie::SO<3>::log(p.getRotationMatrix()).norm();
+}
+
+void expectSamePose(const mrpt::poses::CPose3D & a, const mrpt::poses::CPose3D & b, double tol)
+{
+  const auto d = a - b;
+  EXPECT_NEAR(d.translation().norm(), 0.0, tol);
+  EXPECT_NEAR(rotAngle(d), 0.0, tol);
+}
+}  // namespace
+
+TEST(MapFrameRelevel, TrajectoryRelativePosesArePreserved)
+{
+  const auto poses = makeTrajectory();
+  const auto b = theCorrection();
+
+  mrpt::poses::CPose3DInterpolator traj;
+  for (size_t i = 0; i < poses.size(); i++) {
+    traj.insert(mrpt::Clock::fromDouble(1000.0 + 0.1 * i), poses[i].asTPose());
+  }
+
+  mola::transform_to_new_map_frame(traj, b);
+
+  ASSERT_EQ(traj.size(), poses.size());
+
+  size_t i = 0;
+  std::vector<mrpt::poses::CPose3D> newPoses;
+  for (const auto & [t, p] : traj) {
+    const mrpt::poses::CPose3D pNew(p);
+    // Global poses moved exactly by the gauge rotation:
+    expectSamePose(pNew, b + poses[i], 1e-9);
+    newPoses.push_back(pNew);
+    i++;
+  }
+
+  // ... and every relative pose is untouched, which is what "gauge" means:
+  for (size_t k = 1; k < poses.size(); k++) {
+    expectSamePose(newPoses[k] - newPoses[k - 1], poses[k] - poses[k - 1], 1e-9);
+  }
+}
+
+TEST(MapFrameRelevel, SimplemapKeyframePosesAndCovariances)
+{
+  const auto poses = makeTrajectory();
+  const auto b = theCorrection();
+
+  mrpt::maps::CSimpleMap sm;
+  for (const auto & p : poses) {
+    auto pdf = mrpt::poses::CPose3DPDFGaussian::Create();
+    pdf->mean = p;
+    pdf->cov.setDiagonal(1e-4);
+    // A twist in the VEHICLE frame, which a map-frame change must not touch:
+    sm.insert(pdf, mrpt::obs::CSensoryFrame::Create(), mrpt::math::TTwist3D(1, 0, 0, 0, 0, 0.2));
+  }
+
+  mola::transform_to_new_map_frame(sm, b);
+
+  for (size_t i = 0; i < poses.size(); i++) {
+    const auto & [pose, sf, twist] = sm.get(i);
+    expectSamePose(pose->getMeanVal(), b + poses[i], 1e-9);
+    ASSERT_TRUE(twist.has_value());
+    EXPECT_NEAR(twist->vx, 1.0, 1e-12);
+    EXPECT_NEAR(twist->wz, 0.2, 1e-12);
+  }
+
+  // Relative poses preserved:
+  for (size_t k = 1; k < poses.size(); k++) {
+    const auto & [pk, sfk, twk] = sm.get(k);
+    const auto & [pj, sfj, twj] = sm.get(k - 1);
+    expectSamePose(pk->getMeanVal() - pj->getMeanVal(), poses[k] - poses[k - 1], 1e-9);
+  }
+}
+
+TEST(MapFrameRelevel, MetricMapPointsRotateAndKeepTheirShape)
+{
+  const auto b = theCorrection();
+
+  mp2p_icp::metric_map_t mm;
+  auto pts = mrpt::maps::CSimplePointsMap::Create();
+  std::vector<mrpt::math::TPoint3D> original;
+  for (int i = 0; i < 50; i++) {
+    const mrpt::math::TPoint3D p(0.7 * i, -0.3 * i + 2.0, 0.2 * std::sin(0.3 * i));
+    original.push_back(p);
+    pts->insertPoint(p);
+  }
+  mm.layers["localmap"] = pts;
+
+  mola::transform_to_new_map_frame(mm, b);
+
+  auto out = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(mm.layers.at("localmap"));
+  ASSERT_TRUE(out);
+  ASSERT_EQ(out->size(), original.size());
+
+  for (size_t i = 0; i < original.size(); i++) {
+    mrpt::math::TPoint3D q;
+    out->getPoint(i, q.x, q.y, q.z);
+    const auto expected = b.composePoint(original[i]);
+    // Point maps store single-precision coordinates:
+    EXPECT_NEAR((q - expected).norm(), 0.0, 1e-4);
+  }
+
+  // Inter-point distances (the map's actual content) are untouched:
+  for (size_t i = 1; i < original.size(); i++) {
+    mrpt::math::TPoint3D q0;
+    mrpt::math::TPoint3D q1;
+    out->getPoint(i - 1, q0.x, q0.y, q0.z);
+    out->getPoint(i, q1.x, q1.y, q1.z);
+    EXPECT_NEAR((q1 - q0).norm(), (original[i] - original[i - 1]).norm(), 1e-4);
+  }
+}
+
+TEST(MapFrameRelevel, MetricMapRefusesGeoreferencedMaps)
+{
+  mp2p_icp::metric_map_t mm;
+  mm.layers["localmap"] = mrpt::maps::CSimplePointsMap::Create();
+  mm.georeferencing.emplace();
+
+  EXPECT_THROW(mola::transform_to_new_map_frame(mm, theCorrection()), std::exception);
+}
+
+TEST(MapFrameRelevel, KeyframeDeciderDecisionsAreUnchanged)
+{
+  const auto poses = makeTrajectory();
+  const auto b = theCorrection();
+
+  mola::KeyframeDecisionOptions opts;
+  opts.min_translation_between_keyframes = 1.0;
+  opts.min_rotation_between_keyframes = 15.0;
+
+  mola::KeyframeDecider before(opts);
+  mola::KeyframeDecider after(opts);
+
+  // Feed both with the same (old-frame) history, then rotate one of them:
+  for (size_t i = 0; i < 10; i++) {
+    before.insert(poses[i], 100.0 + i);
+    after.insert(poses[i], 100.0 + i);
+  }
+  after.transform_left_multiply(b);
+
+  // Every query, asked in its own frame, must yield the same decision:
+  for (size_t i = 10; i < poses.size(); i++) {
+    const auto dOld = before.check(opts, poses[i], 100.0 + i);
+    const auto dNew = after.check(opts, b + poses[i], 100.0 + i);
+
+    EXPECT_EQ(dOld.create, dNew.create) << " at i=" << i;
+    EXPECT_NEAR(dOld.translation, dNew.translation, 1e-9);
+    EXPECT_NEAR(dOld.rotation, dNew.rotation, 1e-9);
+  }
+}
+
+TEST(MapFrameRelevel, MapFrameVelocitiesRotateWithTheFrame)
+{
+  // The odometry keeps its twist in the VEHICLE frame; the map-frame velocity
+  // is derived as R*v. After the gauge change the attitude becomes b*R, so the
+  // map-frame velocity must come out rotated by exactly b, with no change in
+  // magnitude. This is the invariant the map-gravity estimator relies on.
+  const auto b = theCorrection();
+  const mrpt::poses::CPose3D R = mrpt::poses::CPose3D::FromYawPitchRoll(0.4, -0.2, 0.15);
+  const mrpt::math::TVector3D vLocal(2.0, -0.5, 0.3);
+
+  const auto vMapOld = R.rotateVector(vLocal);
+  const auto vMapNew = (b + R).rotateVector(vLocal);
+
+  EXPECT_NEAR((vMapNew - b.rotateVector(vMapOld)).norm(), 0.0, 1e-12);
+  EXPECT_NEAR(vMapNew.norm(), vMapOld.norm(), 1e-12);
+}
+
+TEST(MapFrameRelevel, TheCorrectionLevelsTheMap)
+{
+  // End-to-end on the actual quantity consumed: the estimator's `correction`
+  // must take the measured map-frame gravity onto -Z, by the smallest possible
+  // rotation.
+  const mrpt::math::TVector3D gMap(1.21, -0.83, -9.70);
+
+  const auto R = mola::imu::MapGravityEstimator::correction_from_gravity(gMap);
+  const mrpt::poses::CPose3D b =
+    mrpt::poses::CPose3D::FromRotationAndTranslation(R, mrpt::math::TVector3D(0, 0, 0));
+
+  const auto gLevel = b.rotateVector(gMap);
+  EXPECT_NEAR(gLevel.x, 0.0, 1e-9);
+  EXPECT_NEAR(gLevel.y, 0.0, 1e-9);
+  EXPECT_NEAR(gLevel.z, -gMap.norm(), 1e-9);
+
+  // It is the geodesic (minimal-angle) rotation between the two directions, so
+  // its magnitude is exactly the tilt it removes and nothing more. Note that
+  // its Euler yaw is NOT identically zero: for a rotation about an axis in the
+  // XY plane, the ZYX yaw is a second-order term (here ~0.3 deg for a ~9.5 deg
+  // tilt). Yaw is unobservable anyway, so this is another gauge freedom.
+  const double tiltBetween = std::acos(std::clamp(-gMap.z / gMap.norm(), -1.0, 1.0));
+  EXPECT_NEAR(rotAngle(b), tiltBetween, 1e-9);
+}

--- a/test/test_map_frame_relevel.cpp
+++ b/test/test_map_frame_relevel.cpp
@@ -16,9 +16,14 @@
  */
 
 #include <gtest/gtest.h>
-#include <mola_imu_preintegration/MapGravityEstimator.h>
 #include <mola_lidar_odometry/KeyframeDecider.h>
 #include <mola_lidar_odometry/MapFrameRelevel.h>
+// Same optional-dependency probe LidarOdometry.h uses, so this test still
+// builds against a mola_imu_preintegration without the map-gravity estimator.
+#if __has_include(<mola_imu_preintegration/MapGravityEstimator.h>)
+#include <mola_imu_preintegration/MapGravityEstimator.h>
+#define TEST_HAS_MAP_GRAVITY_ESTIMATOR 1
+#endif
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/obs/CSensoryFrame.h>
 #include <mrpt/poses/Lie/SO.h>
@@ -222,6 +227,7 @@ TEST(MapFrameRelevel, MapFrameVelocitiesRotateWithTheFrame)
   EXPECT_NEAR(vMapNew.norm(), vMapOld.norm(), 1e-12);
 }
 
+#if defined(TEST_HAS_MAP_GRAVITY_ESTIMATOR)
 TEST(MapFrameRelevel, TheCorrectionLevelsTheMap)
 {
   // End-to-end on the actual quantity consumed: the estimator's `correction`
@@ -246,3 +252,4 @@ TEST(MapFrameRelevel, TheCorrectionLevelsTheMap)
   const double tiltBetween = std::acos(std::clamp(-gMap.z / gMap.norm(), -1.0, 1.0));
   EXPECT_NEAR(rotAngle(b), tiltBetween, 1e-9);
 }
+#endif

--- a/test/test_map_frame_relevel.cpp
+++ b/test/test_map_frame_relevel.cpp
@@ -171,6 +171,9 @@ TEST(MapFrameRelevel, MetricMapRefusesGeoreferencedMaps)
   EXPECT_THROW(mola::transform_to_new_map_frame(mm, theCorrection()), std::exception);
 }
 
+// Exercises KeyframeDecider::transform_left_multiply(), which is itself only
+// compiled against a mola_pose_list that provides the underlying call.
+#if defined(MOLA_POSE_LIST_HAS_TRANSFORM_LEFT_MULTIPLY)
 TEST(MapFrameRelevel, KeyframeDeciderDecisionsAreUnchanged)
 {
   const auto poses = makeTrajectory();
@@ -200,6 +203,7 @@ TEST(MapFrameRelevel, KeyframeDeciderDecisionsAreUnchanged)
     EXPECT_NEAR(dOld.rotation, dNew.rotation, 1e-9);
   }
 }
+#endif
 
 TEST(MapFrameRelevel, MapFrameVelocitiesRotateWithTheFrame)
 {


### PR DESCRIPTION
> **Stacked PR.** Base is `feat/imu-init-time-window` (#132), not `develop`,
> because both touch `LidarOdometry.h`, `LidarOdometry_Parameters.cpp`,
> `LidarOdometry_ProcessScan.cpp` and `lidar3d-gicp.yaml`. Merge #132 first and
> this retargets to `develop` cleanly. Reviewing the last commit alone shows
> this change.
>
> Also depends on MOLAorg/mola#192 and MOLAorg/mola_state_estimation#55.

## The problem

The map frame is the initial body frame, so a platform that starts tilted
leans the whole session by that much, permanently. Measured on the 13 Oxford
Spires sequences, whose ground truth is gravity-aligned: **5.68 deg** of
map-frame gravity misalignment at the median, 9.87 worst, still 5.42 deg
thirty seconds in. An aligned APE cannot see it.

## What this does

`MapGravityEstimator` already solves for gravity in the map frame from
preintegrated IMU plus this odometry's own relative attitudes and velocities,
so platform acceleration cancels and no quasi-static start is needed. Its
`Result::correction` is exactly the rotation that levels the frame, and
nothing consumed it. This applies it **once**, as an atomic gauge change over
the local map, simplemap poses and covariances, trajectory, both keyframe
deciders, the cached poses and the state estimator, then resets the
verticality reference to level and restarts the estimator window.

**Off by default** (`imu_gravity_correction.map_gravity.relevel_map_frame`).

## It fires at most once, early, by construction

The decision is taken at the estimator's first solve (~5.6 s) and **every**
outcome latches it; the only path that retries is "not enough data yet". A run
that starts level therefore stands down permanently and can never rotate an
already-established map hundreds of metres later. It also refuses outright
once the map frame is tied to something external (a loaded map, a
geo-reference).

## Two deliberate choices in the trigger

- **Readiness is an interval count, not the reported sigmas.** Those measure
  roughly an order of magnitude more confident than the estimate is accurate,
  so gating on them would not mean what it says. It is also explicitly *not*
  `min_intervals_for_convergence` (130, ~143 s): that gates the per-scan prior,
  where the settled estimate is wanted, whereas for leveling once the estimate
  is best at the first solve and degrades afterwards.
- **A magnitude gate**, default 3.0 deg. 2.0 deg was tried first and was wrong:
  the gate tests the *estimate* while the quantity that must be large is the
  *truth*, and they differ by exactly the estimate's error. One sequence fired
  on a 2.82 deg estimate against a 1.08 deg truth and got 0.7 deg worse.
  First-solve error measured 0.63 deg median / 1.43 p90, so the threshold is
  ~2x p90.

## Measured

| | median | p90 | worst | k-of-n |
|---|---|---|---|---|
| map tilt, t<1 s | **5.68 -> 0.98 deg** | 9.44 -> 1.71 | 9.87 -> 3.07 | 10/13 |
| map tilt, ~190 s | 6.85 -> 1.72 deg | | 5.69 / 6.81 | 12/13 |
| APE | 0.165 -> 0.159 m | 0.372 -> 0.357 | 0.383 -> 0.376 | |

- **Zero sequences regressed.** The 3 non-improvers are gate stand-downs,
  byte-identical to the control.
- **Flag off is bit-identical**: 13/13 md5-identical to the stored baseline.
- **Already-level dataset protected**: on BotanicGarden `1018_00` (level to
  0.09 deg) the estimator reports 0.25 deg, the gate stands down, and output is
  bit-identical.
- **The gain is the rotation, not the prior**: a control arm running the
  estimator closed-loop *without* the re-level improves 0 of 13.
- On the pre-event segment the re-leveled trajectory equals the baseline
  left-multiplied by the logged correction to 1.2e-6 m / 1.5e-4 deg, so the
  rotation is exact; later differences are the verticality reference
  legitimately resetting.

7 new unit tests (`test_map_frame_relevel.cpp`): relative poses preserved on
trajectory and simplemap, distances preserved, geo-referenced maps refused,
keyframe decisions unchanged, map-frame velocity consistency, and that
`correction` levels gravity by the minimal rotation.

## Known gaps

- No explicit interlock against a loop closure landing inside the first ~6 s.
- `StateEstimationSmoother` has no `transform_frame()`, so it falls back to
  `reset()` with a warning. Not exercised; all measurements used
  `StateEstimationSimple`.
- `Result::correction` is the geodesic rotation, so its ZYX yaw is not
  identically zero (~0.3 deg for a 9.5 deg tilt) despite the estimator's doc
  claiming so. Harmless, since yaw is unobservable here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional one-time map-frame releveling based on gravity estimates.
  * Added configuration for enabling releveling, minimum estimator intervals, and minimum tilt.
  * Applies accepted corrections consistently across maps, trajectories, keyframes, and navigation state.
  * Records applied releveling rotations in keyframe metadata.

* **Documentation**
  * Documented releveling behavior, restrictions, triggers, affected data, and gravity-estimate limitations.

* **Tests**
  * Added coverage for frame transformations, map handling, state preservation, and gravity-based leveling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->