### PR TITLE
Offline CLI: allow fusing a 3D odometry source as SE(3)

### DIFF
--- a/apps/mola-lidar-odometry-cli.cpp
+++ b/apps/mola-lidar-odometry-cli.cpp
@@ -33,6 +33,7 @@
 #include <mrpt/obs/CObservationIMU.h>
 #include <mrpt/obs/CObservationOdometry.h>
 #include <mrpt/obs/CObservationPointCloud.h>
+#include <mrpt/obs/CObservationRobotPose.h>
 #include <mrpt/obs/CObservationRotatingScan.h>
 #include <mrpt/obs/CObservationVelodyneScan.h>
 #include <mrpt/obs/CRawlog.h>
@@ -457,7 +458,10 @@ std::shared_ptr<mola::OfflineDatasetSource> dataset_from_rosbag2(
         # note in dataset_from_rosbag1().
         - topic: ${MOLA_ODOMETRY_TOPIC|''}
           sensorLabel: ${MOLA_ODOM_SENSOR_LABEL|odom_wheels}
-          type: CObservationOdometry
+          # Planar type: (x, y, yaw) plus a 2D twist. For a 3D odometry
+          # source set MOLA_ODOMETRY_OBS_CLASS=CObservationRobotPose to keep
+          # z, roll, pitch and the source's 6x6 covariance.
+          type: ${MOLA_ODOMETRY_OBS_CLASS|CObservationOdometry}
           is_optional: true
 )"""",
     bagsYaml.c_str(), cli.arg_baseLinkName.getValue().c_str(), cli.arg_tfTopic.getValue().c_str(),
@@ -553,7 +557,13 @@ std::shared_ptr<mola::OfflineDatasetSource> dataset_from_rosbag1(
         # (approximately) base_link-aligned, e.g. BotanicGarden's Xsens IMU.
         - topic: ${MOLA_ODOMETRY_TOPIC|''}
           sensorLabel: ${MOLA_ODOM_SENSOR_LABEL|odom_wheels}
-          type: CObservationOdometry
+          # CObservationOdometry is planar: it can only carry (x, y, yaw)
+          # plus a 2D twist. For a 3D odometry source (legged robot, VIO,
+          # aerial platform) set MOLA_ODOMETRY_OBS_CLASS=CObservationRobotPose
+          # to keep z, roll, pitch and the source's 6x6 covariance. That type
+          # DOES honor a sensor pose, so the frame caveat above applies only
+          # to the planar default.
+          type: ${MOLA_ODOMETRY_OBS_CLASS|CObservationOdometry}
           is_optional: true
 )"""",
     bagsYaml.c_str(), cli.arg_baseLinkName.getValue().c_str(),
@@ -908,6 +918,7 @@ int main_odometry(Cli & cli)
     using mrpt::obs::CObservationIMU;
     using mrpt::obs::CObservationOdometry;
     using mrpt::obs::CObservationPointCloud;
+    using mrpt::obs::CObservationRobotPose;
     using mrpt::obs::CObservationRotatingScan;
     using mrpt::obs::CObservationVelodyneScan;
 
@@ -933,6 +944,11 @@ int main_odometry(Cli & cli)
     }
     if (!obs) {
       obs = sf->getObservationByClass<CObservationOdometry>();
+    }
+    if (!obs) {
+      // The SE(3) counterpart of CObservationOdometry, for 3D odometry
+      // sources whose z/roll/pitch and covariance the planar type drops:
+      obs = sf->getObservationByClass<CObservationRobotPose>();
     }
     if (!obs) {
       obs = sf->getObservationByClass<CObservationIMU>();


### PR DESCRIPTION
Companion to MOLAorg/mola_input_rosbag1#4 (merged) and MOLAorg/mola#209, which taught the bag readers to build a full SE(3) `CObservationRobotPose` from a `nav_msgs/Odometry`. This is the consumer side.

## Two gaps

**1. The dispatch loop dropped the observation on the floor.** `mola-lidar-odometry-cli.cpp` extracts one observation per sensory frame by class, and the chain had no `CObservationRobotPose` case:

```cpp
if (!obs) obs = sf->getObservationByClass<CObservationGPS>();
if (!obs) obs = sf->getObservationByClass<CObservationOdometry>();
if (!obs) obs = sf->getObservationByClass<CObservationIMU>();
if (!obs) continue;                       // <-- silently skipped
```

Measured: a GrandTour run configured to read its legged odometry as `CObservationRobotPose` scored **0.3829 m ATE — identical to four decimals to the same run with no odometry topic at all**, because nothing was ever fused. Silent, and indistinguishable from "the fusion didn't help".

**2. Both rosbag paths hard-coded the planar type.** `type: CObservationOdometry` was fixed in the embedded YAML, so there was no way to request the SE(3) one. `MOLA_ODOMETRY_OBS_CLASS` now selects it, defaulting to `CObservationOdometry` so no existing invocation changes behavior.

## Usage

```bash
MOLA_ODOMETRY_TOPIC=/anymal/state_estimator/odometry \
MOLA_ODOMETRY_OBS_CLASS=CObservationRobotPose \
  mola-lidar-odometry-cli --input-rosbag1 ...
```

Requires a `mola_input_rosbag1` / `mola_input_rosbag2` carrying `toRobotPose()`; with an older one the reader rejects the type with a clear message rather than misbehaving.

`mola::state_estimation_simple` already routes `CObservationRobotPose` to `fuse_odometry_3d_pose()`, which applies the full SE(3) delta and derives a 6-DoF twist — that path existed and was unit-tested, it simply had no way to be fed from a bag.

## Known issue, not addressed here

Odometry fusion makes offline replay **non-deterministic**. Repeating one configuration on GrandTour `arc-3` six times gave 0.3241 / 0.6033 / 1.3857 / 1.3857 / 1.3857 / 1.3857 m ATE, while the same run with odometry disabled reproduces 0.3829 exactly, four times out of four. Two runs that diverge agree until t = 150.5 s and then separate by up to 9.5 m, so a very small early difference decides the outcome.

The mechanism is **not yet established**. Ruled out so far: thread count (two runs at 12 and 16 threads differ by at most 0.0001 m), and dropped scans (all runs, with and without odometry, drop exactly 12). The dataset loop also holds a per-observation `while (liodom->isBusy())` barrier, so the reader does not simply run ahead of the worker.

One candidate worth checking: `isBusy()` counts the worker queues but not `worker_lidar_wait_for_imu_list_`, so a scan parked waiting for IMU coverage can outlive the barrier and be processed after later observations — including odometry fusions — have already been applied to the estimator.

This is worth chasing separately; it does not affect the LiDAR-only path, which is reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TnbdKx4Nv8KbV4toLt7vR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for 3D odometry sources in the command-line application.
  * Added configurable odometry observation types through the `MOLA_ODOMETRY_OBS_CLASS` environment variable.
  * Preserved planar odometry as the default behavior.
  * Added fallback handling for robot pose observations when no other supported observation type matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->