### PR TITLE
Wire wheel odometry into the offline rosbag1 CLI path

### DIFF
--- a/apps/mola-lidar-odometry-cli.cpp
+++ b/apps/mola-lidar-odometry-cli.cpp
@@ -497,16 +497,22 @@ std::shared_ptr<mola::OfflineDatasetSource> dataset_from_rosbag1(
           # If present, this will override whatever /tf tells about the sensor pose:
           fixed_sensor_pose: "${IMU_POSE_X|0} ${IMU_POSE_Y|0} ${IMU_POSE_Z|0} ${IMU_POSE_YAW|0} ${IMU_POSE_PITCH|0} ${IMU_POSE_ROLL|0}" # 'x y z yaw_deg pitch_deg roll_deg''
           use_fixed_sensor_pose: ${MOLA_USE_FIXED_IMU_POSE|false}
-        # Wheel odometry, if the dataset has it (e.g. a separate odom_*.bag,
-        # comma-joined into rosbag_filename above -- Rosbag1Dataset merges
-        # all listed bags into one topic space). is_optional, so datasets
-        # with no such topic are unaffected. No fixed_sensor_pose here:
-        # Rosbag1Dataset::toOdometry() does not apply one, and
-        # StateEstimationSimple::fuse_odometry() consumes the 2D pose
-        # increment directly against base_link, with no sensor-pose
+        # Wheel odometry (disabled by default -- an empty topic name means
+        # no handler is installed, matching lidar_odometry_from_rosbag1.yaml/
+        # rosbag2.yaml's MOLA_ODOMETRY_TOPIC convention exactly, name and
+        # empty-by-default alike, rather than opting every dataset whose bag
+        # happens to carry a topic literally named "/odom" -- a very common
+        # name across unrelated robots/conventions -- into wheel-odom fusion
+        # silently). Set MOLA_ODOMETRY_TOPIC explicitly to enable, e.g. for a
+        # separate odom_*.bag comma-joined into rosbag_filename above
+        # (Rosbag1Dataset merges all listed bags into one topic space).
+        # is_optional, so an empty/absent topic is unaffected either way.
+        # No fixed_sensor_pose here: Rosbag1Dataset::toOdometry() does not
+        # apply one, and StateEstimationSimple::fuse_odometry() consumes the
+        # 2D pose increment directly against base_link, with no sensor-pose
         # composition (unlike the lidar/imu/gps entries above).
-        - topic: ${MOLA_ODOM_TOPIC|'/odom'}
-          sensorLabel: 'odom_wheels'
+        - topic: ${MOLA_ODOMETRY_TOPIC|''}
+          sensorLabel: ${MOLA_ODOM_SENSOR_LABEL|odom_wheels}
           type: CObservationOdometry
           is_optional: true
 )"""",

--- a/apps/mola-lidar-odometry-cli.cpp
+++ b/apps/mola-lidar-odometry-cli.cpp
@@ -506,11 +506,27 @@ std::shared_ptr<mola::OfflineDatasetSource> dataset_from_rosbag1(
         # silently). Set MOLA_ODOMETRY_TOPIC explicitly to enable, e.g. for a
         # separate odom_*.bag comma-joined into rosbag_filename above
         # (Rosbag1Dataset merges all listed bags into one topic space).
-        # is_optional, so an empty/absent topic is unaffected either way.
-        # No fixed_sensor_pose here: Rosbag1Dataset::toOdometry() does not
-        # apply one, and StateEstimationSimple::fuse_odometry() consumes the
-        # 2D pose increment directly against base_link, with no sensor-pose
-        # composition (unlike the lidar/imu/gps entries above).
+        # is_optional is set for readability/consistency with the gps entry
+        # above, but Rosbag1Dataset doesn't actually implement that key (grep
+        # confirms it) -- harmless here regardless, since an empty or absent
+        # topic name is simply never seen in the bag, so no handler ever
+        # fires; nothing about "optional" behavior is being relied on.
+        #
+        # No fixed_sensor_pose here, and this is NOT interchangeable with the
+        # lidar/imu/gps entries above: mrpt::obs::CObservationOdometry cannot
+        # carry a sensor pose at all (getSensorPose()/setSensorPose() are
+        # both no-ops in that class), and Rosbag1Dataset::toOdometry() makes
+        # no attempt to apply one from config either way. If the wheel-
+        # odometry frame has ANY nontrivial rotation relative to base_link,
+        # fusing it here injects motion in the wrong frame -- verified this
+        # is a real, non-hypothetical trap: lidar_odometry_from_citrusfarm.yaml's
+        # odom_wheels entry carries a ~180deg-yaw fixed_sensor_pose (a real
+        # calibration value, matching its lidar entry's rotation) that gets
+        # silently discarded exactly this way, which is why that dataset's
+        # wheel odometry is deliberately NOT enabled anywhere it's actually
+        # invoked (plans-mola-server's run-single-test.sh) as of 2026-08-11.
+        # Fine for a dataset whose wheel-odometry frame is already
+        # (approximately) base_link-aligned, e.g. BotanicGarden's Xsens IMU.
         - topic: ${MOLA_ODOMETRY_TOPIC|''}
           sensorLabel: ${MOLA_ODOM_SENSOR_LABEL|odom_wheels}
           type: CObservationOdometry

--- a/apps/mola-lidar-odometry-cli.cpp
+++ b/apps/mola-lidar-odometry-cli.cpp
@@ -497,6 +497,18 @@ std::shared_ptr<mola::OfflineDatasetSource> dataset_from_rosbag1(
           # If present, this will override whatever /tf tells about the sensor pose:
           fixed_sensor_pose: "${IMU_POSE_X|0} ${IMU_POSE_Y|0} ${IMU_POSE_Z|0} ${IMU_POSE_YAW|0} ${IMU_POSE_PITCH|0} ${IMU_POSE_ROLL|0}" # 'x y z yaw_deg pitch_deg roll_deg''
           use_fixed_sensor_pose: ${MOLA_USE_FIXED_IMU_POSE|false}
+        # Wheel odometry, if the dataset has it (e.g. a separate odom_*.bag,
+        # comma-joined into rosbag_filename above -- Rosbag1Dataset merges
+        # all listed bags into one topic space). is_optional, so datasets
+        # with no such topic are unaffected. No fixed_sensor_pose here:
+        # Rosbag1Dataset::toOdometry() does not apply one, and
+        # StateEstimationSimple::fuse_odometry() consumes the 2D pose
+        # increment directly against base_link, with no sensor-pose
+        # composition (unlike the lidar/imu/gps entries above).
+        - topic: ${MOLA_ODOM_TOPIC|'/odom'}
+          sensorLabel: 'odom_wheels'
+          type: CObservationOdometry
+          is_optional: true
 )"""",
     bagsYaml.c_str(), cli.arg_baseLinkName.getValue().c_str(),
     cli.arg_lidarLabel.getValue().c_str(), cli.arg_imuLabel.getValue().c_str())));

