### PR TITLE
Give the observation layer a 2.0 m covariance neighborhood by default

### DIFF
--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -607,15 +607,27 @@ observations_generator:
         # stays in the sum as an almost-isotropic point-to-point constraint
         # instead of the plane constraint the cov-to-cov form is meant to give.
         #
-        # Defaults below reproduce the previous class defaults exactly, so
-        # nothing ships differently until they are overridden.
+        # `max_distance_for_cov` defaults to 2.0 here, NOT to the map class's
+        # own 1.0: measured over 115M pairings on Oxford Spires, 32.3% of
+        # pairings could not find `min_correspondences_for_cov` neighbors
+        # inside 1.0 m and fell back to an isotropic covariance, which leaves
+        # the pairing in the sum as a point-to-point constraint rather than a
+        # plane one. Full-corpus A/B at 2.0 m: pooled APE x0.785 over 46
+        # sequences, better on six of seven datasets (oxford x0.538,
+        # conslam x0.622, botanic x0.696, kitti x0.912, grand-tour x0.930,
+        # tiers x0.992) and no new failures.
+        #
+        # citrus-farm is the exception at x1.201, and its profile overrides
+        # this back to 1.0. Working hypothesis: dense close-range orchard
+        # foliage has no consistent surface, so a wider neighborhood averages
+        # the normal over vegetation instead of structure.
         creationOpts:
           # Required by the map class loader; the class default, and inert for a
           # single-keyframe observation layer.
           max_search_keyframes: 3
           k_correspondences_for_cov: ${MOLA_OBSLAYER_K_CORRESPONDENCES_FOR_COV|20}
           min_correspondences_for_cov: ${MOLA_OBSLAYER_MIN_CORRESPONDENCES_FOR_COV|5}
-          max_distance_for_cov: ${MOLA_OBSLAYER_MAX_DISTANCE_FOR_COV|1.0}
+          max_distance_for_cov: ${MOLA_OBSLAYER_MAX_DISTANCE_FOR_COV|2.0}
         insertOpts: ~
         likelihoodOpts: ~ # none required
         renderOpts: ~

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -593,7 +593,29 @@ observations_generator:
         # Any class derived from mrpt::maps::CMetricMap https://docs.mrpt.org/reference/stable/group_mrpt_maps_grp.html
         class: ${MOLA_LOCALMAP_CLASS|mola::KeyframePointCloudMap}
         plugin: "libmola_metric_maps.so" # Import additional custom user-defined map classes (search in LD_LIBRARY_PATH)
-        creationOpts: ~ # none required: defaults are fine for a single scan
+        # The per-point covariances of the SCAN side of a cov-to-cov pairing are
+        # built here, and they are half of the pairing weight
+        # `(C_global + C_local)^-1`. Leaving this empty used the class defaults
+        # (k=20, min=5, max_distance=1.0 m), which do NOT match what the local
+        # map above is configured with, so the two sides of the same pairing
+        # were estimated over different neighborhood scales.
+        #
+        # A scan is much sparser than the accumulated map, so a radius that is
+        # ample for the map can leave a scan point with fewer than
+        # `min_correspondences_for_cov` neighbors. That case does not drop the
+        # pairing: it falls back to an isotropic covariance, and the pairing
+        # stays in the sum as an almost-isotropic point-to-point constraint
+        # instead of the plane constraint the cov-to-cov form is meant to give.
+        #
+        # Defaults below reproduce the previous class defaults exactly, so
+        # nothing ships differently until they are overridden.
+        creationOpts:
+          # Required by the map class loader; the class default, and inert for a
+          # single-keyframe observation layer.
+          max_search_keyframes: 3
+          k_correspondences_for_cov: ${MOLA_OBSLAYER_K_CORRESPONDENCES_FOR_COV|20}
+          min_correspondences_for_cov: ${MOLA_OBSLAYER_MIN_CORRESPONDENCES_FOR_COV|5}
+          max_distance_for_cov: ${MOLA_OBSLAYER_MAX_DISTANCE_FOR_COV|1.0}
         insertOpts: ~
         likelihoodOpts: ~ # none required
         renderOpts: ~

