### PR TITLE
Revert #143: freezePairingsAfterIteration is not an mp2p_icp parameter

### DIFF
--- a/pipelines/lidar3d-default-voxelavg.yaml
+++ b/pipelines/lidar3d-default-voxelavg.yaml
@@ -346,10 +346,6 @@ icp_settings_with_vel:
   # See: mp2p_icp::Parameter
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
-    # Stop re-associating after this iteration and keep optimizing the
-    # pairings already found (0 = never freeze, the behavior so far).
-    # Exposed only so it can be swept; the default is unchanged.
-    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
 

--- a/pipelines/lidar3d-dlio-like-only-downsample-voxelavg.yaml
+++ b/pipelines/lidar3d-dlio-like-only-downsample-voxelavg.yaml
@@ -368,10 +368,6 @@ icp_settings_with_vel:
   # See: mp2p_icp::Parameter
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
-    # Stop re-associating after this iteration and keep optimizing the
-    # pairings already found (0 = never freeze, the behavior so far).
-    # Exposed only so it can be swept; the default is unchanged.
-    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
 

--- a/pipelines/lidar3d-dlio-like-only-downsample.yaml
+++ b/pipelines/lidar3d-dlio-like-only-downsample.yaml
@@ -357,10 +357,6 @@ icp_settings_with_vel:
   # See: mp2p_icp::Parameter
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
-    # Stop re-associating after this iteration and keep optimizing the
-    # pairings already found (0 = never freeze, the behavior so far).
-    # Exposed only so it can be swept; the default is unchanged.
-    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
 

--- a/pipelines/lidar3d-dlio-like-revert-downsample.yaml
+++ b/pipelines/lidar3d-dlio-like-revert-downsample.yaml
@@ -240,10 +240,6 @@ icp_settings_with_vel:
   class_name: mp2p_icp::ICP
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
-    # Stop re-associating after this iteration and keep optimizing the
-    # pairings already found (0 = never freeze, the behavior so far).
-    # Exposed only so it can be swept; the default is unchanged.
-    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
     saveIterationDetails: ${MP2P_ICP_LOG_FILES_SAVE_DETAILS|false}

--- a/pipelines/lidar3d-dlio-like-revert-keyframe.yaml
+++ b/pipelines/lidar3d-dlio-like-revert-keyframe.yaml
@@ -236,10 +236,6 @@ icp_settings_with_vel:
   class_name: mp2p_icp::ICP
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
-    # Stop re-associating after this iteration and keep optimizing the
-    # pairings already found (0 = never freeze, the behavior so far).
-    # Exposed only so it can be swept; the default is unchanged.
-    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
     saveIterationDetails: ${MP2P_ICP_LOG_FILES_SAVE_DETAILS|false}

--- a/pipelines/lidar3d-dlio-like-worldframe-decimate.yaml
+++ b/pipelines/lidar3d-dlio-like-worldframe-decimate.yaml
@@ -278,10 +278,6 @@ icp_settings_with_vel:
   class_name: mp2p_icp::ICP
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
-    # Stop re-associating after this iteration and keep optimizing the
-    # pairings already found (0 = never freeze, the behavior so far).
-    # Exposed only so it can be swept; the default is unchanged.
-    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
     saveIterationDetails: ${MP2P_ICP_LOG_FILES_SAVE_DETAILS|false}

--- a/pipelines/lidar3d-dlio-like.yaml
+++ b/pipelines/lidar3d-dlio-like.yaml
@@ -238,10 +238,6 @@ icp_settings_with_vel:
   class_name: mp2p_icp::ICP
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
-    # Stop re-associating after this iteration and keep optimizing the
-    # pairings already found (0 = never freeze, the behavior so far).
-    # Exposed only so it can be swept; the default is unchanged.
-    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
     saveIterationDetails: ${MP2P_ICP_LOG_FILES_SAVE_DETAILS|false}