--- a/state-estimator-params/state-estimation-simple.yaml
+++ b/state-estimator-params/state-estimation-simple.yaml
@@ -17,6 +17,14 @@ params:
 
   sigma_imu_angular_velocity: ${MOLA_NAVSTATE_SIGMA_IMU_ANG_VEL|0.05} # [rad/s]
 
+  # Wheel-odometry velocity fusion (CObservationOdometry with hasVelocities=true).
+  # Kept tighter than sigma_relative_pose_* above: wheel encoders give a direct
+  # per-cycle velocity reading, more trustworthy than a pose difference from a
+  # lower-rate/noisier source. Lower further for platforms with accurate
+  # encoders and no wheel slip; raise for loose terrain (mud, gravel, vegetation).
+  sigma_wheel_odom_linear_vel: ${MOLA_NAVSTATE_SIGMA_WHEEL_ODOM_LINVEL|0.1} # [m/s]
+  sigma_wheel_odom_angular_vel: ${MOLA_NAVSTATE_SIGMA_WHEEL_ODOM_ANGVEL|0.05} # [rad/s]
+
   # Velocity Kalman filter: if true, each fuse_*() measurement is fused via a
   # per-component scalar Kalman filter instead of being written directly.
   # Process noise reuses sigma_random_walk_acceleration_linear/angular.


### PR DESCRIPTION
## Summary
- `dataset_from_rosbag1()` (used by `mola-lidar-odometry-cli --input-rosbag1`) only ever declared lidar, GPS and IMU sensors -- even though the main loop already forwards any `CObservationOdometry` it receives to both the odometry pipeline and the state estimator. A dataset whose wheel odometry lives in the same bag, or a second bag comma-joined into `rosbag_filename` (the same mechanism already used for multi-part sequences), had no way to reach the estimator in offline mode. Only the per-dataset online `mola-cli` launch YAMLs wired it.
- Adds an optional `CObservationOdometry` sensor entry, topic overridable via `MOLA_ODOM_TOPIC` (default `/odom`), mirroring the `MOLA_GNSS_TOPIC` pattern already used for the equally-optional GPS entry.
- Deliberately no `fixed_sensor_pose` on this entry: `Rosbag1Dataset::toOdometry()` doesn't apply one, and `StateEstimationSimple::fuse_odometry()` consumes the 2D pose increment directly against `base_link` with no sensor-pose composition -- wiring one in here would silently do nothing.
- Companion PR in `mola_state_estimation` (MOLAorg/mola_state_estimation#56) exposes the wheel-odometry fusion sigmas as tunable params; this PR also updates the shipped `state-estimation-simple.yaml` default that ships with this repo to surface them via env var.

## Test plan
- [x] `colcon build --packages-select mola_lidar_odometry` -- clean build.
- [x] Smoke-tested against a real BotanicGarden bag (`/odom` topic) with `--only-first-n 3000 --verbosity DEBUG`: confirmed `Installing handler for topic '/odom' as 'CObservationOdometry'` and thousands of `fuse_odometry: twist from velocityLocal: [...]` log lines with real, non-zero velocities -- previously silently dropped in offline mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional wheel-odometry input when processing Rosbag1 data.
  * Added configurable noise parameters for fusing wheel-odometry linear and angular velocity measurements.
  * Added environment-variable overrides and tuning guidance for velocity-fusion settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->