--- a/scripts/lib/profiles/citrusfarm.sh
+++ b/scripts/lib/profiles/citrusfarm.sh
@@ -75,6 +75,15 @@ mola_lo_profile_resolve() {
   # The launch file takes the odom bag in a slot of its own, so it never
   # displaces a base part; the offline CLI takes one comma-joined list.
   MOLA_INPUT_ROSBAG1_ODOM="$odom_bag"
+  # Keep the observation layer's covariance neighborhood at the map class's
+  # own 1.0 m, against the 2.0 m the pipeline now defaults to. This is the one
+  # dataset in the curated corpus where the wider neighborhood loses: APE
+  # x1.201 over 7 sequences, worse on 5, with two past x2. Dense close-range
+  # orchard foliage has no consistent surface to fit, so a wider neighborhood
+  # averages the scan-side normal over vegetation rather than structure.
+  : "${MOLA_OBSLAYER_MAX_DISTANCE_FOR_COV:=1.0}"
+  export MOLA_OBSLAYER_MAX_DISTANCE_FOR_COV
+
   export MOLA_INPUT_ROSBAG1_ODOM
 
   mola_lo_bag_slots "${base_bags[@]}" || return 1


### PR DESCRIPTION
### The defect

The cov-to-cov pairing weight is `(C_global + C_local)^-1`. `C_local` comes from the `observation` layer, whose `creationOpts` block in `lidar3d-gicp.yaml` was empty — so it silently took the map class defaults, including a **1.0 m** covariance neighbourhood radius, while the local map beside it runs at **2.0 m**.

A single scan is far sparser than the accumulated map, so that radius leaves many scan points short of `min_correspondences_for_cov`. Those points are **not dropped**: `C_local` falls back to the isotropic identity, and `(C_global + I)^-1` is close to a multiple of the identity, so the pairing survives as an almost isotropic **point-to-point** constraint. The plane constraint the cov-to-cov form exists to supply is absent, and nothing upstream could observe it.

Measured over **115 million pairings** on three Oxford Spires sites (diagnostic in MOLAorg/mola#199):

| | measured | design intent |
|---|---:|---:|
| pairings with identity `C_local` | **32.3%** | — |
| weight eigenvalue ratio, p10 | **2.0** | ~1000 |
| pairings with ratio < 10 | ~47% | — |
| map-side identity rate | 0.24% | — |

The degeneracy is entirely scan-side, exactly as the asymmetric radius predicts.

### Full-corpus A/B

46 scored sequences, `cfg-01`, identical commits, **no new failures**:

| dataset | n | APE ratio | worse |
|---|---:|---:|---|
| oxford-spires | 13 | **0.538** | 1/13 |
| conslam | 1 | 0.622 | 0/1 |
| botanic | 7 | 0.696 | 2/7 |
| kitti | 11 | 0.912 | 1/11 |
| grand-tour | 4 | 0.930 | 2/4 |
| tiers | 3 | 0.992 | 1/3 |
| citrus-farm | 7 | **1.201** | 5/7 |
| **pooled** | **46** | **0.785** | 12/46 |

On Oxford Spires this reaches parity with both reference implementations: MOLA-LO/Fast-LIO2 goes **×2.22 → ×0.96** and MOLA-LO/DLIO **×1.94 → ×0.94**.

`citrus-farm` regresses and its profile overrides the value back to 1.0.

### Independence from the decimation tuning

A 2×2 against the shipped decimation defaults confirms this is not an artifact of the per-dataset decimation override: the radius is worth **×0.588 at upstream decimation** and **×0.564 at the Oxford tuning** — the same effect either way, and the two axes compose.

### Compatibility

The defaults are env-overridable so a profile can set them per dataset. `max_search_keyframes` is set to the class default because the loader marks it required; it is inert for a single-keyframe observation layer. With the value left at the previous 1.0, a run is byte-identical to the stored baseline over all 2996 poses of `keble-college-02`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added explicit covariance-estimation settings for 3D observation-layer metric maps.
  * Configured keyframe search, correspondence limits, and covariance-neighbor distance.
  * Tuned the CitrusFarm profile to use a 1.0 m covariance neighborhood by default for improved dataset-specific mapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->