### PR TITLE
Keep the default observation-radius path bit-identical

### DIFF
--- a/module/src/LidarOdometry_AdaptiveVariables.cpp
+++ b/module/src/LidarOdometry_AdaptiveVariables.cpp
@@ -187,13 +187,14 @@ namespace
  * number. The quantile path samples with a stride instead of reading every
  * point: it needs the shape of the distribution, not all of it.
  */
-double observationRadius(const mrpt::maps::CPointsMap & pts, double quantile, uint32_t maxSamples)
+/** The quantile path only. The default (`quantile` = 1) is deliberately NOT
+ * routed through here: see the call sites.
+ */
+double observationRadiusQuantile(
+  const mrpt::maps::CPointsMap & pts, double quantile, uint32_t maxSamples)
 {
   const auto bb = pts.boundingBox();
   const double maxNorm = std::max(bb.max.norm(), bb.min.norm());
-  if (quantile >= 1.0) {
-    return maxNorm;
-  }
 
   const auto & xs = pts.getPointsBufferRef_x();
   const auto & ys = pts.getPointsBufferRef_y();
@@ -242,8 +243,18 @@ void LidarOdometry::doInitializeEstimatedObservationRadius(const mrpt::obs::CObs
     return;
   }
 
-  double radius = observationRadius(
-    *pts, params_.observation_radius_quantile, params_.observation_radius_quantile_max_samples);
+  // The default keeps the original expression, in its original place: moving
+  // it into a function changes its inlining context, and a last-ULP
+  // difference in R is enough to flip one point across a range threshold on
+  // a pipeline this sensitive to its input. Measured: routing the default
+  // through the helper changed the trajectory on 2 of 14 sequences.
+  const auto bb = pts->boundingBox();
+
+  double radius = params_.observation_radius_quantile >= 1.0
+                    ? std::max(bb.max.norm(), bb.min.norm())
+                    : observationRadiusQuantile(
+                        *pts, params_.observation_radius_quantile,
+                        params_.observation_radius_quantile_max_samples);
 
   // check for NaN, Infinities, etc.: See: https://github.com/MOLAorg/mola_lidar_odometry/issues/10
   if (!std::isnormal(radius)) {
@@ -279,8 +290,16 @@ void LidarOdometry::doUpdateEstimatedObservationRadius(const mp2p_icp::metric_ma
       continue;  // skip NaN, INF, etc.
     }
 
-    double radius = observationRadius(
-      *pts, params_.observation_radius_quantile, params_.observation_radius_quantile_max_samples);
+    // The default keeps the original expression, in its original place: moving
+    // it into a function changes its inlining context, and a last-ULP
+    // difference in R is enough to flip one point across a range threshold on
+    // a pipeline this sensitive to its input. Measured: routing the default
+    // through the helper changed the trajectory on 2 of 14 sequences.
+    double radius = params_.observation_radius_quantile >= 1.0
+                      ? std::max(bb.max.norm(), bb.min.norm())
+                      : observationRadiusQuantile(
+                          *pts, params_.observation_radius_quantile,
+                          params_.observation_radius_quantile_max_samples);
 
     mrpt::keep_max(radius, params_.absolute_minimum_observation_radius);
 


### PR DESCRIPTION
Follow-up to #144, which I asked you to merge on a claim that turns out to be false.

## The claim, and the measurement

#144 says *"default 1.0 = today's max-norm, so nothing ships differently"*. Measured against its **own parent commit**, every other pin held equal (both carry `min_motion` 0.5 and the freeze key; verified by diffing the pipeline YAML at each pin, not by reading the commit graph):

**bit-identical on 12 of 14 sequences — and different on 2.**

| sequence | parent | #144 at quantile 1.0 |
|---|---|---|
| `botanic-1005_01` | 0.807767 | 0.775884 (−3.9 %) |
| `botanic-1018_00` | 0.067153 | 0.068746 (+2.4 %) |
| `botanic-1018_13` | 0.080484 | 0.080484 (identical) |

BotanicGarden was checked for run-to-run determinism first — two runs, same build, same config, **same md5** — so this is not dataset noise.

## Why, and the fix

Not a logic error: the `quantile >= 1.0` branch returned the same `max(|bb.min|,|bb.max|)` expression. But moving that expression out of its caller into a function changes its inlining context, and the resulting last-ULP difference in `R` is enough to flip one point across a `range_min`/`range_max` threshold.

This pipeline is measurably that sensitive: two arms differing by **32–300 points per scan (0.05 % of the input)** disagree by up to **14 % of APE**, while repeats of one configuration are byte-identical. Deterministic in execution, chaotic in the input.

So the default keeps the original expression in its original place, and only the quantile path goes through the helper.

## Unaffected

The result that motivated #144 stands — it was measured at quantile 0.98, which is not this path. On TIERS: a **divergence** (`indoor02`, est/gt 2.08 → 1.08) and a **truncation** (`forest01`, 74.6 % → 100 % coverage) both fixed, better on 9 of 14 overall, KITTI clean.

## The generalizable part

On a pipeline with a zero run-to-run band and this much input sensitivity, **"same value" is not "same result"**, and a default-preserving claim has to be checked with `cmp` against a pin that differs by nothing else. Three of my earlier attempts at that check were contaminated by comparing across pins that differed by more than the commit under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1ymyPshU5eGhA8Xy1UgSv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adaptive observation-radius calculations for non-default quantile settings.
  * Preserved the default radius behavior to ensure consistent lidar odometry results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->