--- a/pipelines/lidar3d-fastlio-matching.yaml
+++ b/pipelines/lidar3d-fastlio-matching.yaml
@@ -385,10 +385,6 @@ icp_settings_with_vel:
   # See: mp2p_icp::Parameter
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
-    # Stop re-associating after this iteration and keep optimizing the
-    # pairings already found (0 = never freeze, the behavior so far).
-    # Exposed only so it can be swept; the default is unchanged.
-    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
 

--- a/pipelines/lidar3d-gicp-optimize-twist.yaml
+++ b/pipelines/lidar3d-gicp-optimize-twist.yaml
@@ -243,10 +243,6 @@ icp_settings_with_vel:
   # See: mp2p_icp::Parameter
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
-    # Stop re-associating after this iteration and keep optimizing the
-    # pairings already found (0 = never freeze, the behavior so far).
-    # Exposed only so it can be swept; the default is unchanged.
-    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
 

--- a/pipelines/lidar3d-gicp-single-filter.yaml
+++ b/pipelines/lidar3d-gicp-single-filter.yaml
@@ -362,10 +362,6 @@ icp_settings_with_vel:
   # See: mp2p_icp::Parameter
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
-    # Stop re-associating after this iteration and keep optimizing the
-    # pairings already found (0 = never freeze, the behavior so far).
-    # Exposed only so it can be swept; the default is unchanged.
-    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
 

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -390,10 +390,6 @@ icp_settings_with_vel:
   # See: mp2p_icp::Parameter
   params:
     maxIterations: ${MOLA_MAX_ICP_ITERATIONS|25}
-    # Stop re-associating after this iteration and keep optimizing the
-    # pairings already found (0 = never freeze, the behavior so far).
-    # Exposed only so it can be swept; the default is unchanged.
-    freezePairingsAfterIteration: ${MOLA_FREEZE_PAIRINGS_AFTER_ITER|0}
     minAbsStep_trans: 1e-3
     minAbsStep_rot: 1e-4
 


### PR DESCRIPTION
Reverts #143, which I opened on a false premise and which you merged on my description of it. Sorry.

## What is wrong

I claimed `mp2p_icp::Parameters::freezePairingsAfterIteration` "has been loadable from YAML all along". **It is not a parameter of any released `mp2p_icp`.**

```
$ git -C mp2p_icp log --all -S 'freezePairingsAfterIteration'
(no output)
```

It exists only as an **uncommitted working-tree edit** in one developer checkout — `Parameters.h` (+11), `Parameters.cpp` (+2), `ICP.cpp` (+13). I read `Parameters.cpp` and checked that the field was there; I did not check that the line was committed, in a workspace I already knew carried uncommitted changes.

Against every pinned and released build, `freezePairingsAfterIteration:` names a field that does not exist and is silently ignored. #143 therefore added **44 lines of dead configuration across 11 shipped pipelines**.

## Confirmed by measurement

Not just by reading. In the SLAM-eval factorial running now, every cell that sets `MOLA_FREEZE_PAIRINGS_AFTER_ITER=1` produced a trajectory **bit-identical** to the cell that leaves it at 0 — `md5sum` equal, on every sequence. (That comparison is only possible because the same sweep established that this pipeline is bit-deterministic run-to-run.)

## The part that reaches further

`~/plans/lio/03_accuracy_pipeline.md` §3.2 item 5 and ranked action 3g rest on **"APE −45 %, `est/gt` 1.033 on ox1"** for this knob, described there as "one of the largest accuracy effects in the corpus". That was measured against the uncommitted tree, so **it is not reproducible from any pin**, and the `f` axis of the 2×2×2 block cannot test anything. I am correcting those entries.

If the feature is wanted — and a −45 % result would be worth having — it needs to land in `mp2p_icp` first, with the measurement redone against a pinned build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1ymyPshU5eGhA8Xy1UgSv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Removed the pipeline-level option to freeze ICP pairings after a specified iteration.
  * Pairing behavior now consistently uses the underlying default across supported LiDAR pipelines.
  * Removed related documentation and environment-variable overrides from pipeline settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->