### PR TITLE
3D lidar pipelines: expose freezePairingsAfterIteration as an env override

### DIFF
--- a/pipelines/lidar3d-default-voxelavg.yaml
+++ b/pipelines/lidar3d-default-voxelavg.yaml
@@ -346,6 +346,10 @@ icp_settings_with_vel:
   # See: mp2p_icp::Parameter
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
+    # Stop re-associating after this iteration and keep optimizing the
+    # pairings already found (0 = never freeze, the behavior so far).
+    # Exposed only so it can be swept; the default is unchanged.
+    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
 

--- a/pipelines/lidar3d-dlio-like-only-downsample-voxelavg.yaml
+++ b/pipelines/lidar3d-dlio-like-only-downsample-voxelavg.yaml
@@ -368,6 +368,10 @@ icp_settings_with_vel:
   # See: mp2p_icp::Parameter
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
+    # Stop re-associating after this iteration and keep optimizing the
+    # pairings already found (0 = never freeze, the behavior so far).
+    # Exposed only so it can be swept; the default is unchanged.
+    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
 

--- a/pipelines/lidar3d-dlio-like-only-downsample.yaml
+++ b/pipelines/lidar3d-dlio-like-only-downsample.yaml
@@ -357,6 +357,10 @@ icp_settings_with_vel:
   # See: mp2p_icp::Parameter
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
+    # Stop re-associating after this iteration and keep optimizing the
+    # pairings already found (0 = never freeze, the behavior so far).
+    # Exposed only so it can be swept; the default is unchanged.
+    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
 

--- a/pipelines/lidar3d-dlio-like-revert-downsample.yaml
+++ b/pipelines/lidar3d-dlio-like-revert-downsample.yaml
@@ -240,6 +240,10 @@ icp_settings_with_vel:
   class_name: mp2p_icp::ICP
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
+    # Stop re-associating after this iteration and keep optimizing the
+    # pairings already found (0 = never freeze, the behavior so far).
+    # Exposed only so it can be swept; the default is unchanged.
+    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
     saveIterationDetails: ${MP2P_ICP_LOG_FILES_SAVE_DETAILS|false}

--- a/pipelines/lidar3d-dlio-like-revert-keyframe.yaml
+++ b/pipelines/lidar3d-dlio-like-revert-keyframe.yaml
@@ -236,6 +236,10 @@ icp_settings_with_vel:
   class_name: mp2p_icp::ICP
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
+    # Stop re-associating after this iteration and keep optimizing the
+    # pairings already found (0 = never freeze, the behavior so far).
+    # Exposed only so it can be swept; the default is unchanged.
+    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
     saveIterationDetails: ${MP2P_ICP_LOG_FILES_SAVE_DETAILS|false}

--- a/pipelines/lidar3d-dlio-like-worldframe-decimate.yaml
+++ b/pipelines/lidar3d-dlio-like-worldframe-decimate.yaml
@@ -278,6 +278,10 @@ icp_settings_with_vel:
   class_name: mp2p_icp::ICP
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
+    # Stop re-associating after this iteration and keep optimizing the
+    # pairings already found (0 = never freeze, the behavior so far).
+    # Exposed only so it can be swept; the default is unchanged.
+    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
     saveIterationDetails: ${MP2P_ICP_LOG_FILES_SAVE_DETAILS|false}

--- a/pipelines/lidar3d-dlio-like.yaml
+++ b/pipelines/lidar3d-dlio-like.yaml
@@ -238,6 +238,10 @@ icp_settings_with_vel:
   class_name: mp2p_icp::ICP
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
+    # Stop re-associating after this iteration and keep optimizing the
+    # pairings already found (0 = never freeze, the behavior so far).
+    # Exposed only so it can be swept; the default is unchanged.
+    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
     saveIterationDetails: ${MP2P_ICP_LOG_FILES_SAVE_DETAILS|false}

--- a/pipelines/lidar3d-fastlio-matching.yaml
+++ b/pipelines/lidar3d-fastlio-matching.yaml
@@ -385,6 +385,10 @@ icp_settings_with_vel:
   # See: mp2p_icp::Parameter
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
+    # Stop re-associating after this iteration and keep optimizing the
+    # pairings already found (0 = never freeze, the behavior so far).
+    # Exposed only so it can be swept; the default is unchanged.
+    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
 

--- a/pipelines/lidar3d-gicp-optimize-twist.yaml
+++ b/pipelines/lidar3d-gicp-optimize-twist.yaml
@@ -243,6 +243,10 @@ icp_settings_with_vel:
   # See: mp2p_icp::Parameter
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
+    # Stop re-associating after this iteration and keep optimizing the
+    # pairings already found (0 = never freeze, the behavior so far).
+    # Exposed only so it can be swept; the default is unchanged.
+    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
 

--- a/pipelines/lidar3d-gicp-single-filter.yaml
+++ b/pipelines/lidar3d-gicp-single-filter.yaml
@@ -362,6 +362,10 @@ icp_settings_with_vel:
   # See: mp2p_icp::Parameter
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
+    # Stop re-associating after this iteration and keep optimizing the
+    # pairings already found (0 = never freeze, the behavior so far).
+    # Exposed only so it can be swept; the default is unchanged.
+    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
 

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -390,6 +390,10 @@ icp_settings_with_vel:
   # See: mp2p_icp::Parameter
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
+    # Stop re-associating after this iteration and keep optimizing the
+    # pairings already found (0 = never freeze, the behavior so far).
+    # Exposed only so it can be swept; the default is unchanged.
+    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
 


### PR DESCRIPTION
`mp2p_icp::Parameters::freezePairingsAfterIteration` stops the re-association step after a given iteration and keeps optimizing the pairings already found. It has been loadable from YAML all along, but no pipeline here named it, so sweeping it meant editing a pipeline file — and it never reached a second sequence after the one measurement that exists (Oxford `observatory-quarter-01`: APE −45 %, `est/gt` path ratio 1.033, recorded under a *stability* result and not followed up as an accuracy one).

This adds it as `${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}`, directly under `MOLA_MAX_ICP_ITERATIONS`, in every pipeline that carries that knob. **Default 0 = never freeze**, which is exactly what these pipelines did before, so no shipped behavior changes.

Branched from `94d934a` rather than `develop` so a sweep pinning it differs from the `v2026.08.19-baseline` manifest by this commit alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1ymyPshU5eGhA8Xy1UgSv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional setting to stop updating point correspondences after a selected optimization iteration.
  - The setting can be configured through `MOLA_FREEZE_PAIRINGS_AFTER_ITER` across supported LiDAR and ICP pipelines.
  - Defaults to `0`, preserving continuous correspondence updates and existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->