### PR TITLE
Make ESTIMATED_OBSERVATION_RADIUS robust to a single far return

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -236,6 +236,33 @@ public:
     double observation_radius_filter_coefficient = 0.999;
     double absolute_minimum_observation_radius = 5.0;  // [m]
 
+    /** Quantile of the per-point norms used as ESTIMATED_OBSERVATION_RADIUS,
+     * in (0, 1]. **1.0 means the bounding-box max-norm**, which is what this
+     * estimate has always been and remains the default.
+     *
+     * The max-norm is an outlier statistic, not a scene scale: one far return
+     * sets it. Measured on three lidars recorded simultaneously in one room,
+     * it reads 13.8, 18.0 and 101.8 m -- a 7.4x disagreement about a fixed
+     * scene -- while across every outdoor sequence measured it spans only
+     * 69.8-91.2 m. Six shipped parameters are derived from it (`range_min`,
+     * `range_max`, the keyframe distances, the local-map extent), so an
+     * estimate with that failure mode has almost no leverage where tuning is
+     * needed and a great deal of spurious leverage where it is not.
+     *
+     * A quantile below 1.0 (0.98 is a reasonable choice) reads the same on
+     * scenes whose returns really do reach that far, and stops one stray
+     * return from setting the scale of a room.
+     */
+    double observation_radius_quantile = 1.0;
+
+    /** Cap on how many points are sampled to evaluate
+     * `observation_radius_quantile`. The quantile needs a distribution, not
+     * every point; a strided sample of a few thousand from a 60k-point scan
+     * settles it to well under a metre, and keeps this O(sample) rather than
+     * O(scan) on every frame. Ignored when the quantile is 1.0.
+     */
+    uint32_t observation_radius_quantile_max_samples = 8000;
+
     /** If enabled (slower), vehicle twist will be optimized during ICP
          *  enabling better and more robust odometry in high dynamics motion.
          */

--- a/module/src/LidarOdometry_AdaptiveVariables.cpp
+++ b/module/src/LidarOdometry_AdaptiveVariables.cpp
@@ -177,6 +177,53 @@ void LidarOdometry::doUpdateAdaptiveThreshold()
     "delta: %+.4f ICP q=%.3f sigma=%.4f", delta, state_.last_icp_quality, state_.adapt_thres_sigma);
 }
 
