### PR TITLE
KITTI profile: select the point-to-point pipeline

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -40,10 +40,21 @@ without forking the profile. Two variables the caller sets:
 - `MOLA_LO_SKIP_STATE_ESTIMATOR=1` — for callers running a method with its
   own internal estimator (the DLIO / Fast-LIO2 wrappers).
 
+A profile may also pick the pipeline, by publishing
+`MOLA_ODOMETRY_PIPELINE_YAML` the same way. Only where a dataset has a measured
+reason to differ, and the evidence goes in the profile.
+
 Adding a dataset means adding one profile plus two one-line wrappers, and
 listing it in `MOLA_LO_DATASET_WRAPPERS` in `CMakeLists.txt`.
 
 ### Per-dataset notes
+
+- **kitti** selects `pipelines/lidar3d-icp.yaml` over the cov-to-cov default:
+  measured over 00-10 it wins 8/11 on translation and 7/11 on rotation at about
+  half the cost per scan. A forward ablation between the two pipelines found
+  the difference is not attributable to any one stage — intermediate
+  configurations are several times worse than either — so this is a per-dataset
+  choice, not a ranking of the pipelines.
 
 - **conslam** autodetects ROS 1 (`.bag`) vs ROS 2 (`.mcap`) from the
   extension. `CONSLAM_BASE_FRAME` picks which frame the trajectory is

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -411,7 +411,10 @@ icp_settings_with_vel:
   solvers:
     - class: mp2p_icp::Solver_GaussNewton
       params:
-        maxIterations: 1
+        # Inner Gauss-Newton iterations per ICP iteration. Exposed so an
+        # ablation can compare this solver against the annealed multi-iteration
+        # one used by the point-to-point pipeline without editing YAML.
+        maxIterations: ${MOLA_LO_SOLVER_MAX_ITERS|1}
         robustKernel: "${MOLA_LO_ROBUST_KERNEL|RobustKernel::GemanMcClure}"
         robustKernelParam: "${MOLA_LO_ROBUST_KERNEL_PARAM|6.0}" # In GICP, errors are normalized by covariance
         # Blend [0,1] for the robust kernel residual reference toward the prior

--- a/scripts/lib/dataset-profile.sh
+++ b/scripts/lib/dataset-profile.sh
@@ -43,6 +43,11 @@
 # Every value a profile publishes uses the ': "${VAR:=default}"' idiom, so a
 # caller that exported the variable first always wins. That is what lets the
 # CI keep its per-dataset overrides without forking the profile.
+#
+# A profile may also pick the odometry pipeline itself, by publishing
+# MOLA_ODOMETRY_PIPELINE_YAML the same way. Do that only where a dataset has a
+# measured reason to differ from the default, and state the evidence in the
+# profile: see profiles/kitti.sh.
 
 # Absolute path of this library's directory, resolved through symlinks.
 MOLA_LO_LIB_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)

--- a/scripts/lib/profiles/kitti.sh
+++ b/scripts/lib/profiles/kitti.sh
@@ -37,6 +37,22 @@ mola_lo_profile_resolve() {
   : "${MOLA_INITIAL_VX:=20.0}"
   export MOLA_INITIAL_VX
 
+  # KITTI does better on the point-to-point pipeline than on the default
+  # cov-to-cov one, and by enough to be worth selecting here: measured over
+  # sequences 00-10 it is better on 8 of 11 in translation and 7 of 11 in
+  # rotation, and costs about half the time per scan.
+  #
+  # This is a per-dataset choice, not a claim about the pipelines in general.
+  # A forward ablation between the two found that the difference does not come
+  # from any single stage: intermediate configurations are several times worse
+  # than either pipeline, so the two are separate optima rather than points on
+  # a path. Swapping just the matcher, in particular, is far worse than either.
+  #
+  # Batch and regression runs override this the same way they override the
+  # velocity prior above, so their published numbers stay comparable.
+  : "${MOLA_ODOMETRY_PIPELINE_YAML:=$MOLA_LO_PIPELINES_DIR/lidar3d-icp.yaml}"
+  export MOLA_ODOMETRY_PIPELINE_YAML
+
   MOLA_LO_LAUNCH_FILE=lidar_odometry_from_kitti.yaml
   MOLA_LO_CLI_INPUT=(--input-kitti-seq "$seq")
 }


### PR DESCRIPTION
## What

Two changes, both small:

1. `scripts/lib/profiles/kitti.sh` now selects `pipelines/lidar3d-icp.yaml`
   instead of leaving KITTI on the cov-to-cov default. Profiles could not pick a
   pipeline before; they can now, using the same `: "${VAR:=default}"` idiom as
   every other value they publish, so batch and regression runs keep their own
   choices.
2. `pipelines/lidar3d-gicp.yaml` exposes the solver's inner iteration count as
   `MOLA_LO_SOLVER_MAX_ITERS`. The default is unchanged; it was needed to sweep
   an axis that was previously hardcoded.

## Why

Measured over KITTI 00-10, one build, pinned core, deterministic settings:

| pipeline | trans % | rot deg/100m | ms/scan |
|---|---|---|---|
| cov-to-cov default, tuned | 0.639 | 0.221 | 243 |
| `lidar3d-icp.yaml` | **0.582** | **0.167** | **130** |

Better on 8 of 11 sequences in translation and 7 of 11 in rotation, at about
half the cost per scan.

**This is a per-dataset choice, not a ranking of the pipelines.** A forward
ablation between the two, eight arms on 00-10, found that the difference is not
attributable to any single stage: every intermediate configuration is 2-5x worse
than either endpoint, so the two are separate optima rather than points along a
path. Swapping only the matcher, in particular, is far worse than either
pipeline (+189% translation, losing on all 11 sequences), so the cov-to-cov
matcher is emphatically not the reason for the gap.

The solver-iteration knob added here was swept as part of that work and is a
null on the cov-to-cov side (-0.8% translation, flat rotation, saturating at 3
iterations), which is why the default stays at 1.

## Testing

- `mola-lo-cli-kitti 04` runs end to end through the wrapper and emits the
  expected 271 poses.
- Verified the profile's pipeline choice takes effect, and that a caller
  exporting `MOLA_ODOMETRY_PIPELINE_YAML` still overrides it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting an odometry pipeline per dataset.
  * KITTI runs now default to the point-to-point ICP pipeline, with documented benchmark results.
  * Added configuration for the solver’s maximum inner iterations, defaulting to one.

* **Documentation**
  * Documented dataset-specific pipeline overrides and KITTI pipeline selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->