### PR TITLE
Reach the plane-regularization options and the geometry-class pairing weight from lidar3d-gicp.yaml

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -696,6 +696,12 @@ pipeline YAML, not read directly in C++.)
 | `MOLA_OBSLAYER_MAX_PLANE_DEV_FOR_COV` | double | 0 (off) | `pipelines/lidar3d-gicp.yaml` | Same gate, scan side. Gating both sides was measured worse than the map side alone on KITTI |
 | `MOLA_LOCALMAP_PLANE_REG_LAMBDA` | double | 0.001 | `pipelines/lidar3d-gicp.yaml` | Variance asserted along the estimated surface normal, i.e. the plane-confidence ratio (0.001 == 1000:1). **Not a tuning knob**: raising it measured monotonically worse on KITTI |
 | `MOLA_OBSLAYER_PLANE_REG_LAMBDA` | double | 0.001 | `pipelines/lidar3d-gicp.yaml` | Idem, scan side |
+| `MOLA_GCW_ENABLED` | bool | false | `pipelines/lidar3d-gicp.yaml` | Enables mp2p_icp's per-pairing weight by map surface geometry class. Inert while the weights are all ones |
+| `MOLA_GCW_VARIABLE` | string | `incidence` | `pipelines/lidar3d-gicp.yaml` | `incidence` (gravity-free) or `verticality` (needs a gravity source) |
+| `MOLA_GCW_GRAVITY_SOURCE` | string | `map_frame` | `pipelines/lidar3d-gicp.yaml` | `imu` or `map_frame`, for `verticality` only |
+| `MOLA_GCW_SOFTNESS` | double | 10.0 | `pipelines/lidar3d-gicp.yaml` | Ramp width at the breakpoint, in the units of the class variable |
+| `MOLA_GCW_BREAKPOINT` | double | 60.0 | `pipelines/lidar3d-gicp.yaml` | Single class boundary: degrees for `incidence`, \|n.up\| for `verticality` |
+| `MOLA_GCW_W_LOW` / `MOLA_GCW_W_HIGH` | double | 1.0 / 1.0 | `pipelines/lidar3d-gicp.yaml` | Weights below/above the breakpoint. Both 1.0 is a no-op |
 | `MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP` | double | 0 | `module/src/LidarOdometry_ProcessScan.cpp` | Start of a timestamp range for forcing ICP debug-log dumps (paired with `..._TO_TIMESTAMP`) |
 | `MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP` | double | 0 | `module/src/LidarOdometry_ProcessScan.cpp` | End of the timestamp range above |
 | `MOLA_LO_DEBUG_ICP_QUALITY` | bool | false | `module/src/LidarOdometry_ProcessScan.cpp` | Trace ICP quality metrics per scan |

--- a/agents.md
+++ b/agents.md
@@ -692,6 +692,10 @@ pipeline YAML, not read directly in C++.)
 | `MOLA_MATCH_THRESHOLD_FAR` | double | 0 (off) | `pipelines/lidar3d-gicp.yaml` | Range-adaptive matching distance: matching distance beyond `..._KNEE`. 0 keeps the flat `threshold`, bit-identical to before. Interacts with `adaptive_threshold.initial_sigma`/`min_motion` and is a no-op at sigma 0.5 -- do not sweep it alone |
 | `MOLA_MATCH_THRESHOLD_KNEE` | double | 15.0 | `pipelines/lidar3d-gicp.yaml` | Range [m] where the near/far transition is centred |
 | `MOLA_MATCH_THRESHOLD_WIDTH` | double | 5.0 | `pipelines/lidar3d-gicp.yaml` | Width [m] of the near/far logistic transition |
+| `MOLA_LOCALMAP_MAX_PLANE_DEV_FOR_COV` | double | 0 (off) | `pipelines/lidar3d-gicp.yaml` | Map-side planarity gate: reject a covariance neighborhood, falling back to isotropic, when any of its `k` neighbors lies farther than this [m] from their least-squares plane. Measured best at 0.20 on KITTI; 0 is the shipped behavior |
+| `MOLA_OBSLAYER_MAX_PLANE_DEV_FOR_COV` | double | 0 (off) | `pipelines/lidar3d-gicp.yaml` | Same gate, scan side. Gating both sides was measured worse than the map side alone on KITTI |
+| `MOLA_LOCALMAP_PLANE_REG_LAMBDA` | double | 0.001 | `pipelines/lidar3d-gicp.yaml` | Variance asserted along the estimated surface normal, i.e. the plane-confidence ratio (0.001 == 1000:1). **Not a tuning knob**: raising it measured monotonically worse on KITTI |
+| `MOLA_OBSLAYER_PLANE_REG_LAMBDA` | double | 0.001 | `pipelines/lidar3d-gicp.yaml` | Idem, scan side |
 | `MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP` | double | 0 | `module/src/LidarOdometry_ProcessScan.cpp` | Start of a timestamp range for forcing ICP debug-log dumps (paired with `..._TO_TIMESTAMP`) |
 | `MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP` | double | 0 | `module/src/LidarOdometry_ProcessScan.cpp` | End of the timestamp range above |
 | `MOLA_LO_DEBUG_ICP_QUALITY` | bool | false | `module/src/LidarOdometry_ProcessScan.cpp` | Trace ICP quality metrics per scan |

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -429,6 +429,25 @@ icp_settings_with_vel:
         robustKernelPriorRefBlend: "${MOLA_LO_ROBUST_KERNEL_PRIOR_REF_BLEND|0.0}"
         #innerLoopVerbose: true
 
