### PR TITLE
CitrusFarm launch: accept multi-part base_*.bag sequences

### DIFF
--- a/mola-cli-launchs/lidar_odometry_from_citrusfarm.yaml
+++ b/mola-cli-launchs/lidar_odometry_from_citrusfarm.yaml
@@ -32,6 +32,9 @@
 #     mola-cli $(ros2 pkg prefix mola_lidar_odometry)/share/mola_lidar_odometry/mola-cli-launchs/lidar_odometry_from_citrusfarm.yaml
 #
 # Optional environment variables:
+#   MOLA_INPUT_ROSBAG1_2/_3/_4      -- extra parts of a sequence recorded as
+#                                      several base_*.bag files (sequences 01,
+#                                      03, 04, 05 and 07 have 2 to 4 of them)
 #   MOLA_WITH_GUI=false             -- headless mode
 #   MOLA_TIME_WARP=1.0              -- playback speed factor
 #   MOLA_QUIT_ON_DATASET_END=true   -- exit when bag ends
@@ -70,8 +73,14 @@ modules:
       # We use environment variables to force the user to specify the bag file(s), e.g.:
       #   MOLA_INPUT_ROSBAG1=/mnt/storage/CitrusFarm/06_14B_Jackal/base_2023-07-18-14-29-35_0.bag
       #   MOLA_INPUT_ROSBAG1_ODOM=/mnt/storage/CitrusFarm/06_14B_Jackal/odom_2023-07-18-14-29-35.bag
+      #
+      # Most sequences are split into several base_*.bag parts; pass the
+      # 2nd and later ones in the numbered slots, in recording order.
       rosbag_filename:
         - ${MOLA_INPUT_ROSBAG1}
+        - ${MOLA_INPUT_ROSBAG1_2|}
+        - ${MOLA_INPUT_ROSBAG1_3|}
+        - ${MOLA_INPUT_ROSBAG1_4|}
         - ${MOLA_INPUT_ROSBAG1_ODOM|}
 
       base_link_frame_id: imu

--- a/scripts/mola-lo-gui-citrusfarm
+++ b/scripts/mola-lo-gui-citrusfarm
@@ -6,8 +6,11 @@
 # recorded ROS 1 "base_*.bag" (LiDAR+IMU+GPS) and, optionally, the matching
 # "odom_*.bag" (wheel odometry) of one sequence.
 #
+# Most sequences are split into several "base_*.bag" parts; pass them all, in
+# recording order.
+#
 # Usage:
-#   mola-lo-gui-citrusfarm /path/to/base_*.bag [/path/to/odom_*.bag] [additional flags for mola-cli]
+#   mola-lo-gui-citrusfarm /path/to/base_*.bag [more base_*.bag parts] [/path/to/odom_*.bag] [additional flags for mola-cli]
 #
 # Fixed sensor extrinsics (IMU as base_link/reference frame) are baked into
 # lidar_odometry_from_citrusfarm.yaml; see that file's header comment for how
@@ -26,15 +29,30 @@ if [ -d $SCRIPT_DIR/../share/mola_lidar_odometry/mola-cli-launchs ]; then
   MOLA_LAUNCHS_DIR=$SCRIPT_DIR/../share/mola_lidar_odometry/mola-cli-launchs
 fi
 
-# Split the base bag (first non-flag argument) and, if given, the odom bag
-# (second non-flag argument, only if its basename starts with "odom_") from
-# any remaining flags to forward to mola-cli:
+# Split the base bag parts (the first argument, plus any later one whose
+# basename starts with "base_") and, if given, the odom bag (basename starting
+# with "odom_") from any remaining flags to forward to mola-cli. The launch
+# file exposes 4 base slots, which covers every sequence published so far:
 MOLA_INPUT_ROSBAG1=""
+MOLA_INPUT_ROSBAG1_2=""
+MOLA_INPUT_ROSBAG1_3=""
+MOLA_INPUT_ROSBAG1_4=""
 MOLA_INPUT_ROSBAG1_ODOM=""
+BASE_SLOT=0
 EXTRA_ARGS=()
 for arg in "$@"; do
-    if [ -z "$MOLA_INPUT_ROSBAG1" ]; then
-        MOLA_INPUT_ROSBAG1=$arg
+    if [ "$BASE_SLOT" -eq 0 ] || [[ "$(basename "$arg")" == base_* ]]; then
+        BASE_SLOT=$((BASE_SLOT + 1))
+        case "$BASE_SLOT" in
+            1) MOLA_INPUT_ROSBAG1=$arg ;;
+            2) MOLA_INPUT_ROSBAG1_2=$arg ;;
+            3) MOLA_INPUT_ROSBAG1_3=$arg ;;
+            4) MOLA_INPUT_ROSBAG1_4=$arg ;;
+            *)
+                echo "Error: too many base_*.bag parts, the launch file exposes 4 slots."
+                exit 1
+                ;;
+        esac
     elif [ -z "$MOLA_INPUT_ROSBAG1_ODOM" ] && [[ "$(basename "$arg")" == odom_* ]]; then
         MOLA_INPUT_ROSBAG1_ODOM=$arg
     else
