### PR TITLE
GrandTour: default to the incremental local map

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -86,6 +86,12 @@ listing it in `MOLA_LO_DATASET_WRAPPERS` in `CMakeLists.txt`.
   `None`. The /tf tree view is on by default (this is a legged robot with a
   full joint tree, which is the point), skipping the four frames not
   physically on the body: `odom`, `enu_origin`, `dlio_odom`, `dlio_map`.
+  The local map defaults to `mola::IncrementalPointCloud` here: measured lower
+  ATE on every mission of this dataset carrying a reference trajectory (~46% on
+  average). That makes the profile **odometry only** by default -- set
+  `MOLA_LOCALMAP_CLASS=mola::KeyframePointCloudMap` for loop-closure SLAM.
+  `MOLA_MINIMUM_RANGE_FILTER` is 1.5 m and sits next to a cliff: 2.0 m is worse
+  by an order of magnitude, so measure before re-tuning it.
 - **tiers** records FIVE lidars at once — that is what the dataset is for —
   so it gets one wrapper per sensor (`-ouster-os0`, `-ouster-os1`,
   `-velodyne`, `-livox-horizon`, `-livox-avia`) rather than one that silently

--- a/scripts/lib/profiles/grandtour.sh
+++ b/scripts/lib/profiles/grandtour.sh
@@ -174,8 +174,26 @@ mola_lo_profile_resolve() {
   # deskewing it a second time would over-compensate the motion:
   : "${MOLA_DESKEW_METHOD:=MotionCompensationMethod::None}"
   # Use a shorter minimum range since the robot body is small in this dataset:
+  #
+  # This one is on a cliff edge, so re-tune it only with measurements in hand:
+  # dropping to 1.0 m costs little, but raising it to 2.0 m degrades odometry by
+  # more than an order of magnitude, and 3.0 m is *better* than 2.0 m. A legged
+  # platform depends on the near-field ground returns this filter removes.
   : "${MOLA_MINIMUM_RANGE_FILTER:=1.5}"
-  export MOLA_DESKEW_METHOD MOLA_MINIMUM_RANGE_FILTER
+
+  # A single incremental k-d tree in one global frame, rather than the default
+  # keyframe-based local map. Measured across every mission of this dataset that
+  # has a reference trajectory, it lowers absolute trajectory error on all of
+  # them, by ~46% on average, at ~44% more CPU (still comfortably faster than
+  # real time). A constantly pitching platform benefits from a stable, denser
+  # local map instead of one rebuilt from a small rotating keyframe set.
+  #
+  # ODOMETRY ONLY: this map cannot be re-mapped by a global SE(3) correction, so
+  # override it when running loop-closure SLAM on this dataset:
+  #   MOLA_LOCALMAP_CLASS=mola::KeyframePointCloudMap
+  : "${MOLA_LOCALMAP_CLASS:=mola::IncrementalPointCloud}"
+
+  export MOLA_DESKEW_METHOD MOLA_MINIMUM_RANGE_FILTER MOLA_LOCALMAP_CLASS
 
   if [ "$MOLA_LO_MODE" = "gui" ]; then
     # This is a legged robot with a full joint tree in /tf, which is the whole


### PR DESCRIPTION
## What

Sets `MOLA_LOCALMAP_CLASS=mola::IncrementalPointCloud` as the GrandTour profile
default, and documents a sharp discontinuity in the existing minimum-range
filter.

## Why

Measured on all seven GrandTour missions that carry a local reference
trajectory (the total-station prism), offline, `simple` state estimator,
ADIS16475, 16 pinned threads. ATE is RMSE after SE(3) Umeyama alignment,
computed by the same pinned `evo` build the COMFORT benchmark scores with.

| mission | keyframe map | incremental map | change |
|---|---|---|---|
| arc-3  | 0.6632 | **0.3829** | -42.3 % |
| con-1  | 0.0232 | **0.0215** | -7.4 % |
| con-2  | 0.0428 | **0.0202** | -52.7 % |
| con-3  | 0.0562 | **0.0104** | -81.6 % |
| eth-1  | 0.0686 | **0.0391** | -43.0 % |
| eth-2  | 0.0430 | **0.0127** | -70.5 % |
| heap-1 | 0.0529 | **0.0210** | -60.3 % |
| **mean** | **0.1357** | **0.0725** | **-46.5 %** |

Seven of seven. Cost is about 44 % more wall clock (610 s vs 424 s on a 713 s
mission), so the odometry stays faster than real time.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->