### PR TITLE
Offline CLI: several LiDARs at once, and a GrandTour second-sensor selector

### DIFF
--- a/apps/mola-lidar-odometry-cli.cpp
+++ b/apps/mola-lidar-odometry-cli.cpp
@@ -404,14 +404,31 @@ std::shared_ptr<mola::OfflineDatasetSource> dataset_from_mulran(
  *  offline CLI able to expose more than one lidar topic, which the launch
  *  files could already do.
  */
-std::string lidar_sensor_entries(const std::string & labels)
+std::vector<std::string> lidar_sensor_labels(const std::string & labels)
 {
   std::vector<std::string> parts;
   mrpt::system::tokenize(labels, ",", parts);
-  ASSERT_(!parts.empty());
-  std::string s;
+  std::vector<std::string> out;
   for (const auto & p : parts) {
-    s += "\n        - topic: '" + mrpt::system::trim(p) + "'";
+    const std::string one = mrpt::system::trim(p);
+    // A blank entry would reach the pipeline as an empty topic and the run
+    // would start with no lidar input at all, instead of reporting bad input.
+    if (one.empty()) {
+      THROW_EXCEPTION_FMT("--lidar-sensor-label has a blank entry in '%s'", labels.c_str());
+    }
+    out.push_back(one);
+  }
+  if (out.empty()) {
+    THROW_EXCEPTION("--lidar-sensor-label is empty");
+  }
+  return out;
+}
+
+std::string lidar_sensor_entries(const std::string & labels)
+{
+  std::string s;
+  for (const auto & p : lidar_sensor_labels(labels)) {
+    s += "\n        - topic: '" + p + "'";
     s += "\n          type: CObservationPointCloud";
     s += "\n          # If present, this overrides whatever /tf says about the sensor pose.";
     s += "\n          # Note it applies to every lidar listed, so it is only meaningful";
@@ -826,12 +843,10 @@ int main_odometry(Cli & cli)
   }
 
   if (cli.arg_lidarLabel.isSet()) {
-    std::vector<std::string> labels;
-    mrpt::system::tokenize(cli.arg_lidarLabel.getValue(), ",", labels);
-    ASSERT_(!labels.empty());
+    const auto labels = lidar_sensor_labels(cli.arg_lidarLabel.getValue());
     liodom->params_.lidar_sensor_labels.clear();
     for (const auto & l : labels) {
-      liodom->params_.lidar_sensor_labels.emplace_back(mrpt::system::trim(l));
+      liodom->params_.lidar_sensor_labels.emplace_back(l);
     }
     // Several labels only make sense if the odometry is also told to wait for
     // that many observations before treating them as one scan; leaving the

--- a/apps/mola-lidar-odometry-cli.cpp
+++ b/apps/mola-lidar-odometry-cli.cpp
@@ -227,13 +227,16 @@ struct Cli
     // instead of each caller keeping its own flags-vs-env translation table.
     // An explicit command-line flag still wins over the environment.
     arg_lidarLabel.value = "lidar1";
-    arg_lidarLabel.opt = cmd
-                           .add_option(
-                             "--lidar-sensor-label", arg_lidarLabel.value,
-                             "If provided, this supersedes the values in the 'lidar_sensor_labels' "
-                             "entry of the odometry pipeline, defining the sensorLabel/topic name "
-                             "to read LIDAR data from. It can be a regular expression {std::regex}")
-                           ->envname("MOLA_LIDAR_TOPIC");
+    arg_lidarLabel.opt =
+      cmd
+        .add_option(
+          "--lidar-sensor-label", arg_lidarLabel.value,
+          "If provided, this supersedes the values in the 'lidar_sensor_labels' "
+          "entry of the odometry pipeline, defining the sensorLabel/topic name "
+          "to read LIDAR data from. It can be a regular expression {std::regex}, "
+          "or a comma-separated list of them for a rig with several lidars, in "
+          "which case multiple_lidars.lidar_count follows the number given")
+        ->envname("MOLA_LIDAR_TOPIC");
 
     arg_imuLabel.value = "imu";
     arg_imuLabel.opt = cmd
@@ -394,6 +397,34 @@ std::shared_ptr<mola::OfflineDatasetSource> dataset_from_mulran(
 }
 #endif
 
+/** Builds the `sensors:` entries for the lidar(s) named by
+ *  --lidar-sensor-label, which accepts a comma-separated list so a rig with
+ *  several lidars can be replayed as one group. The grouping itself is the
+ *  odometry's (see Parameters::MultipleLidarOptions); this only makes the
+ *  offline CLI able to expose more than one lidar topic, which the launch
+ *  files could already do.
+ */
+std::string lidar_sensor_entries(const std::string & labels)
+{
+  std::vector<std::string> parts;
+  mrpt::system::tokenize(labels, ",", parts);
+  ASSERT_(!parts.empty());
+  std::string s;
+  for (const auto & p : parts) {
+    s += "\n        - topic: '" + mrpt::system::trim(p) + "'";
+    s += "\n          type: CObservationPointCloud";
+    s += "\n          # If present, this overrides whatever /tf says about the sensor pose.";
+    s += "\n          # Note it applies to every lidar listed, so it is only meaningful";
+    s += "\n          # for a single-lidar run; with several, rely on /tf.";
+    s +=
+      "\n          fixed_sensor_pose: \"${LIDAR_POSE_X|0} ${LIDAR_POSE_Y|0} "
+      "${LIDAR_POSE_Z|0} ${LIDAR_POSE_YAW|0} ${LIDAR_POSE_PITCH|0} "
+      "${LIDAR_POSE_ROLL|0}\"  # 'x y z yaw_deg pitch_deg roll_deg'";
+    s += "\n          use_fixed_sensor_pose: ${MOLA_USE_FIXED_LIDAR_POSE|false}";
+  }
+  return s;
+}
+
 #if defined(HAVE_MOLA_INPUT_ROSBAG2)
 std::shared_ptr<mola::OfflineDatasetSource> dataset_from_rosbag2(
   Cli & cli, const std::string & rosbag2file, const mrpt::system::VerbosityLevel logLevel)
@@ -431,12 +462,7 @@ std::shared_ptr<mola::OfflineDatasetSource> dataset_from_rosbag2(
       base_link_frame_id: '%s'
       tf_topic: '%s'
       tf_static_topic: '%s'
-      sensors:
-        - topic: '%s'
-          type: CObservationPointCloud
-          # If present, this will override whatever /tf tells about the sensor pose:
-          fixed_sensor_pose: "${LIDAR_POSE_X|0} ${LIDAR_POSE_Y|0} ${LIDAR_POSE_Z|0} ${LIDAR_POSE_YAW|0} ${LIDAR_POSE_PITCH|0} ${LIDAR_POSE_ROLL|0}"  # 'x y z yaw_deg pitch_deg roll_deg'
-          use_fixed_sensor_pose: ${MOLA_USE_FIXED_LIDAR_POSE|false}
+      sensors:%s
         - topic: ${MOLA_GNSS_TOPIC|'/gps'}
           sensorLabel: 'gps'
           #type: CObservationGPS  # This will be determined automatically by Rosbag2Dataset
@@ -465,7 +491,8 @@ std::shared_ptr<mola::OfflineDatasetSource> dataset_from_rosbag2(
           is_optional: true
 )"""",
     bagsYaml.c_str(), cli.arg_baseLinkName.getValue().c_str(), cli.arg_tfTopic.getValue().c_str(),
-    cli.arg_tfStaticTopic.getValue().c_str(), cli.arg_lidarLabel.getValue().c_str(),
+    cli.arg_tfStaticTopic.getValue().c_str(),
+    lidar_sensor_entries(cli.arg_lidarLabel.getValue()).c_str(),
     cli.arg_imuLabel.getValue().c_str())));
 
   o->initialize(cfg);
@@ -509,12 +536,7 @@ std::shared_ptr<mola::OfflineDatasetSource> dataset_from_rosbag1(
     params:
       rosbag_filename: %s
       base_link_frame_id: '%s'
-      sensors:
-        - topic: '%s'
-          type: CObservationPointCloud
-          # If present, this will override whatever /tf tells about the sensor pose:
-          fixed_sensor_pose: "${LIDAR_POSE_X|0} ${LIDAR_POSE_Y|0} ${LIDAR_POSE_Z|0} ${LIDAR_POSE_YAW|0} ${LIDAR_POSE_PITCH|0} ${LIDAR_POSE_ROLL|0}"  # 'x y z yaw_deg pitch_deg roll_deg'
-          use_fixed_sensor_pose: ${MOLA_USE_FIXED_LIDAR_POSE|false}
+      sensors:%s
         - topic: ${MOLA_GNSS_TOPIC|'/gps'}
           sensorLabel: 'gps'
           is_optional: true
@@ -567,7 +589,8 @@ std::shared_ptr<mola::OfflineDatasetSource> dataset_from_rosbag1(
           is_optional: true
 )"""",
     bagsYaml.c_str(), cli.arg_baseLinkName.getValue().c_str(),
-    cli.arg_lidarLabel.getValue().c_str(), cli.arg_imuLabel.getValue().c_str())));
+    lidar_sensor_entries(cli.arg_lidarLabel.getValue()).c_str(),
+    cli.arg_imuLabel.getValue().c_str())));
 
   o->initialize(cfg);
 
