### PR TITLE
Stop refusing recordings with more bags than launch-file slots

### DIFF
--- a/scripts/lib/dataset-profile.sh
+++ b/scripts/lib/dataset-profile.sh
@@ -76,6 +76,13 @@ MOLA_LO_PIPELINES_DIR="$MOLA_LO_SHARE_DIR/pipelines"
 # the empty string rather than left alone, so a stale value exported by an
 # earlier run cannot leak in as an extra bag.
 #
+# A recording split into MORE parts than there are slots is not an error: every
+# bag goes into the first slot as one comma-separated list, which Rosbag1Dataset
+# splits on exactly as it does for the offline CLI's --input-rosbag1. Only that
+# case uses the joined spelling, so the per-slot layout every existing dataset
+# produces is unchanged. Newer College is the reason: its two sequences carry 10
+# and 16 bags, so before this its online arm could not run at all.
+#
 # The joined list is returned through a variable, not echoed: a caller
 # capturing it with $(...) would run this in a subshell and lose the exports.
 mola_lo_bag_slots() {
@@ -86,22 +93,34 @@ mola_lo_bag_slots() {
   done
 
   local max_slots=5
-  if [ "${#bags[@]}" -gt "$max_slots" ]; then
-    echo "Error: ${#bags[@]} bags given, the rosbag1 launch files expose $max_slots slots." >&2
-    return 1
-  fi
+
+  local joined=""
+  for b in "${bags[@]}"; do
+    joined="${joined:+$joined,}$b"
+  done
+  MOLA_LO_BAGS_JOINED="$joined"
 
   local i
+  local var
+  local value
   for ((i = 0; i < max_slots; i++)); do
-    local var
     var="MOLA_INPUT_ROSBAG1"
-    [ "$i" -gt 0 ] && var="MOLA_INPUT_ROSBAG1_$((i + 1))"
-    printf -v "$var" '%s' "${bags[$i]:-}"
+    if [ "$i" -gt 0 ]; then
+      var="MOLA_INPUT_ROSBAG1_$((i + 1))"
+    fi
+
+    if [ "${#bags[@]}" -le "$max_slots" ]; then
+      value="${bags[$i]:-}"
+    elif [ "$i" -eq 0 ]; then
+      # More bags than slots: they all travel in the first one.
+      value="$joined"
+    else
+      value=""
+    fi
+
+    printf -v "$var" '%s' "$value"
     export "${var?}"
   done
-
-  local IFS=,
-  MOLA_LO_BAGS_JOINED="${bags[*]}"
 }
 
 # Selects the mola_state_estimation_smoother instead of the default simple


### PR DESCRIPTION
### Why

`mola_lo_bag_slots()` refused any dataset with more than the five bags the rosbag1 launch files expose as slots:

```
Error: 10 bags given, the rosbag1 launch files expose 5 slots.
```

That makes the **online** arm unavailable for such datasets, while the offline CLI replays exactly the same sequences without trouble — it takes them comma-joined. Newer College is the concrete case: its two sequences carry **10 and 16** `*_lio.bag` parts, so `mola-lo-gui-newer-college` and every online CI cell for that family have never been able to run.

### What

Past five bags, they now all travel in the first slot as one comma-separated list — the spelling `--input-rosbag1` already uses, and which `Rosbag1Dataset` splits on as of MOLAorg/mola_input_rosbag1#5 (that PR is the dependency; this one is inert without it).

Five or fewer bags keeps the existing per-slot layout exactly, so no current dataset changes behaviour:

```
3 bags -> slot1=a.bag slot2=b.bag slot5=[]  joined=a.bag,b.bag,c.bag
7 bags -> slot1=1.bag,2.bag,3.bag,4.bag,5.bag,6.bag,7.bag  slot2=[] slot5=[]
```

The joined list is now built explicitly instead of via a local `IFS`, because it is needed before the slots are filled rather than after.

### Verified

`newer-college/01_short_experiment` replays online end to end for the first time — all 10 bags open and merge into a single chronological view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Datasets containing more than five bags no longer cause processing errors.
  - All bags are now handled automatically, including datasets that exceed the available input slots.
  - Existing processing behavior for datasets with five or fewer bags remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->