+        # Extra per-pairing weight by the geometry class of the map surface.
+        # Disabled by default, and bit-exactly inert while the weights are all
+        # ones: these numbers do NOT transfer between scene classes, so they
+        # belong in a dataset profile and never in this file's defaults. Read
+        # mp2p_icp's GeometryClassWeights docs before enabling; in particular
+        # 'verticality' is gravity-referenced and needs a gravity source.
+        geometry_class_weights:
+          enabled: ${MOLA_GCW_ENABLED|false}
+          variable: "${MOLA_GCW_VARIABLE|incidence}"
+          gravity_source: "${MOLA_GCW_GRAVITY_SOURCE|map_frame}"
+          softness: ${MOLA_GCW_SOFTNESS|10.0}
+          # Block sequences, not flow ones: the YAML is parsed before the ${}
+          # substitution runs, and a ${..|..} inside [ ] is a parse error.
+          breakpoints:
+            - ${MOLA_GCW_BREAKPOINT|60.0}
+          weights:
+            - ${MOLA_GCW_W_LOW|1.0}
+            - ${MOLA_GCW_W_HIGH|1.0}
+
         # Sequence of one or more pairs (class, params) defining mp2p_icp::Matcher
         # instances to pair geometric entities between pointclouds.
   matchers:

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -516,6 +516,10 @@ localmap_generator:
           k_correspondences_for_cov: ${MOLA_LOCALMAP_K_CORRESPONDENCES_FOR_COV|20}
           min_correspondences_for_cov: ${MOLA_LOCALMAP_MIN_CORRESPONDENCES_FOR_COV|5}
           max_distance_for_cov: ${MOLA_LOCALMAP_MAX_DISTANCE_FOR_COV|2.0}
+          # 0 disables the planarity test, which is the shipped behavior.
+          # See mola::KeyframePointCloudMap's docs before enabling it.
+          max_plane_deviation_for_cov: ${MOLA_LOCALMAP_MAX_PLANE_DEV_FOR_COV|0}
+          plane_regularization_lambda: ${MOLA_LOCALMAP_PLANE_REG_LAMBDA|0.001}
           # --- mola::IncrementalPointCloud only ---
           # Half side [m] of the cube of points kept around the robot on each
           # insertion (Chebyshev distance, as in HashedVoxelPointCloud's
@@ -628,6 +632,8 @@ observations_generator:
           k_correspondences_for_cov: ${MOLA_OBSLAYER_K_CORRESPONDENCES_FOR_COV|20}
           min_correspondences_for_cov: ${MOLA_OBSLAYER_MIN_CORRESPONDENCES_FOR_COV|5}
           max_distance_for_cov: ${MOLA_OBSLAYER_MAX_DISTANCE_FOR_COV|2.0}
+          max_plane_deviation_for_cov: ${MOLA_OBSLAYER_MAX_PLANE_DEV_FOR_COV|0}
+          plane_regularization_lambda: ${MOLA_OBSLAYER_PLANE_REG_LAMBDA|0.001}
         insertOpts: ~
         likelihoodOpts: ~ # none required
         renderOpts: ~


### PR DESCRIPTION
Two independent bits of wiring, one commit each. Both are **no-ops at their defaults**, verified byte-identical on kitti-03 against the unmodified pipeline.

### 1. Plane-regularization options

Companion to **MOLAorg/mola#200**, which makes configurable the two constants every cov-capable map class uses when it regularizes a neighborhood to `U*diag(1,1,1e-3)*U^T`:

- `MOLA_LOCALMAP_MAX_PLANE_DEV_FOR_COV` / `MOLA_OBSLAYER_MAX_PLANE_DEV_FOR_COV` — planarity gate, `0` = off (shipped behavior).
- `MOLA_LOCALMAP_PLANE_REG_LAMBDA` / `MOLA_OBSLAYER_PLANE_REG_LAMBDA` — the plane-confidence ratio, `0.001` = shipped.

Unknown creation-option keys are ignored by the map classes, so this is inert against a core that predates #200 and **merge order does not matter**.

Measured on KITTI 00-10 with the official devkit metric: the map-side gate at `d`=0.20 improves translational drift on 10 of 11 sequences (0.6083 → 0.5772 %); together with `MOLA_LOCALMAP_CLASS=mola::IncrementalPointCloud` it reaches 0.5711 % / 0.1215 deg per 100 m, which is 18% better than KISS-ICP on rotation. See MOLAorg/mola#200 for the tables.

`PLANE_REG_LAMBDA` is exposed for reproducibility, not tuning — raising it measured monotonically worse.

### 2. Geometry-class pairing weight

`mp2p_icp`'s `GeometryClassWeights` has shipped since `58c8e2e` but was not reachable from any pipeline file, so it could only be exercised by hand-editing YAML. Now `MOLA_GCW_*`, disabled by default, and a no-op while both weights are `1.0`.

Deliberately left at that no-op rather than given a tuned default: a weight fitted in one scene class does not transfer to another. On KITTI, down-weighting the ground measured *negative* — this is wiring, not a recommendation.

One gotcha worth recording, and the reason for the block sequences: the YAML is parsed **before** the `${}` substitution runs, so a `${VAR|default}` inside a flow sequence `[ ]` is a parse error.

`agents.md` env-var table updated for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoWrKM3HNosCFeJBEQjYS3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional geometry-class weighting for the Gauss-Newton ICP solver.
  - Added configurable gravity source, weighting softness, breakpoints, and weight values.
  - Added covariance planarity controls for local-map and observation-layer metrics, including maximum plane deviation and plane regularization.

- **Documentation**
  - Documented the new GICP pipeline environment variables and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->