@@ -803,7 +826,24 @@ int main_odometry(Cli & cli)
   }
 
   if (cli.arg_lidarLabel.isSet()) {
-    liodom->params_.lidar_sensor_labels.assign(1, std::regex(cli.arg_lidarLabel.getValue()));
+    std::vector<std::string> labels;
+    mrpt::system::tokenize(cli.arg_lidarLabel.getValue(), ",", labels);
+    ASSERT_(!labels.empty());
+    liodom->params_.lidar_sensor_labels.clear();
+    for (const auto & l : labels) {
+      liodom->params_.lidar_sensor_labels.emplace_back(mrpt::system::trim(l));
+    }
+    // Several labels only make sense if the odometry is also told to wait for
+    // that many observations before treating them as one scan; leaving the
+    // count at its default would instead process each lidar as its own scan.
+    // An explicit count from the pipeline YAML still wins.
+    if (labels.size() > 1 && liodom->params_.multiple_lidars.lidar_count == 1) {
+      liodom->params_.multiple_lidars.lidar_count = static_cast<uint32_t>(labels.size());
+      std::cout << "[mola-lidar-odometry-cli] " << labels.size()
+                << " lidar labels given: setting multiple_lidars.lidar_count to match "
+                   "(override with MOLA_LIDAR_COUNT)."
+                << std::endl;
+    }
   }
 
   if (cli.arg_imuLabel.isSet()) {

--- a/scripts/lib/profiles/grandtour.sh
+++ b/scripts/lib/profiles/grandtour.sh
@@ -136,9 +136,7 @@ mola_lo_profile_resolve() {
   # sensor frame (verified: it has base, hesai_lidar, prism, adis16475_imu
   # and stim320_imu, and the same /tf and /tf_static message counts).
   : "${MOLA_GRANDTOUR_IMU:=adis}"
-  # MOLA_GRANDTOUR_TF_BAG lets a caller supply a TF bag with refined
-  # extrinsics in place of the recorded one; empty keeps the mission's own.
-  local tf_bag=${MOLA_GRANDTOUR_TF_BAG:-${prefix}_tf_minimal.bag}
+  local tf_bag=${prefix}_tf_minimal.bag
   local imu_bag=${prefix}_adis.bag
   local imu_topic=/boxi/adis/imu
 
@@ -154,6 +152,12 @@ mola_lo_profile_resolve() {
       return 1
       ;;
   esac
+
+  # MOLA_GRANDTOUR_TF_BAG lets a caller supply a TF bag with refined extrinsics
+  # in place of whichever recorded one the IMU choice selected; empty keeps that
+  # default. Applied after the case above, so a caller that sets both variables
+  # gets the override rather than having it replaced by the STIM320 default.
+  tf_bag=${MOLA_GRANDTOUR_TF_BAG:-$tf_bag}
 
   # Which camera to preview. The three HDR cameras each ship in their own bag,
   # while the five Alphasense cameras share a single one, so the bag and the
@@ -230,6 +234,11 @@ mola_lo_profile_resolve() {
     echo "Error: MOLA_GRANDTOUR_IMU=stim320 needs '$tf_bag', which was not found." >&2
     echo "       Fetch it with: klein download -p GrandTourDataset -m release_<mission> \\" >&2
     echo "                        --dest <dir> --create-dirs -y <mission>_tf_model.bag" >&2
+    return 1
+  elif [ -n "$lidar2_bag" ]; then
+    # Two sensors cannot share one fixed pose, so /tf is the only thing that can
+    # place them; falling back would silently put both at the vehicle origin.
+    echo "Error: MOLA_GRANDTOUR_LIDAR2 needs the extrinsics in '$tf_bag', not found." >&2
     return 1
   else
     echo "  TF bag   : (not found: '$tf_bag'; using a fixed LiDAR pose at the origin)"

--- a/scripts/lib/profiles/grandtour.sh
+++ b/scripts/lib/profiles/grandtour.sh
@@ -68,6 +68,30 @@ mola_lo_profile_usage() {
   echo "  $0 ~/datasets/grand-tour/2024-10-01-11-29-55/"
 }
 
+# Map a LiDAR tag to the bag suffix and topic it is carried on. Shared by the
+# primary sensor and by the optional second one fused with it, so the two
+# cannot drift apart.
+_grandtour_lidar_spec() {
+  case "$1" in
+    hesai)
+      _gt_lidar_suffix=_hesai_undist.bag
+      _gt_lidar_topic=/boxi/hesai/points_undistorted
+      ;;
+    livox)
+      _gt_lidar_suffix=_livox_undist.bag
+      _gt_lidar_topic=/boxi/livox/points_undistorted
+      ;;
+    velodyne)
+      _gt_lidar_suffix=_anymal_velodyne_undist.bag
+      _gt_lidar_topic=/anymal/velodyne/points_undistorted
+      ;;
+    *)
+      echo "Error: $2 must be 'hesai', 'livox' or 'velodyne', got '$1'." >&2
+      return 1
+      ;;
+  esac
+}
+
 mola_lo_profile_resolve() {
   local arg=$1
   shift
@@ -78,24 +102,9 @@ mola_lo_profile_resolve() {
   : "${MOLA_GRANDTOUR_LIDAR:=hesai}"
   local lidar_suffix
   local lidar_topic_default
-  case "$MOLA_GRANDTOUR_LIDAR" in
-    hesai)
-      lidar_suffix=_hesai_undist.bag
-      lidar_topic_default=/boxi/hesai/points_undistorted
-      ;;
-    livox)
-      lidar_suffix=_livox_undist.bag
-      lidar_topic_default=/boxi/livox/points_undistorted
-      ;;
-    velodyne)
-      lidar_suffix=_anymal_velodyne_undist.bag
-      lidar_topic_default=/anymal/velodyne/points_undistorted
-      ;;
-    *)
-      echo "Error: MOLA_GRANDTOUR_LIDAR must be 'hesai', 'livox' or 'velodyne', got '$MOLA_GRANDTOUR_LIDAR'." >&2
-      return 1
-      ;;
-  esac
+  _grandtour_lidar_spec "$MOLA_GRANDTOUR_LIDAR" MOLA_GRANDTOUR_LIDAR || return 1
+  lidar_suffix=$_gt_lidar_suffix
+  lidar_topic_default=$_gt_lidar_topic
 
   # Resolve the "<dir>/<mission>" prefix shared by all of a mission's bags,
   # from either a mission directory or any one of its bag files:
