### PR TITLE
Link mola_state_estimation_smoother into the offline CLI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ find_package(mola_input_rosbag2) # optional
 find_package(mola_input_rosbag1) # optional
 find_package(mola_input_paris_luco_dataset) # optional
 find_package(mola_state_estimation_simple QUIET) # optional
+find_package(mola_state_estimation_smoother QUIET) # optional
 
 mola_add_executable(
   TARGET  mola-lidar-odometry-cli
@@ -127,6 +128,48 @@ if(mola_state_estimation_simple_FOUND)
   target_compile_definitions(mola-lidar-odometry-cli PRIVATE HAVE_MOLA_SE_SIMPLE)
 else()
   message(STATUS "mola-lidar-odometry-cli: With mola_state_estimation_simple = NO")
+endif()
+
+# Not selected as a default/fallback estimator like mola_state_estimation_simple
+# above (no HAVE_MOLA_SE_SMOOTHER define needed for that): linking it in is
+# what's required so its class is registered with MRPT's RTTI and therefore
+# reachable via the CLI's own --state-estimator <classname> flag
+# (mrpt::rtti::classFactory() finds any class whose translation unit is
+# actually linked into the binary, generic mechanism, no compile-time
+# branching needed on the caller's side). Without this, --state-estimator
+# mola::state_estimation_smoother::StateEstimationSmoother fails at runtime
+# with "Apparently unknown class name ... (missing plugin .so file?)" even
+# though the flag itself is accepted -- found running the first-ever
+# offline+smoother (cfg-02) sweep through this pipeline, 2026-08-11.
+if(mola_state_estimation_smoother_FOUND)
+  message(STATUS "mola-lidar-odometry-cli: With mola_state_estimation_smoother = YES")
+  # mola_state_estimation_smoother's exported target only records its GTSAM
+  # link dependency by bare name (CMake's legacy
+  # IMPORTED_LINK_DEPENDENT_LIBRARIES mechanism, not a namespaced imported
+  # target), so the gtsam/gtsam_unstable targets it references must already
+  # exist in THIS scope too, or the final link fails with "cannot find
+  # -lgtsam" despite the .so already carrying its own GTSAM dependency
+  # privately. find_package(GTSAM) here is what defines them.
+  find_package(GTSAM QUIET)
+  find_package(GTSAM_UNSTABLE QUIET)
+  # --no-as-needed around this one: nothing in this CLI's own source
+  # references a symbol from mola_state_estimation_smoother directly (its
+  # class is only ever reached indirectly, by name, through
+  # mrpt::rtti::classFactory() at runtime -- unlike
+  # mola_state_estimation_simple above, which IS called directly as a
+  # compile-time fallback and so survives linking as-is). Without this, the
+  # default --as-needed linker behavior sees no referenced symbol and drops
+  # the .so from the binary's DT_NEEDED entries entirely, silently
+  # reproducing the exact "missing plugin .so file?" runtime error this
+  # whole block exists to fix -- confirmed via ldd, which showed the
+  # smoother absent even after the .so linked and built without error.
+  target_link_libraries(mola-lidar-odometry-cli
+    "-Wl,--no-as-needed"
+    mola::mola_state_estimation_smoother
+    "-Wl,--as-needed"
+  )
+else()
+  message(STATUS "mola-lidar-odometry-cli: With mola_state_estimation_smoother = NO")
 endif()
 
 if(mola_input_kitti_dataset_FOUND)

--- a/package.xml
+++ b/package.xml
@@ -60,6 +60,8 @@
   <!-- <test_depend>mola_state_estimation_simple</test_depend> -->
   <!-- for it to be detected and used as default s.e. in the cli -->
   <depend>mola_state_estimation_simple</depend>
+  <!-- for it to be selectable via the cli's state estimator flag -->
+  <depend>mola_state_estimation_smoother</depend>
   <depend>mola_imu_preintegration</depend>
 
   <!-- Needed by the mola-lo-* scripts: -->


### PR DESCRIPTION
## Summary
- \`--state-estimator smoother\` on \`mola-lidar-odometry-cli\` (the offline CLI, needed for cfg-02 of 060_slam_quality_evaluation.md's 4-config eval matrix) accepted the flag but crashed at runtime: \`Apparently unknown class name: 'mola::state_estimation_smoother::StateEstimationSmoother' (missing plugin .so file?)\`. The CLI was never built against \`mola_state_estimation_smoother\` at all -- only \`mola_state_estimation_simple\` had a \`find_package\`/\`target_link_libraries\` pair.
- Discovered running the first-ever real \`cfg-02\` (offline+smoother) sweep through the eval pipeline today -- it hit this immediately, for every dataset. \`mola-cli\` (online configs) links state estimators differently and was already working (\`cfg-04\` ran fine), which is why this went unnoticed until now.
- Two issues, both found by trial: (1) \`mola_state_estimation_smoother\`'s exported CMake target records its GTSAM dependency by bare name (\`IMPORTED_LINK_DEPENDENT_LIBRARIES\`, not a namespaced imported target), so \`gtsam\`/\`gtsam_unstable\` need to exist in the consumer's own CMake scope too -- added \`find_package(GTSAM)\`/\`find_package(GTSAM_UNSTABLE)\`. (2) this CLI never calls a symbol from the smoother directly (only reaches its class by name via \`mrpt::rtti::classFactory()\` at runtime), so the default \`--as-needed\` linker behavior silently dropped the \`.so\` from the binary even after a successful link -- wrapped in \`-Wl,--no-as-needed\`/\`--as-needed\`.

## Test plan
- [x] \`colcon build --packages-select mola_lidar_odometry\` -- clean build.
- [x] \`ldd\` on the built \`mola-lidar-odometry-cli\` now lists \`libmola_state_estimation_smoother.so\` (previously absent despite no build error).
- [x] Direct invocation with \`--state-estimator mola::state_estimation_smoother::StateEstimationSmoother\` against KITTI now exits 0 and produces a real trajectory (previously exited 1 immediately with the class-not-found exception).
- [x] Existing test suite: 8/8 passing (none of them exercise \`--state-estimator smoother\` on the offline CLI, so this doesn't regress anything already covered -- worth adding coverage for this path separately).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting the smoother state estimator through the command-line interface when the optional component is available.
  - The application now reports whether smoother support is enabled.
- **Compatibility**
  - Added the required package dependency for smoother state estimation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->