@@ -42,6 +60,9 @@ for arg in "$@"; do
     fi
 done
 export MOLA_INPUT_ROSBAG1
+export MOLA_INPUT_ROSBAG1_2
+export MOLA_INPUT_ROSBAG1_3
+export MOLA_INPUT_ROSBAG1_4
 export MOLA_INPUT_ROSBAG1_ODOM
 
 mola-cli \

--- a/scripts/mola-lo-gui-citrusfarm
+++ b/scripts/mola-lo-gui-citrusfarm
@@ -16,9 +16,11 @@
 # lidar_odometry_from_citrusfarm.yaml; see that file's header comment for how
 # they were derived from the dataset's own calibration results.
 
+USAGE="Usage: $0 /path/to/base_*.bag [more base_*.bag parts] [/path/to/odom_*.bag] [additional flags for mola-cli]"
+
 if [ "$#" -eq 0 ]; then
     echo "Error: A CitrusFarm ROS 1 'base_*.bag' file is required."
-    echo "Usage: $0 /path/to/base_*.bag [/path/to/odom_*.bag] [additional flags for mola-cli]"
+    echo "$USAGE"
     exit 1
 fi
 
@@ -41,7 +43,15 @@ MOLA_INPUT_ROSBAG1_ODOM=""
 BASE_SLOT=0
 EXTRA_ARGS=()
 for arg in "$@"; do
-    if [ "$BASE_SLOT" -eq 0 ] || [[ "$(basename "$arg")" == base_* ]]; then
+    arg_basename=$(basename -- "$arg")
+    # The odometry bag is recognized wherever it appears, including first,
+    # so it never consumes a base slot and shifts the parts by one.
+    if [ -z "$MOLA_INPUT_ROSBAG1_ODOM" ] && [[ "$arg_basename" == odom_* ]]; then
+        MOLA_INPUT_ROSBAG1_ODOM=$arg
+    # The first non-odometry argument is the first base part whatever it is
+    # called, so a renamed or re-exported bag keeps working; later parts have
+    # to be recognizable as such to tell them from mola-cli flags.
+    elif [ "$BASE_SLOT" -eq 0 ] || [[ "$arg_basename" == base_* ]]; then
         BASE_SLOT=$((BASE_SLOT + 1))
         case "$BASE_SLOT" in
             1) MOLA_INPUT_ROSBAG1=$arg ;;
@@ -53,12 +63,16 @@ for arg in "$@"; do
                 exit 1
                 ;;
         esac
-    elif [ -z "$MOLA_INPUT_ROSBAG1_ODOM" ] && [[ "$(basename "$arg")" == odom_* ]]; then
-        MOLA_INPUT_ROSBAG1_ODOM=$arg
     else
         EXTRA_ARGS+=("$arg")
     fi
 done
+
+if [ "$BASE_SLOT" -eq 0 ]; then
+    echo "Error: A CitrusFarm ROS 1 'base_*.bag' file is required."
+    echo "$USAGE"
+    exit 1
+fi
 export MOLA_INPUT_ROSBAG1
 export MOLA_INPUT_ROSBAG1_2
 export MOLA_INPUT_ROSBAG1_3


### PR DESCRIPTION
Most CitrusFarm sequences are recorded as 2 to 4 `base_*.bag` parts (01 has 3, 03 has 4, 04/05/07 have 2), but `lidar_odometry_from_citrusfarm.yaml` exposed a single bag slot. Everything except the two one-part sequences (02, 06) therefore could not be replayed through `mola-cli` at all: passing a comma-joined list in `MOLA_INPUT_ROSBAG1` reaches `Rosbag1Dataset` as one filename and trips `Assert file existence failed`.

This adds `MOLA_INPUT_ROSBAG1_2/_3/_4` to the launch file's `rosbag_filename` list, mirroring what `lidar_odometry_from_rosbag1.yaml` already does. `Rosbag1Dataset` merges the listed bags into one chronological view and already skips empty entries, so a one-part sequence behaves exactly as before.

`mola-lo-gui-citrusfarm` now fills those slots from every `base_*.bag` argument it is given, in the order given, and still recognizes the optional `odom_*.bag` anywhere in the list.

Found while sweeping the full dataset corpus through the MOLA-LO quality-evaluation CI: the offline CLI accepts a comma-separated `--input-rosbag1`, so the same sequences scored fine offline and failed only in the online configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for processing CitrusFarm recordings split across multiple `base_*.bag` files.
  * Up to four base recording parts can now be supplied in recording order, including a first part with a nonstandard filename.
  * Optional odometry bags are recognized regardless of argument order.
  * Additional command-line arguments are forwarded to the application.
* **Bug Fixes**
  * Added validation when no base recording or more than four base parts are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->