@@ -127,7 +136,9 @@ mola_lo_profile_resolve() {
   # sensor frame (verified: it has base, hesai_lidar, prism, adis16475_imu
   # and stim320_imu, and the same /tf and /tf_static message counts).
   : "${MOLA_GRANDTOUR_IMU:=adis}"
-  local tf_bag=${prefix}_tf_minimal.bag
+  # MOLA_GRANDTOUR_TF_BAG lets a caller supply a TF bag with refined
+  # extrinsics in place of the recorded one; empty keeps the mission's own.
+  local tf_bag=${MOLA_GRANDTOUR_TF_BAG:-${prefix}_tf_minimal.bag}
   local imu_bag=${prefix}_adis.bag
   local imu_topic=/boxi/adis/imu
 
@@ -174,12 +185,40 @@ mola_lo_profile_resolve() {
   echo "GrandTour mission '$(basename "$prefix")':"
   echo "  LiDAR bag: $lidar_bag  ($MOLA_GRANDTOUR_LIDAR)"
 
+  # Optional second LiDAR, fused with the first as one scan group. The rig
+  # carries three; the odometry groups them via multiple_lidars.lidar_count,
+  # which the offline CLI derives from the number of comma-separated labels it
+  # is given. Resolved here, before the topic default is frozen below.
+  : "${MOLA_GRANDTOUR_LIDAR2:=}"
+  local lidar2_bag=
+  if [ -n "$MOLA_GRANDTOUR_LIDAR2" ]; then
+    if [ "$MOLA_GRANDTOUR_LIDAR2" = "$MOLA_GRANDTOUR_LIDAR" ]; then
+      echo "Error: MOLA_GRANDTOUR_LIDAR2 must differ from MOLA_GRANDTOUR_LIDAR." >&2
+      return 1
+    fi
+    _grandtour_lidar_spec "$MOLA_GRANDTOUR_LIDAR2" MOLA_GRANDTOUR_LIDAR2 || return 1
+    lidar2_bag=${prefix}${_gt_lidar_suffix}
+    if [ ! -f "$lidar2_bag" ]; then
+      echo "Error: MOLA_GRANDTOUR_LIDAR2=$MOLA_GRANDTOUR_LIDAR2 needs '$lidar2_bag', not found." >&2
+      return 1
+    fi
+    echo "  LiDAR bag 2: $lidar2_bag  ($MOLA_GRANDTOUR_LIDAR2)"
+    lidar_topic_default="${lidar_topic_default},${_gt_lidar_topic}"
+    # One fixed pose cannot describe two sensors: the extrinsics must come
+    # from /tf, which the TF bag below provides.
+    MOLA_USE_FIXED_LIDAR_POSE=false
+    export MOLA_USE_FIXED_LIDAR_POSE
+  fi
+
   # GrandTour topic names and /tf frames:
   : "${MOLA_LIDAR_TOPIC:=$lidar_topic_default}"
   : "${MOLA_TF_BASE_LINK:=base}"  # the ANYmal body frame; NOT named 'base_link'
   export MOLA_LIDAR_TOPIC MOLA_TF_BASE_LINK
 
   local -a bags=("$lidar_bag")
+  if [ -n "$lidar2_bag" ]; then
+    bags+=("$lidar2_bag")
+  fi
 
   if [ -f "$tf_bag" ]; then
     echo "  TF bag   : $tf_bag"


### PR DESCRIPTION
## What

The odometry has grouped several LiDARs into one scan for a long time
(`Parameters::MultipleLidarOptions`), and the `mola-cli` launch files can
declare several lidar topics. The offline CLI could not: it emitted exactly
one `sensors:` entry and then overrode `lidar_sensor_labels` back to a single
regex, so a multi-lidar pipeline YAML was silently reduced to one sensor.

- `--lidar-sensor-label` now accepts a comma-separated list, in the same style
  the bag list already uses, emitting one sensor entry and one regex per
  element. Applies to both the rosbag1 and rosbag2 builders.
- When several labels are given and the pipeline still carries the default
  count of 1, `multiple_lidars.lidar_count` follows the number of labels:
  leaving it at 1 would process each sensor as its own scan instead of
  grouping them, which is a confusing failure rather than an error.
- GrandTour profile: `MOLA_GRANDTOUR_LIDAR2` names a second sensor to fuse
  with the primary one, appending its bag and joining the topics. The
  tag-to-bag-and-topic mapping moves into a helper shared with the existing
  `MOLA_GRANDTOUR_LIDAR` selector so the two cannot drift apart. Refused when
  both name the same sensor, and a fixed lidar pose is turned off, since one
  pose cannot describe two sensors.
- GrandTour profile: `MOLA_GRANDTOUR_TF_BAG` supplies a TF bag with refined
  extrinsics in place of the recorded one. This is what makes an inter-sensor
  calibration testable without teaching any code path about calibration
  overrides.

Defaults are unchanged throughout: one label behaves exactly as before.

## Measured

Verified on the GrandTour prism-reference corpus, 12 threads. The
single-sensor control through this build reproduces every stored baseline to
four decimals (con-1 0.0213, con-2 0.0202, con-3 0.0118, eth-1 0.0395,
heap-1 0.0201, arc-3 0.3146), so the change is neutral when one lidar is
named.

Fusing the Hesai with the Livox was then screened and is **worse on every
mission** (+36 % to +372 %, +98 % on the mean). The cause was measured, not
guessed: on a static epoch the two sensors agree in the mean to under 2 mm but
scatter by 22 mm rms, so merging their clouds thickens every map surface by
about the size of the ATE. Refining the extrinsic (a rig-constant
(-0.036, +0.107, +0.114) deg, calibrated on stationary epochs across three
missions 25 days apart) changes con-1 by nothing, and doubling the point
budget does not recover it either.

So this PR ships the capability, not a recommended configuration. It is worth
having because the offline CLI should be able to do what the launch files can,
and because the next idea in this space (registering each sensor separately
and fusing poses, rather than pooling points) needs the same plumbing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for processing multiple LiDAR topics in a single run.
  * Added optional second-LiDAR fusion for Grand Tour profiles.
  * Added support for supplying a separate TF bag with refined sensor extrinsics.
  * Automatically configures multi-LiDAR settings and validates sensor and bag selections.

* **Documentation**
  * Updated command-line help to describe comma-separated LiDAR topics and multi-LiDAR behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->