### PR TITLE
KITTI: run the shipped pipeline, which halves absolute trajectory error

### DIFF
--- a/scripts/lib/profiles/kitti.sh
+++ b/scripts/lib/profiles/kitti.sh
@@ -37,26 +37,28 @@ mola_lo_profile_resolve() {
   : "${MOLA_INITIAL_VX:=20.0}"
   export MOLA_INITIAL_VX
 
-  # KITTI does better on the point-to-point pipeline than on the default
-  # cov-to-cov one, and by enough to be worth selecting here: measured over
-  # sequences 00-10 it is better on 8 of 11 in translation and 7 of 11 in
-  # rotation, and costs about half the time per scan.
+  # No pipeline override: KITTI runs the shipped default, like every other
+  # dataset here.
   #
-  # This is a per-dataset choice, not a claim about the pipelines in general.
-  # A forward ablation between the two found that the difference does not come
-  # from any single stage: intermediate configurations are several times worse
-  # than either pipeline, so the two are separate optima rather than points on
-  # a path. Swapping just the matcher, in particular, is far worse than either.
+  # This profile used to select the point-to-point pipeline
+  # (lidar3d-icp.yaml), on a measurement over 00-10 that it wins the KITTI
+  # devkit's relative metric on 8 of 11 sequences. That result still
+  # reproduces -- relative translation error is 3.8 % lower on average, better
+  # on 8 of 11 -- but it prices only local registration. Scored on absolute
+  # trajectory error over the same 11 sequences, the default cov-to-cov
+  # pipeline wins 9 of 11, with a mean of 1.65 m against 2.72 m and a median
+  # of 1.07 m against 1.93 m. Three sequences are not close: 06 is 0.45 m
+  # against 4.78 m, 01 is 2.02 against 4.09, and 09 is 1.07 against 1.93.
   #
-  # Batch and regression runs override this the same way they override the
-  # velocity prior above, so their published numbers stay comparable.
-  : "${MOLA_ODOMETRY_PIPELINE_YAML:=$MOLA_LO_PIPELINES_DIR/lidar3d-icp.yaml}"
-  export MOLA_ODOMETRY_PIPELINE_YAML
+  # Good local registration that drifts is what that pattern describes, and
+  # ATE is the metric this dataset's users compare. Note the two are not in
+  # conflict about anything subtle: the relative gain is a few percent and the
+  # absolute cost is 65 %.
+  #
+  # The decimation tuning below was always measured against this pipeline, so
+  # the two now agree instead of being tuned for different targets.
 
-  # GICP-pipeline decimation tuning, for whenever lidar3d-gicp.yaml is
-  # selected instead of the pipeline default above (e.g. the SLAM-eval
-  # harness always evaluates job=lio against lidar3d-gicp.yaml regardless of
-  # this profile's own pipeline choice). A coarser voxel visited completely
+  # Decimation tuning for that pipeline. A coarser voxel visited completely
   # via the stride bound beats the shipped fine voxel sampled at a stride of
   # 3-5, on both translation and rotation, at a third of the cost, on the
   # full 00-10 corpus. Per-dataset, not a shipped pipeline default: it was


### PR DESCRIPTION
### The measurement

All 11 KITTI sequences with ground truth, offline, `simple` estimator, this profile otherwise unchanged. `lidar3d-default.yaml` is a symlink to `lidar3d-gicp.yaml`, i.e. the shipped cov-to-cov pipeline.

| seq | default ATE [m] | icp ATE [m] | ATE | default RPEt [%] | icp RPEt [%] | RPEt |
|---|---:|---:|---:|---:|---:|---:|
| 00 | **3.6019** | 4.8232 | +33.9 % | 0.9948 | **0.9395** | −5.6 % |
| 01 | **2.0248** | 4.0868 | +101.8 % | 0.9754 | **0.9018** | −7.5 % |
| 02 | **4.8885** | 7.5227 | +53.9 % | 0.9552 | **0.8827** | −7.6 % |
| 03 | 0.7423 | **0.6258** | −15.7 % | 0.9396 | **0.9004** | −4.2 % |
| 04 | 1.0232 | **0.8741** | −14.6 % | 0.4413 | **0.3845** | −12.9 % |
| 05 | **1.1206** | 1.5792 | +40.9 % | **0.4895** | 0.4908 | +0.3 % |
| 06 | **0.4481** | 4.7789 | **+966.6 %** | 0.5329 | **0.5076** | −4.7 % |
| 07 | **0.3444** | 0.3524 | +2.3 % | **0.4148** | 0.4173 | +0.6 % |
| 08 | **2.1641** | 2.4550 | +13.4 % | 1.3164 | **1.3062** | −0.8 % |
| 09 | **1.0687** | 1.9302 | +80.6 % | 0.7389 | **0.7263** | −1.7 % |
| 10 | **0.7312** | 0.8739 | +19.5 % | **0.7855** | 0.7974 | +1.5 % |

- **ATE**: default wins 9 of 11. Mean 1.65 m against 2.72 m, median 1.07 m against 1.93 m.
- **RPE translational**: point-to-point wins 8 of 11, mean 0.780 % against 0.750 % — i.e. 3.8 % better.

### Why change it

The original choice was not wrong about what it measured: the point-to-point pipeline really does win the KITTI devkit's *relative* metric, and this run reproduces that. But relative error prices local registration only, and the two metrics disagree here by two orders of magnitude in cost: a few percent of relative accuracy against 65 % of absolute accuracy. Good local registration that drifts is exactly the pattern the table shows, most starkly on seq 06 (0.45 m against 4.78 m).

### Why drop the override rather than repoint it

`dataset-profile.sh` says a profile should pick its own pipeline "only where a dataset has a measured reason to differ from the default". After this measurement KITTI no longer has one, so the honest encoding is no override — and KITTI then follows the shipped default if that default ever improves.

The decimation knobs immediately below were always tuned against the cov-to-cov pipeline (their comment says so), so profile and pipeline now aim at the same target instead of different ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the KITTI profile to use the shipped default odometry pipeline.
  * Clarified decimation tuning guidance for the default pipeline.

* **Documentation**
  * Added comparative ATE/RTE performance results for the KITTI profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->