### PR TITLE
lidar3d-gicp: clear the observation layer before filling it

### DIFF
--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -37,8 +37,10 @@ params:
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion without an IMU.
   # NOTE: Disabled for more efficient deskew in the GICP pipeline with IMU.
-  # If using LO without IMU, try lidar3d-gicp-optimize-twist.yaml to enable optimize_twist if needed.
-  optimize_twist: false
+  # Enabling it costs about 25% more time per scan. On KITTI, which has no IMU
+  # and so no other source of velocity, it still bought nothing measurable, so
+  # do not assume it helps just because a platform lacks an IMU: measure it.
+  optimize_twist: ${MOLA_OPTIMIZE_TWIST|false}
 
   # IMU accelerometer-based verticality correction:
   # Uses averaged accelerometer readings to constrain ICP pitch/roll.
@@ -666,6 +668,15 @@ observations_filter_1st_pass:
 
 # 2nd pass:
 observations_filter_2nd_pass:
+  # The merge below appends to "observation", so this pass has to start from an
+  # empty layer: with optimize_twist enabled the whole pass re-runs after a
+  # twist correction, and a second append leaves the cov-capable observation
+  # map holding two keyframes, which the cov-to-cov nearest-neighbor search
+  # rejects outright.
+  - class_name: mp2p_icp_filters::FilterClear
+    params:
+      target_layer: "observation"
+
   - class_name: mp2p_icp_filters::FilterMerge
     params:
       name: "FilterMerge (icp into obs)"


### PR DESCRIPTION
## The bug

`lidar3d-gicp.yaml`'s second filter pass appends `decimated_for_icp` into the
`observation` layer without emptying it first:

```yaml
observations_filter_2nd_pass:
  - class_name: mp2p_icp_filters::FilterMerge
    params:
      input_pointcloud_layer: "decimated_for_icp"
      target_layer: "observation"
```

That is harmless while the pass runs once per scan. But `optimize_twist` re-runs
the whole second pass after each twist correction, so a second keyframe is
appended to a map that `Matcher_Cov2Cov` requires to hold exactly one, and the
run aborts on the third scan:

```
ASSERT_EQUAL_(localMapKF->keyframes_.size(),1U) failed with
localMapKF->keyframes_.size()=2
  KeyframePointCloudMap.cpp:989 nn_search_cov2cov_impl
```

The pipeline's own comment points users at `lidar3d-gicp-optimize-twist.yaml`
for this feature, and that file carries a `FilterClear` on the `observation`
layer which the main pipeline never had. This ports that one filter.

## Also here

`optimize_twist` becomes `${MOLA_OPTIMIZE_TWIST|false}`, default unchanged, so
the knob is reachable on this pipeline without switching files.

That matters because `lidar3d-gicp-optimize-twist.yaml` is a hand-maintained
copy that has drifted from its source: it is missing the whole
`imu_gravity_correction` block, among others. Anyone following the comment's
advice today silently loses features. **Suggested follow-up, not done here:**
with this fix that duplicate file is redundant and could be retired.

## Testing

- With `optimize_twist` off, output is **bit-identical** to the previous
  pipeline (md5 of the estimated trajectory, KITTI seq 04, pinned core and
  deterministic settings). No regression.
- With `MOLA_OPTIMIZE_TWIST=true` the pipeline now completes; it previously
  aborted on scan 3.
- Swept over KITTI 00-10: enabling the twist optimization is a **null** on
  accuracy (-1.1% translation, 8/11; -0.4% rotation, 4/11) at **1.25x** the
  time per scan. The default therefore stays `false`, and the comment now says
  so rather than implying a platform without an IMU should enable it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable twist optimization, disabled by default.
  * Added guidance on the performance cost and expected benefits of twist optimization.

* **Bug Fixes**
  * Prevented duplicate keyframes from accumulating when the observation pipeline runs repeatedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->