### PR TITLE
Optional, env-gated log of the local-map insert/skip decision

### DIFF
--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -73,8 +73,16 @@ std::ostream * mapGateStream()
     *f << "# scan\ttimestamp\tw_norm\tobs_radius\tthr_trans_m\tthr_rot_deg"
           "\tdist_trans_m\tdist_rot_deg\tdecider_create\ticp_good\thas_motion_model"
           "\tmapping_enabled\tfrozen_post_reloc\tupdate_local_map\n";
+    if (!f->good()) {
+      return {};
+    }
     return f;
   }();
+  // A write that failed silently would leave a truncated log looking like a
+  // complete one, so stop handing out a stream that has already gone bad.
+  if (s_file && !s_file->good()) {
+    s_file.reset();
+  }
   return s_file ? s_file.get() : nullptr;
 }
 

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -37,10 +37,49 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <memory>
 #include <mutex>
+#include <ostream>
 
 namespace mola
 {
+namespace
+{
+/** Optional diagnostic: append the local-map insert/skip decision to a TSV
+ *  file, one row per scan that reaches the gate.
+ *
+ *  Enabled only if the environment variable MOLA_LO_MAP_GATE_LOG is set to a
+ *  writable path, so it costs one cached lookup when unused. The two keyframe
+ *  thresholds are dynamic expressions of the angular rate, so which of the two
+ *  branches can fire at all depends on the motion and is not observable from
+ *  the trajectory.
+ *
+ *  Not thread-safe by design: it is for single-threaded diagnostic runs.
+ */
+std::ostream * mapGateStream()
+{
+  static std::unique_ptr<std::ofstream> s_file = []() -> std::unique_ptr<std::ofstream> {
+    const char * path = ::getenv("MOLA_LO_MAP_GATE_LOG");
+    if (!path || !path[0]) {
+      return {};
+    }
+    auto f = std::make_unique<std::ofstream>(path, std::ios::out | std::ios::app);
+    if (!f->is_open()) {
+      return {};
+    }
+    *f << "# scan\ttimestamp\tw_norm\tobs_radius\tthr_trans_m\tthr_rot_deg"
+          "\tdist_trans_m\tdist_rot_deg\tdecider_create\ticp_good\thas_motion_model"
+          "\tmapping_enabled\tfrozen_post_reloc\tupdate_local_map\n";
+    return f;
+  }();
+  return s_file ? s_file.get() : nullptr;
+}
+
+uint64_t mapGateScanCounter = 0;
+}  // namespace
 
 bool LidarOdometry::isPipelineUsingIMU() const
 {
@@ -1388,6 +1427,31 @@ void LidarOdometry::processLidarScan(  // NOLINT
        !mapFrozenPostReloc
        );
     // clang-format on
+
+    if (auto * gs = mapGateStream(); gs) {
+      double wNorm = 0;
+      double obsRadius = 0;
+      {
+        auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+        const auto vars = state_.parameter_source.getVariableValues();
+        const auto readVar = [&vars](const char * name) {
+          const auto it = vars.find(name);
+          return it != vars.end() ? it->second : 0.0;
+        };
+        const double wx = readVar("wx");
+        const double wy = readVar("wy");
+        const double wz = readVar("wz");
+        wNorm = std::sqrt(wx * wx + wy * wy + wz * wz);
+        obsRadius = readVar("ESTIMATED_OBSERVATION_RADIUS");
+      }
+      *gs << mapGateScanCounter++ << '\t' << obsTimestamp << '\t' << wNorm << '\t' << obsRadius
+          << '\t' << params_.local_map_updates.min_translation_between_keyframes << '\t'
+          << params_.local_map_updates.min_rotation_between_keyframes << '\t'
+          << euclidean_dist_since_last << '\t' << mrpt::RAD2DEG(rot_since_last) << '\t'
+          << (distFarEnoughLocal ? 1 : 0) << '\t' << (icpIsGood ? 1 : 0) << '\t'
+          << (hasMotionModel ? 1 : 0) << '\t' << (params_.local_map_updates.enabled ? 1 : 0) << '\t'
+          << (mapFrozenPostReloc ? 1 : 0) << '\t' << (updateLocalMap ? 1 : 0) << '\n';
+    }
 
     if (updateLocalMap) {
       state_.kf_decider_local_map->insert(lidarPoseInWorld, obsTimestamp);


### PR DESCRIPTION
A write-only diagnostic on the local-map update gate, enabled by
`MOLA_LO_MAP_GATE_LOG=<path>`. **Off by default**, one cached `getenv` lookup
when unused, and no numerical path changes: verified by running one Oxford
Spires sequence with it disabled and getting a **byte-identical** trajectory
against the stored reference run of the same pinned commits.

One TSV row per scan reaching the gate:

    scan  timestamp  w_norm  obs_radius  thr_trans_m  thr_rot_deg
    dist_trans_m  dist_rot_deg  decider_create  icp_good
    has_motion_model  mapping_enabled  frozen_post_reloc  update_local_map

Why it is worth having. `min_translation_between_keyframes` and
`min_rotation_between_keyframes` are dynamic expressions of the angular rate
and of `ESTIMATED_OBSERVATION_RADIUS`, so *which branch of the decider can
fire at all* depends on the motion and on the scene scale. Neither the
thresholds, nor the distances they are compared against, nor which of the
five gate conditions blocked an insertion, were observable from the
trajectory or from any existing log line.

Measured on `oxford-spires-keble-college-02`, the shipped Oxford profile:
`|w|` runs at a median 0.245 rad/s, which puts the translation threshold at a
median 1.9 m and a p90 of 3.9 m against roughly 0.12 m of walk per scan, so
insertion falls to the rotation branch for most of the route.

`|w|` and the observation radius are read back from the parameter source
under `imu_state_mtx_` (recursive, and last in the documented lock order), so
the logged values are exactly the ones the thresholds were evaluated from.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional diagnostic logging for local-map keyframe decisions.
  - Records scan motion, observation radius, thresholds, distances, and decision results in a TSV file.
  - Includes a header and process-wide scan counter for easier analysis.

- **Configuration**
  - Enable logging by setting `MOLA_LO_MAP_GATE_LOG` to a writable file path.
  - Logging remains disabled when the setting is absent, or automatically stops if the file cannot be opened or written.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->