### PR TITLE
Allow the verticality reading to come from an odometry source's attitude

### DIFF
--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -757,6 +757,58 @@ public:
       /// 0 defers indefinitely until a quiet reading shows up.
       double map_origin_capture_timeout = 3.0;
 
+      /// Take the verticality reading from an odometry source's ABSOLUTE
+      /// attitude instead of from the accelerometer.
+      ///
+      /// Only the "up" axis is taken, never the position or the heading. The
+      /// source's reference frame differs from the map frame by an unknown yaw
+      /// and translation, and neither of those touches the direction of
+      /// gravity, so the vertical transfers between the two frames exactly
+      /// while nothing else does.
+      ///
+      /// The motivation is that an accelerometer only measures gravity while
+      /// the platform is quasi-static, so on a legged or otherwise
+      /// continuously-accelerating platform `adaptive_sigma` correctly stands
+      /// the constraint down almost all of the time, leaving the vertical
+      /// unconstrained for the whole run. A kinematic-inertial state estimator
+      /// on the platform itself does not have that limitation and publishes an
+      /// attitude that stays gravity-referenced while walking.
+      ///
+      /// The map-origin reference is then captured from the same source (see
+      /// captureMapOriginVerticality), because mixing a reading from one
+      /// source with a reference from another injects the constant offset
+      /// between them as a permanent map tilt.
+      ///
+      /// Only honored by the rank-2 prior path; `use_rank2_prior: false`
+      /// ignores it, with a warning at initialization.
+      struct OdometryAttitude
+      {
+        bool enabled = false;
+
+        /// Sensor label of the odometry observation to read. It must carry a
+        /// full 3D attitude, i.e. arrive as mrpt::obs::CObservationRobotPose;
+        /// planar CObservationOdometry has no pitch or roll to offer and is
+        /// ignored.
+        std::string sensor_label = "odom_wheels";
+
+        /// Sigma [degrees] of the verticality constraint when the reading
+        /// comes from this source. `adaptive_sigma` does not apply here: it
+        /// widens by accelerometer dispersion, which says nothing about an
+        /// external attitude estimate.
+        double sigma_deg = 1.0;
+
+        /// Maximum age [s] of the reading, measured against the newest
+        /// observation timestamp seen by the system. Older readings are
+        /// ignored and the accelerometer is used instead, so a source that
+        /// stops publishing degrades to the previous behavior rather than
+        /// freezing the vertical. 0 = no age limit.
+        double max_age_seconds = 0.5;
+
+        void initialize(const Yaml & c);
+      };
+
+      OdometryAttitude odometry_attitude;
+
       /// Estimate the map-frame gravity direction online, instead of freezing
       /// it from one accelerometer average at the first keyframe.
       ///
@@ -1197,6 +1249,38 @@ private:
     /// the map-origin verticality capture, so the dispersion gate's timeout can be measured.
     std::optional<double> gravity_calib_first_available_time;
 
+    /// Newest verticality reading taken from an odometry source's absolute
+    /// attitude, when `imu_gravity_correction.odometry_attitude` is enabled.
+    /// Protected by imu_state_mtx_.
+    struct OdometryAttitudeState
+    {
+      /// "Up" direction in the vehicle frame.
+      mrpt::math::TVector3D up_body{0, 0, 1};
+
+      /// Observation timestamp, on the same sensor-time scale as
+      /// `latest_obs_time_`, so the two can be compared directly.
+      double timestamp = 0;
+
+      bool valid = false;
+    };
+
+    /// Protected by imu_state_mtx_.
+    OdometryAttitudeState odom_attitude;
+
+    /// True when the map-origin verticality reference was captured from the
+    /// odometry attitude source. The per-scan reading is then taken from that
+    /// same source and from nowhere else: a reading referenced against a
+    /// vertical defined by a different sensor carries the constant offset
+    /// between the two as a permanent map tilt, which is the error this
+    /// reference exists to prevent.
+    /// Protected by imu_state_mtx_.
+    bool gravity_calib_from_odometry = false;
+
+    /// When the map-origin capture first had to wait for the odometry attitude
+    /// source, on the sensor-time scale. Bounds that wait.
+    /// Protected by imu_state_mtx_.
+    std::optional<double> odom_attitude_wait_since;
+
     /// Vehicle pose at the instant `gravity_calib_pitch_roll` was captured.
     /// The capture is attempted at the first keyframe, but the accelerometer
     /// average is often not available yet there: at the very first scan the