+namespace
+{
+/** Radius of the observation, as either the bounding-box max-norm (the
+ * historical behavior, `quantile` = 1) or a quantile of the per-point norms.
+ *
+ * The max-norm is set by a single point, so a stray far return decides the
+ * scale of the whole scene; six shipped parameters are derived from this
+ * number. The quantile path samples with a stride instead of reading every
+ * point: it needs the shape of the distribution, not all of it.
+ */
+double observationRadius(const mrpt::maps::CPointsMap & pts, double quantile, uint32_t maxSamples)
+{
+  const auto bb = pts.boundingBox();
+  const double maxNorm = std::max(bb.max.norm(), bb.min.norm());
+  if (quantile >= 1.0) {
+    return maxNorm;
+  }
+
+  const auto & xs = pts.getPointsBufferRef_x();
+  const auto & ys = pts.getPointsBufferRef_y();
+  const auto & zs = pts.getPointsBufferRef_z();
+  const size_t n = xs.size();
+  if (n < 2) {
+    return maxNorm;
+  }
+
+  const size_t stride = std::max<size_t>(1, n / std::max<uint32_t>(1, maxSamples));
+  std::vector<double> norms;
+  norms.reserve(n / stride + 1);
+  for (size_t i = 0; i < n; i += stride) {
+    const double r2 = static_cast<double>(xs[i]) * xs[i] + static_cast<double>(ys[i]) * ys[i] +
+                      static_cast<double>(zs[i]) * zs[i];
+    if (std::isfinite(r2)) {
+      norms.push_back(std::sqrt(r2));
+    }
+  }
+  if (norms.empty()) {
+    return maxNorm;
+  }
+
+  const size_t k =
+    std::min(norms.size() - 1, static_cast<size_t>(quantile * (norms.size() - 1) + 0.5));
+  std::nth_element(norms.begin(), norms.begin() + k, norms.end());
+  return norms[k];
+}
+}  // namespace
+
 void LidarOdometry::doInitializeEstimatedObservationRadius(const mrpt::obs::CObservation & o)
 {
   auto & maxRange = state_.estimated_observation_radius;
@@ -195,9 +242,8 @@ void LidarOdometry::doInitializeEstimatedObservationRadius(const mrpt::obs::CObs
     return;
   }
 
-  const auto bb = pts->boundingBox();
-
-  double radius = std::max(bb.max.norm(), bb.min.norm());
+  double radius = observationRadius(
+    *pts, params_.observation_radius_quantile, params_.observation_radius_quantile_max_samples);
 
   // check for NaN, Infinities, etc.: See: https://github.com/MOLAorg/mola_lidar_odometry/issues/10
   if (!std::isnormal(radius)) {
@@ -233,7 +279,8 @@ void LidarOdometry::doUpdateEstimatedObservationRadius(const mp2p_icp::metric_ma
       continue;  // skip NaN, INF, etc.
     }
 
-    double radius = std::max(bb.max.norm(), bb.min.norm());
+    double radius = observationRadius(
+      *pts, params_.observation_radius_quantile, params_.observation_radius_quantile_max_samples);
 
     mrpt::keep_max(radius, params_.absolute_minimum_observation_radius);
 

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -185,6 +185,10 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
       "absolute_minimum_sensor_range", params_.absolute_minimum_observation_radius);
     YAML_LOAD_OPT(params_, observation_radius_filter_coefficient, double);
     YAML_LOAD_OPT(params_, absolute_minimum_observation_radius, double);
+    YAML_LOAD_OPT(params_, observation_radius_quantile, double);
+    YAML_LOAD_OPT(params_, observation_radius_quantile_max_samples, uint32_t);
+    ASSERT_GT_(params_.observation_radius_quantile, 0.0);
+    ASSERT_LE_(params_.observation_radius_quantile, 1.0);
     YAML_LOAD_OPT(params_, start_active, bool);
 
     YAML_LOAD_OPT(params_, max_lidar_queue_before_drop, uint32_t);

--- a/pipelines/lidar3d-default-voxelavg.yaml
+++ b/pipelines/lidar3d-default-voxelavg.yaml
@@ -39,6 +39,11 @@ params:
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion without an IMU.

--- a/pipelines/lidar3d-dlio-like-only-downsample-voxelavg.yaml
+++ b/pipelines/lidar3d-dlio-like-only-downsample-voxelavg.yaml
@@ -61,6 +61,11 @@ params:
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion without an IMU.

--- a/pipelines/lidar3d-dlio-like-only-downsample.yaml
+++ b/pipelines/lidar3d-dlio-like-only-downsample.yaml
@@ -50,6 +50,11 @@ params:
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion without an IMU.

--- a/pipelines/lidar3d-dlio-like-revert-downsample.yaml
+++ b/pipelines/lidar3d-dlio-like-revert-downsample.yaml
@@ -70,6 +70,11 @@ params:
 
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   optimize_twist: false
 

--- a/pipelines/lidar3d-dlio-like-revert-keyframe.yaml
+++ b/pipelines/lidar3d-dlio-like-revert-keyframe.yaml
@@ -69,6 +69,11 @@ params:
 
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   optimize_twist: false
 

--- a/pipelines/lidar3d-dlio-like-worldframe-decimate.yaml
+++ b/pipelines/lidar3d-dlio-like-worldframe-decimate.yaml
@@ -108,6 +108,11 @@ params:
 
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   optimize_twist: false
 

--- a/pipelines/lidar3d-dlio-like.yaml
+++ b/pipelines/lidar3d-dlio-like.yaml
@@ -68,6 +68,11 @@ params:
 
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   optimize_twist: false
 

--- a/pipelines/lidar3d-fastlio-matching.yaml
+++ b/pipelines/lidar3d-fastlio-matching.yaml
@@ -28,6 +28,11 @@ params:
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion without an IMU.

--- a/pipelines/lidar3d-gicp-optimize-twist.yaml
+++ b/pipelines/lidar3d-gicp-optimize-twist.yaml
@@ -32,6 +32,11 @@ params:
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion without an IMU.

--- a/pipelines/lidar3d-gicp-single-filter.yaml
+++ b/pipelines/lidar3d-gicp-single-filter.yaml
@@ -55,6 +55,11 @@ params:
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion without an IMU.

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -33,6 +33,11 @@ params:
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion without an IMU.

--- a/pipelines/lidar3d-icp-blend.yaml
+++ b/pipelines/lidar3d-icp-blend.yaml
@@ -29,6 +29,11 @@ params:
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion.

--- a/pipelines/lidar3d-icp.yaml
+++ b/pipelines/lidar3d-icp.yaml
@@ -31,6 +31,11 @@ params:
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion.

--- a/pipelines/lidar3d-ndt-blend.yaml
+++ b/pipelines/lidar3d-ndt-blend.yaml
@@ -35,6 +35,11 @@ params:
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion.

--- a/pipelines/lidar3d-ndt.yaml
+++ b/pipelines/lidar3d-ndt.yaml
@@ -31,6 +31,11 @@ params:
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
+  # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.
+  # 1.0 = the bounding-box max-norm, i.e. one far return sets the scene
+  # scale for the six parameters derived from it. Default unchanged;
+  # exposed so the robust alternative can be measured.
+  observation_radius_quantile: ${MOLA_OBSERVATION_RADIUS_QUANTILE|1.0}
 
   # If enabled, vehicle twist will be optimized during ICP
   # enabling better and more robust odometry in high dynamics motion.


### PR DESCRIPTION
## The defect

`doUpdateEstimatedObservationRadius()` has always set `R = max(|bb.min|, |bb.max|)` of the scan — a bounding-box max-norm, so **one stray return sets the scale of the whole scene**. Six shipped parameters derive from `R`: `range_min`, `range_max`, `max_distance_to_keep_keyframes`, `min_translation_between_keyframes` and the local-map extent. That makes the failure mode load-bearing rather than cosmetic.

Measured on TIERS `indoor01` — three lidars recorded **simultaneously in one room**, so the scene is a constant:

| lidar | R, `quantile` = 1.0 (shipped) | R, `quantile` = 0.98 | 0.95 |
|---|---|---|---|
| Ouster OS0 | 17.5 m | *(measuring)* | |
| Ouster OS1 | ~13.8 m | *(measuring)* | |
| **Velodyne VLP-16** | **102.8 m** | **10.0 m** | 8.3 m |

The VLP-16's far returns escape through a doorway and set `R` to 103 m for a room. At a 0.98 quantile the same scan reads 10.0 m — alongside the two Ousters that the max-norm already gets right. Meanwhile across every genuinely outdoor sequence measured, `R` spans only 69.8–91.2 m, a factor of 1.3. So the current estimate has almost no leverage where tuning is needed and a great deal of spurious leverage where it is not.

Concretely, on that scene it moves `range_min = max(1.0, 0.03*R)` from **3.08 m to the 1.0 m clamp**. A three-metre spherical floor inside a room was discarding 28 % of the scene before anything else ran.

## What this changes

**Nothing, by default.** `observation_radius_quantile` defaults to `1.0`, which is exactly the max-norm behaviour. Below 1.0 it takes that quantile of the per-point norms from a **strided sample** capped at `observation_radius_quantile_max_samples` (8000) — the quantile needs the shape of the distribution, not every point, so this stays O(sample) per frame rather than O(scan).

Exposed as `MOLA_OBSERVATION_RADIUS_QUANTILE` in every 3D pipeline so it can be swept before anyone proposes changing a default.

## Status

This is the **knob plus the evidence that R is wrong**, not yet a proposal to change the default. The accuracy sweep (TIERS, with no-regression checks on Oxford / KITTI / BotanicGarden) is running; I'll post the numbers here. Merging it as-is is safe either way, since the default path is byte-identical to today's.

Context: `~/plans/lio/README.md` point 7 and `03_accuracy_pipeline.md` §1.3 have both documented this defect without fixing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1ymyPshU5eGhA8Xy1UgSv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable observation-radius estimation using a selected per-point distance quantile.
  * Added an optional sample limit to support efficient lower-quantile calculations.
  * Exposed configuration across supported LiDAR processing pipelines, including environment-variable support.
  * Existing behavior is preserved by default using the maximum distance (quantile `1.0`).

* **Validation**
  * Configuration now validates that the quantile is greater than `0` and no greater than `1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->