### PR TITLE
GrandTour: fuse the legged odometry by default, as SE(3)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -138,7 +138,8 @@ cannot carry one, so the twist must already be expressed in `base_link`
 sensor pose, so that restriction does not apply to it.
 
 GrandTour is the one profile that turns odometry fusion on by default, and
-reads it as `CObservationRobotPose`; see `profiles/grandtour.sh` for the
+reads it as `CObservationRobotPose`; see `scripts/lib/profiles/grandtour.sh`
+for the
 measurements behind that and behind its loose velocity sigmas.
 
 ## Robot /tf tree visualization (opt-in)

--- a/agents.md
+++ b/agents.md
@@ -126,9 +126,20 @@ purpose: `/odom` is a very common topic name across unrelated robots, so
 auto-detecting it would silently opt every bag that has one into wheel-odom
 fusion.
 
-No `fixed_sensor_pose` on that entry: `mrpt::obs::CObservationOdometry` cannot
-carry one, so the twist must already be expressed in `base_link`
-(`nav_msgs/Odometry`'s `child_frame_id`).
+`MOLA_ODOMETRY_OBS_CLASS` picks how the topic is read: the planar
+`CObservationOdometry` (default) or `CObservationRobotPose`, which keeps the
+full SE(3) pose and its 6x6 covariance. Use the latter for any 3D source
+(legged, VIO, aerial); the planar type drops z, roll and pitch. It needs a
+`mola_input_rosbag1`/`rosbag2` new enough to build it from a `nav_msgs/Odometry`.
+
+No `fixed_sensor_pose` on the planar entry: `mrpt::obs::CObservationOdometry`
+cannot carry one, so the twist must already be expressed in `base_link`
+(`nav_msgs/Odometry`'s `child_frame_id`). `CObservationRobotPose` does carry a
+sensor pose, so that restriction does not apply to it.
+
+GrandTour is the one profile that turns odometry fusion on by default, and
+reads it as `CObservationRobotPose`; see `profiles/grandtour.sh` for the
+measurements behind that and behind its loose velocity sigmas.
 
 ## Robot /tf tree visualization (opt-in)
 

--- a/scripts/lib/profiles/grandtour.sh
+++ b/scripts/lib/profiles/grandtour.sh
@@ -33,9 +33,12 @@ mola_lo_profile_usage() {
   echo "       $0 /path/to/<mission>_hesai_undist.bag [additional flags]"
   echo ""
   echo "Optional environment variables:"
-  echo "  MOLA_ODOMETRY_TOPIC    set to '/anymal/state_estimator/odometry' to fuse the"
-  echo "                         robot's legged kinematic-inertial odometry (this adds"
-  echo "                         <mission>_anymal_state.bag to the inputs)"
+  echo "  MOLA_ODOMETRY_TOPIC    the robot's legged kinematic-inertial odometry, fused"
+  echo "                         by default (this adds <mission>_anymal_state.bag to"
+  echo "                         the inputs). Set it EMPTY to run LiDAR-inertial only"
+  echo "  MOLA_ODOMETRY_OBS_CLASS  how to read that topic: 'CObservationRobotPose'"
+  echo "                         (default, full SE(3) + covariance) or the planar"
+  echo "                         'CObservationOdometry'"
   echo "  MOLA_GRANDTOUR_IMU     which IMU to use: 'adis' (default, 200 Hz) or"
   echo "                         'stim320' (500 Hz, tactical grade). The STIM320 also"
   echo "                         requires <mission>_tf_model.bag, since its frame is"
@@ -171,18 +174,36 @@ mola_lo_profile_resolve() {
   fi
   export MOLA_IMU_TOPIC
 
-  # Legged kinematic-inertial odometry, opt-in via MOLA_ODOMETRY_TOPIC -- the
-  # same convention as every other profile: a dataset is not opted into odometry
-  # fusion merely because a bag on disk happens to carry a pose topic.
+  # Legged kinematic-inertial odometry, ON by default for this dataset. Every
+  # other profile leaves odometry fusion opt-in, because a dataset is not opted
+  # in merely by carrying a pose topic; here it is enabled because it was
+  # measured to help, and the frame is known to be right.
   #
   # `/anymal/state_estimator/odometry` is a nav_msgs/Odometry reported as
   # odom -> base, i.e. for the very frame this profile already uses as
-  # MOLA_TF_BASE_LINK. That is what makes it safe to fuse:
-  # mrpt::obs::CObservationOdometry cannot carry a sensor pose at all, so a
-  # source reported for anything else injects motion in the wrong frame --
-  # which is precisely why CitrusFarm's wheel odometry is deliberately never
-  # enabled anywhere. Checked by reading the messages' child_frame_id, not
+  # MOLA_TF_BASE_LINK. Checked by reading the messages' child_frame_id, not
   # assumed from the topic name.
+  #
+  # Read as CObservationRobotPose, not the default CObservationOdometry: the
+  # latter is planar, so it would drop z, roll, pitch and the covariance this
+  # source publishes -- exactly the components that matter on stairs.
+  #
+  # The velocity sigmas are deliberately loose. This source's pose channel is
+  # good and its velocity channel is not worth trusting against ICP: measured
+  # on the missions with a reference, tightening them degrades the result
+  # monotonically (0.3146 -> 0.3952 -> 0.6496 -> 0.7947 m ATE on arc-3 as the
+  # linear sigma goes 1.0 -> 0.3 -> 0.1 -> 0.03).
+  #
+  # Measured across the seven missions that have a reference: -13.3 % mean ATE,
+  # driven almost entirely by the one mission that goes indoors (arc-3,
+  # 0.3829 -> 0.3146). Set MOLA_ODOMETRY_TOPIC= (empty) to turn it off.
+  : "${MOLA_ODOMETRY_TOPIC:=/anymal/state_estimator/odometry}"
+  : "${MOLA_ODOMETRY_OBS_CLASS:=CObservationRobotPose}"
+  : "${MOLA_NAVSTATE_SIGMA_WHEEL_ODOM_LINVEL:=1.0}"
+  : "${MOLA_NAVSTATE_SIGMA_WHEEL_ODOM_ANGVEL:=0.5}"
+  export MOLA_ODOMETRY_TOPIC MOLA_ODOMETRY_OBS_CLASS
+  export MOLA_NAVSTATE_SIGMA_WHEEL_ODOM_LINVEL MOLA_NAVSTATE_SIGMA_WHEEL_ODOM_ANGVEL
+
   if [ -n "${MOLA_ODOMETRY_TOPIC:-}" ]; then
     if [ -f "$odom_bag" ]; then
       echo "  Odometry bag: $odom_bag"

--- a/scripts/lib/profiles/grandtour.sh
+++ b/scripts/lib/profiles/grandtour.sh
@@ -197,7 +197,9 @@ mola_lo_profile_resolve() {
   # Measured across the seven missions that have a reference: -13.3 % mean ATE,
   # driven almost entirely by the one mission that goes indoors (arc-3,
   # 0.3829 -> 0.3146). Set MOLA_ODOMETRY_TOPIC= (empty) to turn it off.
-  : "${MOLA_ODOMETRY_TOPIC:=/anymal/state_estimator/odometry}"
+  # Note "=" and not ":=": an explicitly empty MOLA_ODOMETRY_TOPIC is how a
+  # caller turns fusion off, and ":=" would treat that as unset and re-enable it.
+  : "${MOLA_ODOMETRY_TOPIC=/anymal/state_estimator/odometry}"
   : "${MOLA_ODOMETRY_OBS_CLASS:=CObservationRobotPose}"
   : "${MOLA_NAVSTATE_SIGMA_WHEEL_ODOM_LINVEL:=1.0}"
   : "${MOLA_NAVSTATE_SIGMA_WHEEL_ODOM_ANGVEL:=0.5}"


### PR DESCRIPTION
The ANYmal publishes a kinematic-inertial odometry that is right about motion the LiDAR gets wrong indoors, and it was being ignored unless explicitly asked for. This turns it on for this dataset and reads it as `CObservationRobotPose`.

## Why the SE(3) type

`CObservationOdometry` is planar — `(x, y, yaw)` plus a 2D twist — so it drops `z`, roll, pitch and the covariance this source publishes. Those are exactly the components that matter on stairs, which is where this dataset's hardest mission spends its time. `MOLA_ODOMETRY_OBS_CLASS=CObservationRobotPose` keeps them (needs `mola_input_rosbag1`/`rosbag2` with `toRobotPose()`).

## Why the sigmas are loose

`sigma_wheel_odom_linear_vel = 1.0`, `angular = 0.5`. This source's *pose* channel is worth having; its *velocity* channel is not worth trusting against ICP. Measured on arc-3, tightening degrades monotonically:

| σ_lin / σ_ang | ATE |
|---|---|
| **1.0 / 0.5** | **0.3146** |
| 0.3 / 0.15 | 0.3952 |
| 0.1 / 0.05 | 0.6496 |
| 0.03 / 0.01 | 0.7947 |

## Measurements

Across the seven missions that have a local prism reference:

| mission | LiDAR-inertial only | + legged odometry | Δ | that odometry alone |
|---|---|---|---|---|
| **arc-3** | 0.3829 | **0.3146** | **−17.8 %** | 0.8370 |
| heap-1 | 0.0210 | 0.0201 | −4.3 % | 0.8394 |
| con-1 | 0.0215 | 0.0213 | −0.7 % | — |
| con-2 | 0.0202 | 0.0202 | −0.4 % | — |
| con-3 | 0.0104 | 0.0118 | +14.3 % | — |
| eth-1 | 0.0391 | 0.0395 | +1.0 % | 0.3327 |
| eth-2 | 0.0127 | 0.0125 | −1.2 % | 0.4656 |
| **mean** | 0.0725 | **0.0629** | **−13.3 %** | |

5 of 7 improve. Read honestly: **the gain is arc-3 and nothing else** — the other six are a wash (+0.5 % on their mean), and con-3's +14.3 % is 1.4 mm on the corpus's best mission. arc-3 is the only mission that goes inside a building, which is where the LiDAR world frame tips and where a legged estimator's own odometry is the thing that still knows the floor is flat.

The fused result also beats that odometry on its own everywhere it can be scored — 0.3146 vs 0.8370 on arc-3 — which is the floor any fusion has to clear to be worth doing.

## Reproducibility

These numbers depend on MOLAorg/mola_state_estimation#67: before it, odometry was fused on arrival rather than in timestamp order, and repeats of one configuration on arc-3 varied 4.3x. With it, repeats are byte-identical.

## Escape hatch

`MOLA_ODOMETRY_TOPIC=` (empty) restores LiDAR-inertial only; `MOLA_ODOMETRY_OBS_CLASS=CObservationOdometry` restores the planar reading. `agents.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TnbdKx4Nv8KbV4toLt7vR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GrandTour now enables ANYmal wheel odometry fusion by default.
  - Added support for full 3D robot-pose odometry, including sensor pose and six-degree-of-freedom covariance.
  - Added configurable linear and angular velocity noise settings.

- **Documentation**
  - Clarified odometry observation options, including planar versus full-pose behavior.
  - Documented the default odometry topic and how to disable fusion by setting it to an empty value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->