### PR TITLE
README: fix the broken Docs badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI Build colcon](https://github.com/MOLAorg/mola_lidar_odometry/actions/workflows/build-ros.yml/badge.svg)](https://github.com/MOLAorg/mola_lidar_odometry/actions/workflows/build-ros.yml)
 [![CI clang-format](https://github.com/MOLAorg/mola_lidar_odometry/actions/workflows/check-clang-format.yml/badge.svg)](https://github.com/MOLAorg/mola_lidar_odometry/actions/workflows/check-clang-format.yml)
-[![Docs](https://img.shields.io/badge/docs-latest-brightgreen.svg)]([https://docs.mola-slam.org/latest/](https://docs.mola-slam.org/latest/mola_state_estimators.html))
+[![Docs](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://docs.mola-slam.org/latest/mola_lidar_odometry.html)
 [![codecov](https://codecov.io/gh/MOLAorg/mola_lidar_odometry/graph/badge.svg?token=C11VFFK0NW)](https://codecov.io/gh/MOLAorg/mola_lidar_odometry)
 
 # mola_lidar_odometry


### PR DESCRIPTION
The Docs badge target was a markdown link nested inside another link, so GitHub rendered it as literal text rather than a link, and it pointed at the state-estimators page instead of this package's own.

Also audited every other badge in the README: all 15 ROS build-farm job URLs (dev + amd64/arm64 binary jobs, Humble through Rolling), both GitHub Actions badges, the codecov badge and all `img.shields.io/ros/v/...` version badges resolve correctly, so no other URL needed changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CuUE9xzppqyDewwshiY8D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Docs badge link to direct readers to the MOLA LiDAR Odometry documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->