### PR TITLE
docs: fix the inverted visualizer table and the PIPELINE_YAML variable that does not exist

### DIFF
--- a/docs/mola_lidar_odometry.rst
+++ b/docs/mola_lidar_odometry.rst
@@ -119,7 +119,7 @@ Internally, MOLA LO is based on mp2p_icp filtering and ICP pipelines:
    Block diagram of the MOLA-LO module (Figure adapted from :cite:`blanco2025mola_lo`).
 
 
-Most blocks in the diagram above can be redefined without coding, just changing the :ref:`MOLA-LO pipeline configuration YAML file <>`.
+Most blocks in the diagram above can be redefined without coding, just changing the :ref:`MOLA-LO pipeline configuration YAML file <mola_lo_pipelines>`.
 Refer to the MOLA LO paper for further details.
 
 .. note::

--- a/docs/mola_lo_apps.rst
+++ b/docs/mola_lo_apps.rst
@@ -64,15 +64,17 @@ Choosing a visualizer module
 MOLA provides two alternative visualizer modules, both allowing MRPT's OpenGL rendering,
 that can be used with all GUI applications:
 
-- **MolaVizImGui** (``mola_viz_imgui``): The most recent and modern visualizer built on Dear ImGui (default).
-- **MolaViz** (``mola_viz``): An older visualizer, based on nanogui.
+- **MolaVizImGui** (``mola_viz_imgui``): The most recent visualizer, built on
+  Dear ImGui, with dockable subwindows, a log console and live metric plots.
+  **This is the default.**
+- **MolaViz** (``mola_viz``): The older visualizer, based on nanogui.
 
 .. list-table::
    :widths: 50 50
    :header-rows: 1
 
-   * - MolaViz (default)
-     - MolaVizImGui
+   * - MolaVizImGui (default)
+     - MolaViz
    * - .. image:: https://mrpt.github.io/imgs/screenshot_molaviz_imgui.png
           :alt: MolaVizImGui GUI screenshot
           :width: 100%
@@ -85,16 +87,11 @@ any of the GUI applications:
 
 .. code-block:: bash
 
-   # Explicitly select MolaViz (nanogui-based):
-   MOLA_GUI_MODULE=mola::MolaViz mola-lo-gui-rosbag2 /path/to/your/dataset.mcap
-
-   # Select the alternative MolaVizImGui (Dear ImGui-based):
+   # Explicitly select MolaVizImGui (Dear ImGui-based, the default):
    MOLA_GUI_MODULE=mola::MolaVizImGui mola-lo-gui-rosbag2 /path/to/your/dataset.mcap
 
-.. note::
-
-   ``MolaViz`` is the current default. ``MolaVizImGui`` is under active development
-   and may become the default in a future release once it reaches full feature parity.
+   # Fall back to the older MolaViz (nanogui-based):
+   MOLA_GUI_MODULE=mola::MolaViz mola-lo-gui-rosbag2 /path/to/your/dataset.mcap
 
 |
 
@@ -286,7 +283,7 @@ Runs MOLA-LO on a sequence of the Mulran dataset.
         mola-lo-gui-mulran KAIST01
 
         # Example using the 3D-NDT alternative pipeline:
-        PIPELINE_YAML=$(ros2 pkg prefix mola_lidar_odometry)/share/mola_lidar_odometry/pipelines/lidar3d-ndt.yaml \
+        MOLA_ODOMETRY_PIPELINE_YAML=$(ros2 pkg prefix mola_lidar_odometry)/share/mola_lidar_odometry/pipelines/lidar3d-ndt.yaml \
         MOLA_LOCAL_VOXELMAP_RESOLUTION=5.0 \
         mola-lo-gui-mulran KAIST01
 
@@ -314,9 +311,17 @@ Runs MOLA-LO on a sequence of the Mulran dataset.
 1.6. Common env variables
 ------------------------------
 
-- ``PIPELINE_YAML`` (Default: full path to installed ``lidar3d-default.yaml``): Can be set to override
-  the default pipeline and experiment with custom MOLA-LO systems described through a modified YAML file.
-  Example: see the example for :ref:`mola-lo-gui-mulran <mola_lo_gui_mulran>`.
+- ``MOLA_ODOMETRY_PIPELINE_YAML`` (Default: the installed ``lidar3d-default.yaml``,
+  which is a symlink to :ref:`lidar3d-gicp.yaml <mola_3d_gicp_pipeline>`): set it to
+  override the default pipeline and experiment with custom MOLA-LO systems described
+  through a modified YAML file. See :ref:`the available pipelines <mola_icp_pipelines_summary>`,
+  and the example for :ref:`mola-lo-gui-mulran <mola_lo_gui_mulran>`.
+
+- ``MOLA_WITH_GUI`` (Default: ``true``): set to ``false`` to run a ``mola-lo-gui-*``
+  launcher headless, e.g. over ssh or in a batch job.
+
+- ``MOLA_GUI_MODULE`` (Default: ``mola::MolaVizImGui``): selects the
+  :ref:`visualizer backend <mola_lo_gui_visualizer_selection>`.
 
 
 |
@@ -363,7 +368,7 @@ Process a ROS 2 bag
 .. dropdown:: Does your bag lack ``/tf``?
     :icon: alert
 
-    By default, ``mola-lidar-odometry-cl`` will try to use ``tf2`` messages in the rosbag to find out the relative pose
+    By default, ``mola-lidar-odometry-cli`` will try to use ``tf2`` messages in the rosbag to find out the relative pose
     of the LiDAR sensor with respect to the vehicle frame (default: ``base_link``). If your system **does not** have ``tf`` data
     (for example, if you only launched the LiDAR driver node) you must then set the environment variable ``MOLA_USE_FIXED_LIDAR_POSE=true``
     to use the default (identity) sensor pose on the vehicle. So, launch it like: 
