### PR TITLE
GrandTour: optional legged odometry input

### DIFF
--- a/scripts/lib/profiles/grandtour.sh
+++ b/scripts/lib/profiles/grandtour.sh
@@ -11,6 +11,7 @@
 #   <mission>_tf_minimal.bag    /tf, /tf_static                          (optional)
 #   <mission>_adis.bag          /boxi/adis/imu                   200 Hz  (optional)
 #   <mission>_hdr_front.bag     /boxi/hdr/front/image_raw/...    ~11 Hz  (optional, GUI only)
+#   <mission>_anymal_state.bag  /anymal/state_estimator/odometry         (opt-in, see below)
 #
 # Sensor extrinsics come from the dataset's own /tf_static (base -> box_base ->
 # hesai_lidar / adis16475_imu / hdr_base -> hdr_front), so no fixed sensor
@@ -27,6 +28,11 @@ mola_lo_profile_usage() {
   echo "Error: A GrandTour mission directory (or its '*_hesai_undist.bag') is required."
   echo "Usage: $0 /path/to/<mission-dir>/ [additional flags]"
   echo "       $0 /path/to/<mission>_hesai_undist.bag [additional flags]"
+  echo ""
+  echo "Optional environment variables:"
+  echo "  MOLA_ODOMETRY_TOPIC    set to '/anymal/state_estimator/odometry' to fuse the"
+  echo "                         robot's legged kinematic-inertial odometry (this adds"
+  echo "                         <mission>_anymal_state.bag to the inputs)"
   echo ""
   echo "Example:"
   echo "  $0 ~/datasets/grand-tour/2024-10-01-11-29-55/"
@@ -62,6 +68,7 @@ mola_lo_profile_resolve() {
   local tf_bag=${prefix}_tf_minimal.bag
   local imu_bag=${prefix}_adis.bag
   local camera_bag=${prefix}_hdr_front.bag
+  local odom_bag=${prefix}_anymal_state.bag
 
   echo "GrandTour mission '$(basename "$prefix")':"
   echo "  LiDAR bag: $lidar_bag"
@@ -95,6 +102,27 @@ mola_lo_profile_resolve() {
     : "${MOLA_IMU_TOPIC:=}"
   fi
   export MOLA_IMU_TOPIC
+
+  # Legged kinematic-inertial odometry, opt-in via MOLA_ODOMETRY_TOPIC -- the
+  # same convention as every other profile: a dataset is not opted into odometry
+  # fusion merely because a bag on disk happens to carry a pose topic.
+  #
+  # `/anymal/state_estimator/odometry` is a nav_msgs/Odometry reported as
+  # odom -> base, i.e. for the very frame this profile already uses as
+  # MOLA_TF_BASE_LINK. That is what makes it safe to fuse:
+  # mrpt::obs::CObservationOdometry cannot carry a sensor pose at all, so a
+  # source reported for anything else injects motion in the wrong frame --
+  # which is precisely why CitrusFarm's wheel odometry is deliberately never
+  # enabled anywhere. Checked by reading the messages' child_frame_id, not
+  # assumed from the topic name.
+  if [ -n "${MOLA_ODOMETRY_TOPIC:-}" ]; then
+    if [ -f "$odom_bag" ]; then
+      echo "  Odometry bag: $odom_bag"
+      bags+=("$odom_bag")
+    else
+      echo "  Odometry bag: (not found: '$odom_bag'; MOLA_ODOMETRY_TOPIC matches nothing)"
+    fi
+  fi
 
   # The camera is a GUI preview only: nothing in the odometry consumes it, so
   # a batch run would pay for decoding several GB of JPEG for nothing.


### PR DESCRIPTION
Each GrandTour mission ships `<mission>_anymal_state.bag` carrying
`/anymal/state_estimator/odometry` — a `nav_msgs/Odometry` from the robot's
kinematic-inertial state estimator, i.e. the **legged analogue of wheel
odometry**, and a message type `mola_input_rosbag1` already maps to
`CObservationOdometry`.

Opt-in via `MOLA_ODOMETRY_TOPIC`, matching every other profile: a dataset is not
opted into odometry fusion merely because a bag on disk carries a pose topic.

**The frame was checked, not assumed**, because this is exactly where CitrusFarm's
wheel odometry falls down: `mrpt::obs::CObservationOdometry` cannot carry a sensor
pose at all, so a source reported for anything other than `base_link` injects
motion in the wrong frame. Reading the messages directly:

```
frame_id='odom'  child_frame_id='base'
```

and `base` is already what this profile sets as `MOLA_TF_BASE_LINK`. So it is safe
to fuse, for the same reason BotanicGarden's is and CitrusFarm's is not.

## Why it is worth having

BotanicGarden is currently the **only** dataset in our evaluation corpus that
feeds any odometry to the state estimator, so every conclusion about odometry
fusion rests on one platform — a skid-steer chassis in dense vegetation, where
(measured, everything else held fixed) fusing the odometry is *worse than
ignoring it* on 6 of 7 sequences. That may well be a property of that data, but
with n=1 platform there is no way to tell.

A legged platform across five already-scored missions is a genuinely different
second opinion, and it is the thing that would let the recent odometry work in
`mola_state_estimation` (#61, #62) be judged on more than one robot.

No behaviour change unless `MOLA_ODOMETRY_TOPIC` is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GrandTour profiles can now optionally include an ANYmal state odometry recording.
  * Added configuration support for selecting the odometry topic.
  * Clear feedback is provided when the configured odometry recording is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->