### PR TITLE
Offline CLI: deterministic estimator by default, run totals, range-adaptive matcher knobs

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -621,11 +621,30 @@ Trajectory-to-trajectory comparisons are only meaningful under all of:
   scheduling changes the result. Pinning makes runs bit-identical; check with
   `md5sum` on the output `.tum` before comparing anything.
 - **`MOLA_ASYNC_BACKEND=false`** when using the smoother state estimator (its
-  async serving path is non-deterministic).
+  async serving path is non-deterministic). `mola-lidar-odometry-cli` now
+  defaults it to false itself (it is a batch tool with no real-time deadline,
+  and with no clock pacing the front end outruns the backend by construction),
+  so this only needs stating for other offline entry points. Measured
+  accuracy-neutral over 49 sequences before being adopted, so it buys
+  reproducibility rather than accuracy.
 
 The smoother also needs `-l <libmola_state_estimation_smoother.so>`; the CLI
 does not load that plugin by default and the class factory otherwise fails with
 "unknown class name".
+
+**Run totals at shutdown.** Every run now logs one INFO line before saving:
+
+```
+Run totals: registrations=N no_motion_model=K (x.xx%) icp_rejected=M (y.yy%)
+```
+
+`no_motion_model` counts the scans registered from a **zero-motion initial
+guess**, because the state estimator returned nothing (or a prediction too
+uncertain to pass `min_motion_model_xyz_cov_inv`). The front end has always
+logged a warning for that, but throttled, so it could not be counted: an
+estimator silently failing on 1 scan in 20 looked exactly like one that never
+failed. Read it next to `scan_drop_pct`; a nonzero value means part of the
+trajectory was registered without a motion prior, whatever the APE says.
 
 Always characterize the run-to-run noise floor (the same config twice) before
 believing a difference between two configs, and confirm the estimate covers the
@@ -653,6 +672,9 @@ pipeline YAML, not read directly in C++.)
 
 | Variable | Type | Default | Location | Purpose |
 |----------|------|---------|----------|---------|
+| `MOLA_MATCH_THRESHOLD_FAR` | double | 0 (off) | `pipelines/lidar3d-gicp.yaml` | Range-adaptive matching distance: matching distance beyond `..._KNEE`. 0 keeps the flat `threshold`, bit-identical to before. Interacts with `adaptive_threshold.initial_sigma`/`min_motion` and is a no-op at sigma 0.5 -- do not sweep it alone |
+| `MOLA_MATCH_THRESHOLD_KNEE` | double | 15.0 | `pipelines/lidar3d-gicp.yaml` | Range [m] where the near/far transition is centred |
+| `MOLA_MATCH_THRESHOLD_WIDTH` | double | 5.0 | `pipelines/lidar3d-gicp.yaml` | Width [m] of the near/far logistic transition |
 | `MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP` | double | 0 | `module/src/LidarOdometry_ProcessScan.cpp` | Start of a timestamp range for forcing ICP debug-log dumps (paired with `..._TO_TIMESTAMP`) |
 | `MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP` | double | 0 | `module/src/LidarOdometry_ProcessScan.cpp` | End of the timestamp range above |
 | `MOLA_LO_DEBUG_ICP_QUALITY` | bool | false | `module/src/LidarOdometry_ProcessScan.cpp` | Trace ICP quality metrics per scan |

--- a/apps/mola-lidar-odometry-cli.cpp
+++ b/apps/mola-lidar-odometry-cli.cpp
@@ -701,6 +701,21 @@ int main_odometry(Cli & cli)
                  "raw sensor data.\n";
   }
 