@@ -1450,6 +1534,12 @@ private:
   /// direction dispersion (see `adaptive_sigma`). Caller must hold state_mtx_.
   [[nodiscard]] double effectiveGravitySigmaRad() const;
 
+  /// The newest verticality reading from the odometry attitude source, as an
+  /// "up" direction in the vehicle frame, or nullopt when that source is
+  /// disabled, has produced nothing yet, or its newest reading is older than
+  /// `odometry_attitude.max_age_seconds`. Caller must hold imu_state_mtx_.
+  [[nodiscard]] std::optional<mrpt::math::TVector3D> odometryUpBody() const;
+
   /// Captures the map-origin verticality reference from the accelerometer, if
   /// it has not been captured yet and an average is available. Safe (and
   /// intended) to call on every scan: it is a no-op once captured.
@@ -1634,6 +1724,12 @@ private:
 
   void onIMU(const CObservation::ConstPtr & o);
   void onIMUImpl(const CObservation::ConstPtr & o);
+
+  /** Stores the "up" direction implied by an odometry observation's absolute
+   *  attitude, for use as the verticality reading. Like onIMU(), it only
+   *  buffers, so it runs inline on the caller's thread and the stored value
+   *  stays a function of the input sequence alone. */
+  void onOdometryAttitude(const CObservation::ConstPtr & o);
 
   /** Feeds every pending IMU observation with a timestamp not newer than
    *  `upToTime` into the IMU-derived state (de-skew velocity buffer, initial

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -278,6 +278,19 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
     }
 #endif
 
+    // The odometry attitude source feeds the rank-2 prior's reading only. The
+    // legacy pose-prior path derives its tilt straight from the accelerometer,
+    // so leaving this silently ignored there would look like the setting had
+    // no effect.
+    if (
+      params_.imu_gravity_correction.odometry_attitude.enabled &&
+      !params_.imu_gravity_correction.use_rank2_prior) {
+      MRPT_LOG_WARN(
+        "imu_gravity_correction.odometry_attitude is enabled but "
+        "use_rank2_prior is false: the legacy pose-prior path reads the "
+        "accelerometer directly, so the odometry attitude will be ignored.");
+    }
+
     if (c.has("initial_localization")) {
       params_.initial_localization.initialize(c["initial_localization"]);
     }

--- a/module/src/LidarOdometry_Parameters.cpp
+++ b/module/src/LidarOdometry_Parameters.cpp
@@ -367,8 +367,35 @@ void LidarOdometry::Parameters::IMUGravityCorrection::initialize(const Yaml & cf
       sigma_deg > 0, mrpt::format("imu_gravity_correction.sigma_deg=%.4f must be > 0", sigma_deg));
   }
 
+  if (cfg.has("odometry_attitude")) {
+    odometry_attitude.initialize(cfg["odometry_attitude"]);
+  }
+
   if (cfg.has("map_gravity")) {
     map_gravity.initialize(cfg["map_gravity"]);
+  }
+}
+
+void LidarOdometry::Parameters::IMUGravityCorrection::OdometryAttitude::initialize(const Yaml & cfg)
+{
+  YAML_LOAD_OPT(enabled, bool);
+  YAML_LOAD_OPT(sensor_label, std::string);
+  YAML_LOAD_OPT(sigma_deg, double);
+  YAML_LOAD_OPT(max_age_seconds, double);
+
+  if (enabled) {
+    ASSERTMSG_(
+      !sensor_label.empty(),
+      "imu_gravity_correction.odometry_attitude.sensor_label cannot be empty when enabled");
+    ASSERTMSG_(
+      sigma_deg > 0,
+      mrpt::format(
+        "imu_gravity_correction.odometry_attitude.sigma_deg=%.4f must be > 0", sigma_deg));
+    ASSERTMSG_(
+      max_age_seconds >= 0,
+      mrpt::format(
+        "imu_gravity_correction.odometry_attitude.max_age_seconds=%.4f must be >= 0",
+        max_age_seconds));
   }
 }
 

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -336,13 +336,6 @@ std::optional<mp2p_icp::GravityPrior> LidarOdometry::buildGravityPrior() const
   // reference it is combined with come from one consistent snapshot:
   auto lckImu = mrpt::lockHelper(imu_state_mtx_);
 
-  const auto pr = state_.gravity_estimator.estimatedPitchRoll(
-    params_.imu_gravity_correction.averaging_samples,
-    params_.imu_gravity_correction.max_age_seconds);
-  if (!pr.has_value()) {
-    return std::nullopt;
-  }
-
   // "Up" unit vector from (pitch, roll), matching the convention of
   // GravityEstimator::estimatedPitchRoll(): pitch = asin(-u.x),
   // roll = atan2(u.y, u.z). At rest the accelerometer's specific force points
@@ -353,7 +346,28 @@ std::optional<mp2p_icp::GravityPrior> LidarOdometry::buildGravityPrior() const
   };
 
   mp2p_icp::GravityPrior g;
-  g.up_body = upFrom(pr->first, pr->second);
+
+  // Where this scan's reading comes from: the odometry attitude source when
+  // one is configured and current, otherwise the accelerometer average. The
+  // odometry reading carries its own fixed sigma, since the adaptive widening
+  // below measures accelerometer dispersion and has nothing to say about an
+  // externally estimated attitude.
+  std::optional<double> readingSigmaRad;
+
+  const auto upOdom = state_.gravity_calib_from_odometry ? odometryUpBody() : std::nullopt;
+
+  if (upOdom.has_value()) {
+    g.up_body = *upOdom;
+    readingSigmaRad = mrpt::DEG2RAD(params_.imu_gravity_correction.odometry_attitude.sigma_deg);
+  } else {
+    const auto pr = state_.gravity_estimator.estimatedPitchRoll(
+      params_.imu_gravity_correction.averaging_samples,
+      params_.imu_gravity_correction.max_age_seconds);
+    if (!pr.has_value()) {
+      return std::nullopt;
+    }
+    g.up_body = upFrom(pr->first, pr->second);
+  }
 
   // Gravity direction expressed in the MAP frame. The map origin is not
   // necessarily level (nonzero fixed_initial_pose, or starting on a slope), so
@@ -368,7 +382,7 @@ std::optional<mp2p_icp::GravityPrior> LidarOdometry::buildGravityPrior() const
   // happened to be at the first keyframe and which never improves afterwards.
   if (
     params_.imu_gravity_correction.map_gravity.enabled &&
-    !params_.imu_gravity_correction.map_gravity.log_only) {
+    !params_.imu_gravity_correction.map_gravity.log_only && !state_.gravity_calib_from_odometry) {
     if (const auto & r = state_.map_gravity.estimator.latest_result();
         r.has_value() && r->converged) {
       const auto & gm = r->gravity_in_map;
@@ -398,11 +412,34 @@ std::optional<mp2p_icp::GravityPrior> LidarOdometry::buildGravityPrior() const
     }
   }
 
-  const double s = effectiveGravitySigmaRad();
+  const double s = readingSigmaRad.value_or(effectiveGravitySigmaRad());
   g.sigma_rad = std::sqrt(s * s + extraSigmaRad * extraSigmaRad);
   return g;
 }
+
 #endif  // MOLA_LO_HAS_MP2P_GRAVITY_PRIOR
+
+std::optional<mrpt::math::TVector3D> LidarOdometry::odometryUpBody() const
+{
+  // Caller holds imu_state_mtx_, under which odom_attitude is written.
+  const auto & oa = params_.imu_gravity_correction.odometry_attitude;
+
+  if (!oa.enabled || !state_.odom_attitude.valid) {
+    return std::nullopt;
+  }
+
+  // Fall back to the accelerometer rather than to a stale attitude: a source
+  // that stops publishing must degrade to the previous behavior, not freeze
+  // the vertical at its last value for the rest of the run.
+  if (oa.max_age_seconds > 0) {
+    const double age = latest_obs_time_.load() - state_.odom_attitude.timestamp;
+    if (age > oa.max_age_seconds) {
+      return std::nullopt;
+    }
+  }
+
+  return state_.odom_attitude.up_body;
+}
 
 void LidarOdometry::captureMapOriginVerticality(const mrpt::poses::CPose3D & poseAtCapture)
 {
@@ -410,6 +447,63 @@ void LidarOdometry::captureMapOriginVerticality(const mrpt::poses::CPose3D & pos
   auto lckImu = mrpt::lockHelper(imu_state_mtx_);
 
   if (!params_.imu_gravity_correction.enabled || state_.gravity_calib_pitch_roll.has_value()) {
+    return;
+  }
+
+  // A reading from the odometry attitude source has to be referenced against a
+  // map origin captured from that same source. Mixing the two turns the
+  // constant offset between them into a permanent tilt of the map frame, which
+  // is exactly what this reference exists to avoid. No dispersion gate applies
+  // here: the source publishes an already-filtered attitude rather than a raw
+  // specific force, so there is nothing to wait for.
+  //
+  // It does have to be waited FOR, though: the capture runs on the first scan,
+  // which routinely precedes the first odometry message. Without this the
+  // reference would come from the accelerometer and the readings from the
+  // odometry, i.e. the very mix described above.
+  const auto oaUp = odometryUpBody();
+
+  if (params_.imu_gravity_correction.odometry_attitude.enabled && !oaUp.has_value()) {
+    const double now = state_.last_obs_timestamp.has_value()
+                         ? mrpt::Clock::toDouble(*state_.last_obs_timestamp)
+                         : 0.0;
+
+    if (!state_.odom_attitude_wait_since.has_value()) {
+      state_.odom_attitude_wait_since = now;
+    }
+    const double waited = now - *state_.odom_attitude_wait_since;
+    const double timeout = params_.imu_gravity_correction.map_origin_capture_timeout;
+
+    if (timeout <= 0 || waited < timeout) {
+      MRPT_LOG_THROTTLE_INFO_FMT(
+        2.0,
+        "Deferring the map-origin verticality capture: waiting for odometry source '%s' (%.1f s)",
+        params_.imu_gravity_correction.odometry_attitude.sensor_label.c_str(), waited);
+      return;
+    }
+
+    MRPT_LOG_WARN_FMT(
+      "Odometry attitude source '%s' produced nothing in %.1f s: falling back to the "
+      "accelerometer for BOTH the map-origin reference and the per-scan reading, so the two "
+      "stay consistent.",
+      params_.imu_gravity_correction.odometry_attitude.sensor_label.c_str(), waited);
+  }
+
+  if (oaUp.has_value()) {
+    const auto & u = *oaUp;
+    state_.gravity_calib_pitch_roll =
+      std::make_pair(std::asin(std::clamp(-u.x, -1.0, 1.0)), std::atan2(u.y, u.z));
+    state_.gravity_calib_pose = poseAtCapture;
+    state_.gravity_calib_from_odometry = true;
+
+    const auto [pOdom, rOdom] = *state_.gravity_calib_pitch_roll;
+    MRPT_LOG_INFO_FMT(
+      "Map-origin verticality reference captured from the odometry attitude source '%s': "
+      "pitch=%.3f roll=%.3f deg (tilt %.3f deg), at pose [%s]",
+      params_.imu_gravity_correction.odometry_attitude.sensor_label.c_str(), mrpt::RAD2DEG(pOdom),
+      mrpt::RAD2DEG(rOdom),
+      mrpt::RAD2DEG(std::acos(std::clamp(std::cos(pOdom) * std::cos(rOdom), -1.0, 1.0))),
+      poseAtCapture.asString().c_str());
     return;
   }
 

--- a/module/src/LidarOdometry_ProcessScan.cpp
+++ b/module/src/LidarOdometry_ProcessScan.cpp
@@ -359,6 +359,14 @@ std::optional<mp2p_icp::GravityPrior> LidarOdometry::buildGravityPrior() const
   if (upOdom.has_value()) {
     g.up_body = *upOdom;
     readingSigmaRad = mrpt::DEG2RAD(params_.imu_gravity_correction.odometry_attitude.sigma_deg);
+  } else if (state_.gravity_calib_from_odometry) {
+    // The map-origin reference was captured from the odometry source, so an
+    // accelerometer reading here would be measured against a different
+    // vertical: the constant offset between the two would stop being a gauge
+    // and become a tilt of the map frame, which is what capturing both from
+    // one source exists to prevent. Emitting no prior for this scan is the
+    // only consistent option while the source is silent.
+    return std::nullopt;
   } else {
     const auto pr = state_.gravity_estimator.estimatedPitchRoll(
       params_.imu_gravity_correction.averaging_samples,
@@ -428,9 +436,10 @@ std::optional<mrpt::math::TVector3D> LidarOdometry::odometryUpBody() const
     return std::nullopt;
   }
 
-  // Fall back to the accelerometer rather than to a stale attitude: a source
-  // that stops publishing must degrade to the previous behavior, not freeze
-  // the vertical at its last value for the rest of the run.
+  // Report nothing rather than a stale attitude: a source that stops
+  // publishing must not freeze the vertical at its last value for the rest of
+  // the run. What that degrades to is the caller's decision, since it depends
+  // on which source the map-origin reference was captured from.
   if (oa.max_age_seconds > 0) {
     const double age = latest_obs_time_.load() - state_.odom_attitude.timestamp;
     if (age > oa.max_age_seconds) {

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -174,9 +174,18 @@ void LidarOdometry::onOdometryAttitude(const CObservation::ConstPtr & o)
     return;
   }
 
+  const double stamp = mrpt::Clock::toDouble(obs->timestamp);
+
   auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+
+  // Readings can arrive out of order. Letting an older one land would move the
+  // vertical backwards and, with no age limit configured, keep it there.
+  if (state_.odom_attitude.valid && stamp < state_.odom_attitude.timestamp) {
+    return;
+  }
+
   state_.odom_attitude.up_body = up * (1.0 / n);
-  state_.odom_attitude.timestamp = mrpt::Clock::toDouble(obs->timestamp);
+  state_.odom_attitude.timestamp = stamp;
   state_.odom_attitude.valid = true;
 
   MRPT_TRY_END

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -29,6 +29,7 @@
 #include <mrpt/obs/CObservationGPS.h>
 #include <mrpt/obs/CObservationIMU.h>
 #include <mrpt/obs/CObservationOdometry.h>
+#include <mrpt/obs/CObservationRobotPose.h>
 
 // Std:
 #include <regex>
@@ -101,6 +102,16 @@ void LidarOdometry::onNewObservation(const CObservation::ConstPtr & o)
     onIMU(o);
   }
 
+  // Is it the odometry source whose absolute attitude provides the verticality
+  // reading? Handled inline for the same reason as the IMU above: it only
+  // stores the newest value, so doing it on the caller's thread keeps what a
+  // scan sees a function of the input sequence rather than of scheduling.
+  if (
+    params_.imu_gravity_correction.odometry_attitude.enabled &&
+    o->sensorLabel == params_.imu_gravity_correction.odometry_attitude.sensor_label) {
+    onOdometryAttitude(o);
+  }
+
   // Is it GNSS?
   if (
     params_.gnss_sensor_label &&
@@ -124,6 +135,49 @@ void LidarOdometry::onNewObservation(const CObservation::ConstPtr & o)
 
     break;  // do not keep processing the list
   }
+
+  MRPT_TRY_END
+}
+
+void LidarOdometry::onOdometryAttitude(const CObservation::ConstPtr & o)
+{
+  MRPT_TRY_START
+
+  const auto obs = std::dynamic_pointer_cast<const mrpt::obs::CObservationRobotPose>(o);
+  if (!obs) {
+    MRPT_LOG_THROTTLE_WARN_FMT(
+      5.0,
+      "Observation '%s' is configured as the odometry attitude source but is not a "
+      "CObservationRobotPose, so it carries no 3D attitude. Ignoring it.",
+      o->sensorLabel.c_str());
+    return;
+  }
+
+  // Move the reading from the sensor to the vehicle frame, as the state
+  // estimator does for the same observation.
+  auto pose = obs->pose.mean;
+  if (obs->sensorPose != mrpt::poses::CPose3D()) {
+    pose = pose + (-obs->sensorPose);
+  }
+
+  // Only the vertical is taken. Writing R = R_odom_vehicle, the source frame's
+  // "up" in vehicle coordinates is R^T * [0,0,1], i.e. R's third row. The
+  // source frame and the map frame differ by an unknown yaw and translation,
+  // and a rotation about the vertical leaves the vertical fixed, so this one
+  // direction transfers between them exactly while the position and the
+  // heading do not.
+  const auto R = pose.getRotationMatrix();
+  const auto up = mrpt::math::TVector3D(R(2, 0), R(2, 1), R(2, 2));
+
+  const double n = up.norm();
+  if (n < 1e-6) {
+    return;
+  }
+
+  auto lckImu = mrpt::lockHelper(imu_state_mtx_);
+  state_.odom_attitude.up_body = up * (1.0 / n);
+  state_.odom_attitude.timestamp = mrpt::Clock::toDouble(obs->timestamp);
+  state_.odom_attitude.valid = true;
 
   MRPT_TRY_END
 }

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -87,9 +87,12 @@ params:
     # becoming a growing tilt.
     odometry_attitude:
       enabled: ${MOLA_ODOM_VERTICALITY|false}
-      # Must match the odometry observation's label (MOLA_ODOM_SENSOR_LABEL
-      # in the shipped launch files), and that observation must be a
-      # CObservationRobotPose: planar odometry has no pitch or roll to offer.
+      # The VALUE here must equal the label the odometry observation is
+      # published under, which the shipped launch files set through their own
+      # MOLA_ODOM_SENSOR_LABEL variable; the two variables are separate on
+      # purpose, since the verticality source need not be the fused one. That
+      # observation must also be a CObservationRobotPose: planar odometry has
+      # no pitch or roll to offer.
       sensor_label: "${MOLA_ODOM_VERTICALITY_LABEL|odom_wheels}"
       sigma_deg: ${MOLA_ODOM_VERTICALITY_SIGMA_DEG|1.0}
       max_age_seconds: ${MOLA_ODOM_VERTICALITY_MAX_AGE|0.5}

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -72,6 +72,28 @@ params:
     # rate, or estimatedPitchRoll() returns nothing and the constraint is
     # silently inactive (at 400 Hz, 2.0 s holds only ~800 samples).
     #
+    # Take the verticality reading from an odometry source's ABSOLUTE attitude
+    # instead of the accelerometer. Only the "up" axis is used: the source's
+    # frame differs from the map frame by an unknown yaw and translation, and
+    # neither moves the vertical, so that one direction transfers exactly while
+    # the position and heading do not.
+    #
+    # An accelerometer only measures gravity while quasi-static, so on a
+    # platform that accelerates continuously `adaptive_sigma` correctly stands
+    # the constraint down nearly always, leaving the vertical unconstrained. A
+    # kinematic-inertial estimator on the platform has no such limitation.
+    # The map-origin reference is captured from the same source, so the
+    # constant offset between the two verticals stays a gauge instead of
+    # becoming a growing tilt.
+    odometry_attitude:
+      enabled: ${MOLA_ODOM_VERTICALITY|false}
+      # Must match the odometry observation's label (MOLA_ODOM_SENSOR_LABEL
+      # in the shipped launch files), and that observation must be a
+      # CObservationRobotPose: planar odometry has no pitch or roll to offer.
+      sensor_label: "${MOLA_ODOM_VERTICALITY_LABEL|odom_wheels}"
+      sigma_deg: ${MOLA_ODOM_VERTICALITY_SIGMA_DEG|1.0}
+      max_age_seconds: ${MOLA_ODOM_VERTICALITY_MAX_AGE|0.5}
+
     # Estimate the map-frame vertical online instead of freezing it from one
     # accelerometer average at the first keyframe. See
     # mola::imu::MapGravityEstimator: it solves for gravity in the map frame


### PR DESCRIPTION
## What

Lets the per-scan verticality reading come from an odometry source's **absolute
attitude** instead of the accelerometer, through the existing rank-2
`mp2p_icp::GravityPrior` slot. **No `mp2p_icp` change.** Off by default.

```yaml
imu_gravity_correction:
  odometry_attitude:
    enabled: ${MOLA_ODOM_VERTICALITY|false}
    sensor_label: "${MOLA_ODOM_VERTICALITY_LABEL|odom_wheels}"
    sigma_deg: ${MOLA_ODOM_VERTICALITY_SIGMA_DEG|1.0}
    max_age_seconds: ${MOLA_ODOM_VERTICALITY_MAX_AGE|0.5}
```

## Why

An accelerometer only measures gravity while quasi-static, so on a
continuously-accelerating platform `adaptive_sigma` correctly stands the
verticality constraint down almost all of the time, and the map frame's
vertical is then free to drift for the whole run. A kinematic-inertial state
estimator on the platform itself has no such limitation, and on the platforms
that have one it is already on the wire.

Measured on a legged dataset, comparing both estimators against the same
accelerometer at 11 detected standstills of one mission:

| | first stop | last stop (t=718 s) | change |
|---|---:|---:|---:|
| MOLA-LO | 0.013 deg | 0.211 deg | **+0.198** |
| platform state estimator | 0.723 deg | 0.695 deg | **-0.028** |

The platform's attitude holds to 0.03 deg over 12 minutes where LO drifts by
0.2. On another mission of the same corpus, enabling this halves the measured
drift (1.28 deg -> 0.64 deg) at every sigma tried.

## Correctness

Only the up axis is taken. The source's frame differs from the map frame by an
unknown yaw and translation; a rotation about the vertical leaves the vertical
fixed, so that one direction transfers between the frames exactly while the
position and the heading do not, and neither is used.

The map-origin reference is captured from the **same** source, and the per-scan
reading is only used once it has been. Mixing them injects the constant offset
between the two verticals as a permanent map tilt: on the dataset above that
offset is 0.7 deg (accelerometer reference 1.455 deg vs odometry 1.861 deg),
which is larger than the drift being corrected. The capture therefore waits for
the source, since it runs on the first scan and routinely precedes the first
odometry message, and falls back to the accelerometer for *both* halves
together if the source never appears.

`adaptive_sigma` deliberately does not apply to this reading: it widens by
accelerometer dispersion, which says nothing about an external attitude
estimate.

Honored only by the rank-2 prior path; `use_rank2_prior: false` logs a warning
at initialization rather than ignoring the setting silently.

## Scope, and what it does not do

**This does not by itself improve ATE.** On a 4-mission corpus at three sigmas
the best result was -1.5 % and the worst +50 %: the tilt-versus-vertical
exchange documented elsewhere. Its measured value is as a *stabilizer* for
aggressive decimation settings, which amplify tilt on a mission whose vertical
is already unstable (one mission goes from +106 % to -5 % ATE when this is
enabled alongside them). It is off by default and should be enabled on
evidence, per platform.

## Testing

- Bit-identical output to the previous behavior when disabled, verified by
  `md5sum` on a full mission.
- Exercised end-to-end on 20+ scored runs across 5 missions and 3 sigmas.
- Builds clean; `clang-format-14` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional odometry-based verticality correction for IMU gravity estimation.
  * Supports configurable sensor selection, confidence, and data freshness limits.
  * Added configuration examples for GICP pipelines.
  * Uses the latest valid attitude data while rejecting outdated or out-of-order readings.

* **Bug Fixes**
  * Prevents stale odometry attitude data from generating an invalid gravity prior.
  * Added validation and startup warnings for incompatible gravity-correction settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->