### PR TITLE
KITTI eval: record that MOLA_INITIAL_VX is coupled to the pipeline, not the dataset

### DIFF
--- a/eval/cli_kitti.sh
+++ b/eval/cli_kitti.sh
@@ -42,6 +42,30 @@ fi
 # on the rest of the corpus. A sweep that reports one aggregate number over
 # all sequences is therefore reporting a compromise; keep that in mind before
 # reading a small delta here as a pipeline improvement.
+#
+# CAVEAT ADDED 2026-08-21, and it is about the pipeline this script runs.
+# "A large prior is needed on seq 12" was established on `lidar3d-icp.yaml`.
+# This script exports MOLA_ODOMETRY_PIPELINE_YAML itself, defaulting to
+# `lidar3d-default.yaml` (GICP) -- overriding the ICP default that
+# scripts/lib/profiles/kitti.sh would otherwise apply -- and on GICP that claim
+# does not hold. Measured on the sparse 2D reference for seqs 11-15, ratio of
+# estimated to reference path length and RMSE after planar alignment:
+#
+#            seq 12 unseeded          VX=18 vs unseeded, seqs 11-15
+#   ICP      0.268 / 403 m            (the seed is what rescues it)
+#   GICP     0.995 / 4.82 m           worse on 4 of 5; its only gain is seq 12
+#                                     itself, 4.16 vs 4.82, inside the ~3 m
+#                                     noise floor of that reference
+#
+# So the seed is coupled to the PIPELINE, not to the dataset, and this script
+# currently pairs it with the pipeline that does not need it. The value is left
+# at 18.0 deliberately: the published numbers from this sweep were produced with
+# it, and changing it silently would break comparability with its own history --
+# which is the same reason the line above exists. Anyone re-baselining should
+# drop it, or switch this script to the ICP pipeline, rather than keep both.
+#
+# Full measurements: ~/plans/lio/detail/216_smoother_state_estimator_parity.md
+# section 11.
 parallel -j${NUM_THREADS} --lb --halt now,fail=1 \
   SEQ={} \
   MOLA_INITIAL_VX=18.0 \


### PR DESCRIPTION
Comment-only. It corrects a justification that is true of one pipeline and
stated as if it were true of the dataset.

`eval/cli_kitti.sh`'s existing note says the seed is kept because *"a large
prior is needed on seq 12, which starts already at speed"*. That was established
on **`lidar3d-icp.yaml`**. But this script exports
`MOLA_ODOMETRY_PIPELINE_YAML` itself, defaulting to **`lidar3d-default.yaml`**
(GICP) — thereby overriding the ICP default `scripts/lib/profiles/kitti.sh`
would otherwise apply — and on GICP the claim does not hold.

Measured on the sparse 2D reference for seqs 11–15 (ratio of estimated to
reference path length / RMSE after planar alignment, ~3 m noise floor):

| | seq 12 unseeded | VX=18 across 11–15 |
|---|---|---|
| `lidar3d-icp.yaml` | **0.268 / 403 m** | the seed is what rescues it |
| `lidar3d-gicp.yaml` | **0.995 / 4.82 m** | **worse on 4 of 5**; its only gain is seq 12 itself (4.16 vs 4.82), inside the noise floor |

So `MOLA_INITIAL_VX` is coupled to the **pipeline**, not to the dataset, and this
script currently pairs it with the pipeline that does not need it — paying the
startup artifact for nothing. Seq 14 shows the cost plainly: `est/ref` 1.028
against the unseeded 1.007, on a 341 m sequence short enough that a startup
offset does not dilute.

**The value is deliberately left at 18.0.** The published numbers from this
sweep were produced with it, and changing it silently would break comparability
with its own history — which is precisely the reason the existing comment gives
for pinning it. Acting on this belongs to a re-baselining, where the choice is
to drop the seed *or* switch the script to the ICP pipeline, not to keep both.

Also worth flagging for whoever does that: `lidar3d-icp.yaml` is not a stray
alternative — per `03_accuracy_pipeline.md` §0.1 it is the best KITTI
configuration on record (0.582 vs GICP's 0.639) and what was submitted to the
KITTI test server. The two pipelines are two local optima, so "which pipeline"
and "seed or not" have to be decided together.

Full measurements: `~/plans/lio/detail/216_smoother_state_estimator_parity.md` §11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance clarifying when the `MOLA_INITIAL_VX=18.0` setting is relevant.
  * Documented performance comparisons across sequences 11–15 and differences between ICP and GICP pipelines.
  * Preserved the existing setting for historical comparability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->