### PR TITLE
Offline CLI: allow wheel-odometry fusion from a ROS 2 bag

### DIFF
--- a/apps/mola-lidar-odometry-cli.cpp
+++ b/apps/mola-lidar-odometry-cli.cpp
@@ -447,6 +447,18 @@ std::shared_ptr<mola::OfflineDatasetSource> dataset_from_rosbag2(
           # If present, this will override whatever /tf tells about the sensor pose:
           fixed_sensor_pose: "${IMU_POSE_X|0} ${IMU_POSE_Y|0} ${IMU_POSE_Z|0} ${IMU_POSE_YAW|0} ${IMU_POSE_PITCH|0} ${IMU_POSE_ROLL|0}" # 'x y z yaw_deg pitch_deg roll_deg''
           use_fixed_sensor_pose: ${MOLA_USE_FIXED_IMU_POSE|false}
+        # Wheel odometry, disabled unless MOLA_ODOMETRY_TOPIC is set: same
+        # name and empty-by-default convention as dataset_from_rosbag1()
+        # below and as lidar_odometry_from_rosbag2.yaml, rather than opting
+        # every bag carrying a topic named "/odom" into wheel-odom fusion.
+        # No fixed_sensor_pose: mrpt::obs::CObservationOdometry cannot carry
+        # one, so the wheel-odometry twist must already be expressed in
+        # base_link (nav_msgs/Odometry's child_frame_id) -- see the longer
+        # note in dataset_from_rosbag1().
+        - topic: ${MOLA_ODOMETRY_TOPIC|''}
+          sensorLabel: ${MOLA_ODOM_SENSOR_LABEL|odom_wheels}
+          type: CObservationOdometry
+          is_optional: true
 )"""",
     bagsYaml.c_str(), cli.arg_baseLinkName.getValue().c_str(), cli.arg_tfTopic.getValue().c_str(),
     cli.arg_tfStaticTopic.getValue().c_str(), cli.arg_lidarLabel.getValue().c_str(),


### PR DESCRIPTION
`MOLA_ODOMETRY_TOPIC` has no effect on the `--input-rosbag2` path.
`dataset_from_rosbag2()` builds its `sensors:` list with lidar, GNSS and
IMU entries and no `CObservationOdometry` one, so the topic is reported as
`unhandled` and the wheel odometry never reaches the state estimator.

`dataset_from_rosbag1()`, directly below it, has carried such an entry
since #134 — only the ROS 1 half was ever wired.

Nothing underneath was missing:

- `Rosbag2Dataset` already handles `type: CObservationOdometry` (and, unlike
  `Rosbag1Dataset`, really does implement `is_optional`).
- Its `toOdometry()` sets `hasVelocities` and fills `velocityLocal` from the
  message twist, which is what `StateEstimationSimple`'s
  `sigma_wheel_odom_linear_vel` / `sigma_wheel_odom_angular_vel` consume.

So this is twelve lines mirroring the sibling entry, empty-by-default
convention included, so that a bag which happens to carry a topic named
`/odom` is not opted into wheel-odom fusion silently. **Inert unless
`MOLA_ODOMETRY_TOPIC` is set**, so no existing invocation changes.

The frame caveat from the rosbag1 entry applies equally and is repeated in
the comment: `mrpt::obs::CObservationOdometry` cannot carry a sensor pose,
so the wheel-odometry twist has to already be expressed in `base_link`
(`nav_msgs/Odometry`'s `child_frame_id`).

### Testing

Verified on a 14-minute ROS 2 (mcap) recording with a 128-beam lidar, a
325 Hz IMU and a 50 Hz `nav_msgs/Odometry` wheel stream. Before the change
the odometry topic logs as `unhandled`; after it, `Rosbag2Dataset` installs
the callback and `StateEstimationSimple` fuses it. Over a ~990 m outdoor
loop, against an otherwise identical lidar+IMU run, fusing the wheel
odometry improved start-to-end closure by 11% overall and 29% horizontally,
and reduced start-to-end tilt drift by 26%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional wheel odometry support when importing ROS 2 bag datasets.
  * Wheel odometry can be enabled through configuration and uses a default sensor label when none is provided.
  * Existing workflows remain unchanged when no wheel odometry topic is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->