+  // This is an OFFLINE batch tool: it consumes the dataset as fast as the
+  // pipeline allows, and reproducibility is the whole point of running it.
+  // The smoother's shipped YAML defaults `async_backend` to true, which is the
+  // right setting for a real-time deployment (queries are served from a
+  // lock-free predictor re-anchored on the backend's last completed solve) and
+  // the wrong one here twice over: that serving path is non-deterministic, and
+  // with no clock pacing the front end outruns the backend by construction, so
+  // how stale the anchor is becomes a function of host load rather than of the
+  // data.
+  //
+  // Default it off for this binary, without overwriting an explicit setting
+  // (third argument 0), so anyone who really wants the real-time path can still
+  // ask for it. Datasets whose YAML does not read this variable are unaffected.
+  setenv("MOLA_ASYNC_BACKEND", "false", 0 /* do not overwrite */);
+
   // Make mandatory to specify state estimation config file, so defaults and initialize() are not skipped
   {
     const auto seParamsFile = cli.arg_stateEstimatorParams.getValue();

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -1265,6 +1265,18 @@ private:
     // recovery in AdaptiveThreshold.
     int consecutive_bad_icps = 0;
 
+    /// Run totals, reported once at shutdown. `registration_no_motion_model` is
+    /// the one that had no aggregate before: the front end already logs a
+    /// throttled warning when the state estimator returns nothing (or returns a
+    /// prediction too uncertain to use) and falls back to a zero-motion initial
+    /// guess, but a throttled line cannot be counted, so an estimator that was
+    /// silently failing on 1 scan in 20 looked identical to one that never
+    /// failed. Both counters exclude the very first scan, which has no motion
+    /// model by definition.
+    size_t registrations_attempted = 0;
+    size_t registration_no_motion_model = 0;
+    size_t registration_icp_rejected = 0;
+
     // Automatic estimation of the observation bounding-radius (measured from
     // base_link, not from the sensor — see ESTIMATED_OBSERVATION_RADIUS docs):
     std::optional<double> estimated_observation_radius;

--- a/module/src/LidarOdometry_Main.cpp
+++ b/module/src/LidarOdometry_Main.cpp
@@ -121,6 +121,22 @@ void LidarOdometry::shutdownCleanup()
     worker_viz_.clear();
     worker_viz_local_map_.clear();
 
+    // Run totals, once, in a form a harness can scrape. `no_motion_model` is
+    // the number the corpus had no aggregate for: it is the difference between
+    // "the state estimator is helping" and "the front end has been registering
+    // scans from a zero-motion guess", and until now it surfaced only as a
+    // throttled warning line that nothing counted.
+    if (state_.registrations_attempted > 0) {
+      const double pctNoModel =
+        100.0 * state_.registration_no_motion_model / state_.registrations_attempted;
+      const double pctRejected =
+        100.0 * state_.registration_icp_rejected / state_.registrations_attempted;
+      MRPT_LOG_INFO_FMT(
+        "Run totals: registrations=%zu no_motion_model=%zu (%.2f%%) icp_rejected=%zu (%.2f%%)",
+        state_.registrations_attempted, state_.registration_no_motion_model, pctNoModel,
+        state_.registration_icp_rejected, pctRejected);
+    }
+
     if (params_.simplemap.generate) {
       saveReconstructedMapToFile();
     }

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -983,6 +983,13 @@ void LidarOdometry::processLidarScan(  // NOLINT
     // correspondence threshold:
     in.align_kind = hasMotionModel ? AlignKind::RegularOdometry : AlignKind::NoMotionModel;
 
+    // Run totals (reported at shutdown). Counted here rather than where the
+    // warning is emitted, because that one is throttled.
+    state_.registrations_attempted++;
+    if (!hasMotionModel) {
+      state_.registration_no_motion_model++;
+    }
+
     in.icp_params = params_.icp[in.align_kind].icp_parameters;
     in.last_keyframe_pose = state_.last_lidar_pose.mean;
 
@@ -1197,6 +1204,9 @@ void LidarOdometry::processLidarScan(  // NOLINT
     const bool icpIsGood = (out.goodness >= params_.min_icp_goodness);
 
     state_.last_icp_was_good = icpIsGood;
+    if (!icpIsGood) {
+      state_.registration_icp_rejected++;
+    }
     state_.last_icp_quality = out.goodness;
     state_.last_icp_iterations = out.icp_iterations;
 

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -435,6 +435,25 @@ icp_settings_with_vel:
     - class: mp2p_icp::Matcher_Cov2Cov
       params:
         threshold: "2.0*ADAPTIVE_THRESHOLD_SIGMA"
+        # Optional range-adaptive matching distance. thresholdFar: 0 (the
+        # default) keeps the flat threshold above, i.e. today's behaviour
+        # exactly. When set, the matching distance ramps from `threshold` near
+        # the sensor to `thresholdFar` beyond `thresholdKneeRange`.
+        #
+        # Why the axis exists: a pose-prediction error `dtheta` displaces a
+        # point at range `r` by `dtheta*r`, so a flat threshold rejects far
+        # returns first, precisely when the prediction is worst. Measured: at a
+        # flat 0.34 m, 1 deg of yaw error takes beyond-25 m acceptance from 82%
+        # to 4.6% while r<10 m stays at 99%; a 1.0 m far window keeps 94%. Those
+        # far returns carry most of the rotation and along-track leverage.
+        #
+        # Note this is a no-op while ADAPTIVE_THRESHOLD_SIGMA sits at its
+        # initial 0.5, where the near value already equals a 1.0 m far value:
+        # it interacts with adaptive_threshold.initial_sigma and .min_motion and
+        # cannot be swept independently of them.
+        thresholdFar: "${MOLA_MATCH_THRESHOLD_FAR|0}"
+        thresholdKneeRange: "${MOLA_MATCH_THRESHOLD_KNEE|15.0}"
+        thresholdTransitionWidth: "${MOLA_MATCH_THRESHOLD_WIDTH|5.0}"
         pairingsPerPoint: 1
         allowMatchAlreadyMatchedGlobalPoints: true # faster
         # Both layers here must be of the very same cov-capable map class, the


### PR DESCRIPTION
Three small changes, all found while attributing why the **smoother** state
estimator diverged on whole dataset families where the lightweight one did not
(write-up: `~/plans/lio/detail/216_smoother_state_estimator_parity.md`).

### 1. `mola-lidar-odometry-cli` defaults `MOLA_ASYNC_BACKEND` to false

The smoother's shipped YAML defaults `async_backend: true`. That is the right
setting for a real-time deployment — `estimated_navstate()` is served from a
lock-free predictor re-anchored on the backend's last completed solve — and the
wrong one for a batch tool twice over:

- the serving path is documented non-deterministic;
- with no clock pacing the front end outruns the backend **by construction**, so
  how stale the anchor is becomes a function of host load rather than of the
  data. When it goes staler than `max_time_to_use_velocity_model`, `predict()`
  returns nothing and the front end registers the scan from a zero-motion guess.

`setenv(..., 0)`, so an explicit setting still wins (verified: an explicit
`MOLA_ASYNC_BACKEND=true` produces a different trajectory from the new default).

**Measured before being adopted**, not assumed: 49 sequences, median 1.00x,
better on 20. It buys reproducibility, not accuracy — worth stating plainly,
since I expected otherwise.

### 2. Run totals at shutdown

```
Run totals: registrations=270 no_motion_model=6 (2.22%) icp_rejected=0 (0.00%)
```

`no_motion_model` counts scans registered from a **zero-motion initial guess**,
because the state estimator returned nothing or a prediction too uncertain to
pass `min_motion_model_xyz_cov_inv`. The front end has always logged that, but
throttled — so it could not be counted, and an estimator silently failing on 1
scan in 20 looked identical to one that never failed. It is the number the whole
attribution turned on, and it had no aggregate anywhere.

### 3. `Matcher_Cov2Cov`'s range-adaptive matching distance, reachable at last

`thresholdFar` / `thresholdKneeRange` / `thresholdTransitionWidth` exist in
`mp2p_icp` but appear nowhere in `lidar3d-gicp.yaml`, so the axis could not be
evaluated. Now `MOLA_MATCH_THRESHOLD_{FAR,KNEE,WIDTH}`, with `FAR: 0` keeping
the flat threshold — today's behaviour exactly.

Motivation, measured: a pose-prediction error `dtheta` displaces a point at
range `r` by `dtheta*r`, so a flat threshold rejects far returns first, exactly
when the prediction is worst. At a flat 0.34 m, 1 deg of yaw takes beyond-25 m
acceptance from 82% to **4.6%** while `r < 10 m` stays at 99%; a 1.0 m far window
keeps 94%. Those far returns carry most of the rotation and along-track leverage.

The comment in the YAML records the trap that made the previous attempt at this
axis ambiguous: it is a **no-op** while `ADAPTIVE_THRESHOLD_SIGMA` sits at its
initial 0.5, so it cannot be swept independently of
`adaptive_threshold.initial_sigma`/`min_motion`.

`agents.md` updated for all three.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional range-adaptive ICP matching thresholds for improved handling of distant points while preserving existing defaults.
  * Added shutdown summaries showing registration attempts, missing motion models, and ICP rejections.

* **Bug Fixes**
  * Offline CLI runs now default to a synchronous backend for deterministic results, while preserving explicit configuration overrides.

* **Documentation**
  * Documented the offline backend default, shutdown metrics, and new matching-threshold settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->