@@ -392,7 +397,7 @@ Process a ROS 2 bag
     If you prefer to visualize the results as they are being processed, there are two options:
 
     * Use the built-in GUI in the provided apps: :ref:`mola-lo-gui-rosbag2 <mola_lo_apps>`.
-    * Replay the bag with `ros2 bag play` and launch the :ref:`ROS 2 launch file <mola_lo_ros>` so you can use RViz2 or FoxGlove for visualization.aunch
+    * Replay the bag with `ros2 bag play` and launch the :ref:`ROS 2 launch file <mola_lo_ros>` so you can use RViz2 or FoxGlove for visualization.
 
 .. dropdown:: More parameters
     :icon: list-unordered

--- a/docs/mola_lo_diagnostics.rst
+++ b/docs/mola_lo_diagnostics.rst
@@ -9,7 +9,7 @@ health status is published, when running in a ROS 2 stack, as
 ``diagnostic_msgs/DiagnosticArray`` messages on the ``/diagnostics`` topic,
 following `REP-107 <https://www.ros.org/reps/rep-0107.html>`_.
 
-Publication is handled by :ref:`mola_bridge_ros2 <mola_bridge_ros2>`, which
+Publication is handled by :ref:`mola_bridge_ros2 <doxid-group__mola__bridge__ros2__grp>`, which
 discovers all loaded modules implementing ``DiagnosticsProvider`` via
 ``findService<>()`` and aggregates their statuses.
 

--- a/docs/mola_lo_pipelines.rst
+++ b/docs/mola_lo_pipelines.rst
@@ -4,8 +4,6 @@
 LO/LIO pipelines
 ============================
 
-____________________________________________
-
 .. contents::
    :depth: 1
    :local:
@@ -61,6 +59,7 @@ ____________________________________________
 |
 
 .. _mola_icp_pipelines_summary:
+
 Summary of ICP pipelines
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -268,6 +267,7 @@ This pipeline exploits the **point-to-plane pairings**.
 
 
 |
+
 ____________________________________________
 
 |
@@ -430,7 +430,7 @@ Sensor inputs: GPS (GNSS) (optional)
   .. note::
 
      For ROS 2 live or rosbag sources, the ROS topic name that the bridge subscribes to is controlled separately
-     by ``MOLA_GNSS_TOPIC`` (see :ref:`mola_lo_ros_mola-cli-env-vars`). These are two different variables:
+     by ``MOLA_GNSS_TOPIC`` (see :ref:`the sensor-input environment variables <mola_lo_ros_mola-cli-env-vars>`). These are two different variables:
      ``MOLA_GPS_NAME`` is the internal sensor label; ``MOLA_GNSS_TOPIC`` is the ROS topic.
 
 


### PR DESCRIPTION
## What

Documentation fixes in `docs/`. Two of them were actively misleading, not merely stale.

### 1. `PIPELINE_YAML` is not a variable anyone reads

`mola_lo_apps.rst` documented `PIPELINE_YAML` as the way to override the odometry pipeline, and gave a worked example:

```bash
PIPELINE_YAML=.../pipelines/lidar3d-ndt.yaml \
MOLA_LOCAL_VOXELMAP_RESOLUTION=5.0 \
mola-lo-gui-mulran KAIST01
```

The launch files read `${MOLA_ODOMETRY_PIPELINE_YAML|../pipelines/lidar3d-default.yaml}`. `PIPELINE_YAML` is only a shell local inside `eval/cli_*.sh`, so that example silently ran the **default** pipeline while appearing to select NDT.

Both places now name `MOLA_ODOMETRY_PIPELINE_YAML`. `MOLA_WITH_GUI` and `MOLA_GUI_MODULE` are documented alongside it, since both are commonly needed and neither appeared anywhere in the docs.

### 2. The visualizer comparison was inverted

`MOLA_GUI_MODULE` defaults to `mola::MolaVizImGui` in every `mola-cli-launchs/*.yaml`. The page said otherwise in two of three places:

- the table header read `MolaViz (default)` over `screenshot_molaviz_imgui.png`, and `MolaVizImGui` over `screenshot_molaviz.png`;
- a closing note said "`MolaViz` is the current default. `MolaVizImGui` is under active development and may become the default in a future release".

Only the bullet list was right. The table now matches its own screenshots and the note is gone.

### 3. Links and markup

- `mola_lidar_odometry.rst` had a literally empty target: ``:ref:`MOLA-LO pipeline configuration YAML file <>` `` → now points at `mola_lo_pipelines`.
- `mola_lo_diagnostics.rst` referenced `mola_bridge_ros2`, which exists only as a doxygen group label.
- `mola_lo_pipelines.rst`: a label glued to its heading with no blank line; a decorative `____` rule directly under the page title, which docutils reads as a section-leading transition (an ERROR); a line block missing its trailing blank line; and a `:ref:` with no text to a label that has no title.
- Two typos: `mola-lidar-odometry-cl`, and `for visualization.aunch`.

## Verification

Full sphinx build of the docs site: no warnings or errors remain on any page from this repo.

## Context

Part of unbreaking docs.mola-slam.org, which is serving v3.0.0 with three dead navigation sections. Companion PRs: MOLAorg/mola and MOLAorg/mola_mapper#8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed broken cross-references across the MOLA-LO documentation.
  * Clarified that `MolaVizImGui` is the default GUI visualizer and updated selection examples.
  * Updated pipeline and environment-variable examples, including GUI configuration options.
  * Corrected CLI documentation typos and improved the sensor-input environment-variable link.
  * Removed minor unnecessary formatting from the pipeline documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->