### PR TITLE
state-estimation-simple.yaml: expose initial_twist_sigma_lin/ang

### DIFF
--- a/state-estimator-params/state-estimation-simple.yaml
+++ b/state-estimator-params/state-estimation-simple.yaml
@@ -31,8 +31,11 @@ params:
   # Set to true when IMU or ICP produce noisy velocity readings.
   velocity_filter_enabled: ${MOLA_NAVSTATE_VELOCITY_FILTER|true}
 
-  # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s):
+  # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s),
+  # used only until the first real velocity measurement is fused:
   initial_twist: [ "${MOLA_INITIAL_VX|0.0}", 0.0, 0.0, 0.0, 0.0, 0.0 ]
+  initial_twist_sigma_lin: ${MOLA_INITIAL_TWIST_SIGMA_LIN|20.0} # [m/s]
+  initial_twist_sigma_ang: ${MOLA_INITIAL_TWIST_SIGMA_ANG|3.0} # [rad/s]
 
   # If enabled, the estimator will enforce z, pitch, and roll to be always 0:
   enforce_planar_motion: ${MOLA_NAVSTATE_ENFORCE_PLANAR_MOTION|false}


### PR DESCRIPTION
## Summary
- Companion to MOLAorg/mola_state_estimation#57, which makes `params.initial_twist` (`MOLA_INITIAL_VX`) actually take effect in `StateEstimationSimple` and adds two new uncertainty knobs for it.
- Exposes those as `MOLA_INITIAL_TWIST_SIGMA_LIN`/`MOLA_INITIAL_TWIST_SIGMA_ANG` in the shipped `state-estimator-params/state-estimation-simple.yaml`, matching the naming already used by `mola_state_estimation_smoother`.

## Test plan
- [x] YAML-only change, defaults match the new C++ defaults (20.0 m/s / 3.0 rad/s) so no behavior change unless the env vars are set.
- Depends on MOLAorg/mola_state_estimation#57 being merged/released for the new keys to be recognized (unknown YAML keys are otherwise harmlessly ignored).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable linear and angular uncertainty parameters with default values.
  * Clarified that the initial twist configuration applies only until the first real velocity measurement is fused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->