### PR TITLE
FIX: manual relocalization is ignored unless initial_localization.method is FixedPose

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -192,6 +192,21 @@ footprint-to-base_link offset, not the localization starting pose). Use
 `mola_footprint_to_base_link_tf`); empty (default) leaves the pipeline
 YAML's own fallback (origin) in place.
 
+## A manual relocalization request overrides `initial_localization.method`
+
+`relocalize_near_pose_pdf()` sets `method = InitLocalization::FixedPose` along
+with the requested pose. Without that, a system configured with
+`FromStateEstimator` (what `gnss_mode:=relocalize` selects in the ROS 2 launch)
+or `PitchAndRollFromIMU` would store the pose and never read it, while the
+`initial_localization_done = false` set by the same call already stopped scans
+from being processed in `onLidar()`: the request would stall the front end
+instead of relocalizing it. This is the case that matters most, since a manual
+request is typically what is used when the automatic source cannot converge
+(e.g. poor GNSS coverage).
+
+`relocalize_from_gnss()` moves the method back to `FromStateEstimator`, so the
+two entry points can be alternated at runtime.
+
 ## State estimator integration
 
 Per LiDAR scan, `LidarOdometry` queries the configured `mola::NavStateFilter`

--- a/module/src/LidarOdometry_Relocalization.cpp
+++ b/module/src/LidarOdometry_Relocalization.cpp
@@ -56,6 +56,13 @@ void LidarOdometry::relocalize_near_pose_pdf_impl(const mrpt::poses::CPose3DPDFG
   // In this pose:
   il.fixed_initial_pose = p.mean.asTPose();
   il.initial_pose_cov = p.cov;
+  // An explicit pose request must also select the method that consumes it:
+  // otherwise, a system configured to initialize from the state estimator
+  // (or from the IMU) would ignore the pose and keep waiting for its own
+  // source to converge, while the `initial_localization_done = false` above
+  // already stopped scans from being processed. That is precisely the case
+  // where a manual re-localization is needed, e.g. poor GNSS coverage.
+  il.method = InitLocalization::FixedPose;
 
   // Reset adaptive sigma to initial value:
   state_.adapt_thres_sigma = std::sqrt(p.cov.asEigen().block<2, 2>(0, 0).trace());

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,18 @@ endif()
 set(DEFAULT_PIPELINE_YAML ${mola_lidar_odometry_SOURCE_DIR}/pipelines/lidar3d-default.yaml)
 set(DEFAULT_STATE_ESTIMATOR_YAML ${mola_lidar_odometry_SOURCE_DIR}/state-estimator-params/state-estimation-simple.yaml)
 
+# Test: relocalization requests (no dataset needed, but needs a state estimator)
+# ------------------------------------------------------------------------------
+ament_add_gtest(test_relocalization_request test_relocalization_request.cpp
+  ENV LO_PIPELINE_YAML=${DEFAULT_PIPELINE_YAML}
+  ENV LO_STATE_ESTIM_YAML=${DEFAULT_STATE_ESTIMATOR_YAML}
+  ENV MOLA_PROFILER=false
+)
+target_link_libraries(test_relocalization_request
+  mola::mola_state_estimation_simple
+  mola::mola_lidar_odometry
+)
+
 # Test: from rawlog file, using KITTI fragment
 # ---------------------------------------------------
 set(KITTI00_DATASET_FILE "${mola_test_datasets_DIR}/../datasets/kitti/kitti_00_extract.rawlog")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,22 @@ find_package(mola_metric_maps)
 find_package(mola_input_rosbag2)
 find_package(mola_state_estimation_simple)
 
+# Test: relocalization requests. Reads no dataset, so it is gated only on what
+# it does need: the metric maps the LO pipeline instantiates, and a state
+# estimator for LO to attach to.
+# ------------------------------------------------------------------------------
+if(mola_metric_maps_FOUND AND mola_state_estimation_simple_FOUND)
+  ament_add_gtest(test_relocalization_request test_relocalization_request.cpp
+    ENV LO_PIPELINE_YAML=${mola_lidar_odometry_SOURCE_DIR}/pipelines/lidar3d-default.yaml
+    ENV LO_STATE_ESTIM_YAML=${mola_lidar_odometry_SOURCE_DIR}/state-estimator-params/state-estimation-simple.yaml
+    ENV MOLA_PROFILER=false
+  )
+  target_link_libraries(test_relocalization_request
+    mola::mola_state_estimation_simple
+    mola::mola_lidar_odometry
+  )
+endif()
+
 if((NOT mola_test_datasets_FOUND) OR
    (NOT mola_metric_maps_FOUND) OR
    (NOT mola_input_rosbag2_FOUND) OR
@@ -45,18 +61,6 @@ endif()
 
 set(DEFAULT_PIPELINE_YAML ${mola_lidar_odometry_SOURCE_DIR}/pipelines/lidar3d-default.yaml)
 set(DEFAULT_STATE_ESTIMATOR_YAML ${mola_lidar_odometry_SOURCE_DIR}/state-estimator-params/state-estimation-simple.yaml)
-
-# Test: relocalization requests (no dataset needed, but needs a state estimator)
-# ------------------------------------------------------------------------------
-ament_add_gtest(test_relocalization_request test_relocalization_request.cpp
-  ENV LO_PIPELINE_YAML=${DEFAULT_PIPELINE_YAML}
-  ENV LO_STATE_ESTIM_YAML=${DEFAULT_STATE_ESTIMATOR_YAML}
-  ENV MOLA_PROFILER=false
-)
-target_link_libraries(test_relocalization_request
-  mola::mola_state_estimation_simple
-  mola::mola_lidar_odometry
-)
 
 # Test: from rawlog file, using KITTI fragment
 # ---------------------------------------------------

--- a/test/test_relocalization_request.cpp
+++ b/test/test_relocalization_request.cpp
@@ -1,0 +1,107 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+/**
+ * @file   test_relocalization_request.cpp
+ * @brief  A relocalization request must select the method that consumes it
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include <gtest/gtest.h>
+#include <mola_kernel/MinimalModuleContainer.h>
+#include <mola_lidar_odometry/LidarOdometry.h>
+#include <mola_state_estimation_simple/StateEstimationSimple.h>
+#include <mola_yaml/yaml_helpers.h>
+#include <mrpt/core/get_env.h>
+
+#include <memory>
+
+namespace
+{
+struct Fixture
+{
+  mola::LidarOdometry::Ptr liodom = mola::LidarOdometry::Create();
+  mola::state_estimation_simple::StateEstimationSimple::Ptr stateEstimator =
+    mola::state_estimation_simple::StateEstimationSimple::Create();
+
+  // Keeps both modules visible to each other, so LO can find the state estimator:
+  mola::MinimalModuleContainer moduleContainer = {{liodom, stateEstimator}};
+
+  Fixture()
+  {
+    liodom->setMinLoggingLevel(mrpt::system::LVL_WARN);
+    liodom->initialize(mola::load_yaml_file(mrpt::get_env<std::string>("LO_PIPELINE_YAML")));
+
+    stateEstimator->setMinLoggingLevel(mrpt::system::LVL_WARN);
+    stateEstimator->initialize(
+      mola::load_yaml_file(mrpt::get_env<std::string>("LO_STATE_ESTIM_YAML")));
+
+    liodom->params_.simplemap.generate = false;
+    liodom->params_.estimated_trajectory.output_file.clear();
+  }
+
+  /// Relocalization entry points only enqueue the request; spinOnce() runs it.
+  void runPendingRequests() { liodom->spinOnce(); }
+};
+
+mrpt::poses::CPose3DPDFGaussian someRequestedPose()
+{
+  mrpt::poses::CPose3DPDFGaussian p;
+  p.mean =
+    mrpt::poses::CPose3D::FromXYZYawPitchRoll(10.0, -4.0, 0.5, mrpt::DEG2RAD(30.0), 0.0, 0.0);
+  p.cov.setDiagonal(std::vector<double>({0.25, 0.25, 0.01, 0.01, 0.01, 0.05}));
+  return p;
+}
+}  // namespace
+
+// A manual request carries the pose in initial_localization.fixed_initial_pose,
+// which only the FixedPose method reads. Requesting it from any other
+// configured method must switch to FixedPose: otherwise the pose is stored and
+// never used, while the same request has already stopped scan processing.
+TEST(Relocalization, NearPoseSelectsFixedPoseMethod)
+{
+  for (const auto configuredMethod :
+       {mola::InitLocalization::FromStateEstimator, mola::InitLocalization::PitchAndRollFromIMU,
+        mola::InitLocalization::FixedPose}) {
+    Fixture f;
+    f.liodom->params_.initial_localization.method = configuredMethod;
+
+    const auto p = someRequestedPose();
+    f.liodom->relocalize_near_pose_pdf(p);
+    f.runPendingRequests();
+
+    const auto & il = f.liodom->params_.initial_localization;
+
+    EXPECT_EQ(il.method, mola::InitLocalization::FixedPose)
+      << "configured method index: " << static_cast<int>(configuredMethod);
+
+    EXPECT_NEAR((mrpt::poses::CPose3D(il.fixed_initial_pose) - p.mean).norm(), 0.0, 1e-9);
+    ASSERT_TRUE(il.initial_pose_cov.has_value());
+    EXPECT_NEAR((*il.initial_pose_cov - p.cov).sum_abs(), 0.0, 1e-9);
+  }
+}
+
+// The two entry points must remain usable in any order at runtime.
+TEST(Relocalization, FromGnssRestoresStateEstimatorMethod)
+{
+  Fixture f;
+
+  f.liodom->relocalize_near_pose_pdf(someRequestedPose());
+  f.runPendingRequests();
+  EXPECT_EQ(f.liodom->params_.initial_localization.method, mola::InitLocalization::FixedPose);
+
+  f.liodom->relocalize_from_gnss();
+  f.runPendingRequests();
+  EXPECT_EQ(
+    f.liodom->params_.initial_localization.method, mola::InitLocalization::FromStateEstimator);
+}


### PR DESCRIPTION
### The defect

`relocalize_near_pose_pdf()` (topic `/initialpose`, or the `relocalize_near_pose` service) stores the requested pose in `initial_localization.fixed_initial_pose` / `initial_pose_cov` and clears `initial_localization_done`, but it never touches `initial_localization.method`.

`handleInitialLocalization()` dispatches on that method, so only a system already configured as `InitLocalization::FixedPose` ever consumes the pose.

### Why it matters

`ros2-lidar-odometry.launch.py` sets `MOLA_LO_INITIAL_LOCALIZATION_METHOD=InitLocalization::FromStateEstimator` for `gnss_mode:=relocalize` — the GNSS auto-initialization mode, which also requires the smoother. In that configuration a manual relocalization request:

- is stored and never read, and
- leaves `initial_localization_done == false`, which makes `onLidar()` return before ICP (`LidarOdometry_ProcessScan.cpp`).

So the request **stalls the front end** rather than relocalizing it, and LO then waits for a GNSS convergence that never arrives. `from_state_estimator_timeout` only logs an error and re-arms the wait; there is no fallback. This is exactly the scenario where a manual pose is needed: initializing in an area with poor GNSS coverage.

The same trap applies in reverse to `PitchAndRollFromIMU`, and after any call to `relocalize_from_gnss()` (which permanently moves the method to `FromStateEstimator`), later manual requests were dead even in a `FixedPose` deployment.

### The fix

Select `InitLocalization::FixedPose` along with the pose. `relocalize_from_gnss()` still moves the method back to `FromStateEstimator`, so the two entry points can be alternated at runtime.

Nothing else in the path needed changing: `BridgeROS2` already composes `reference_frame <- header.frame_id` via tf for poses arriving in another frame, the request is dispatched to the LiDAR worker thread without taking `state_mtx_`, and the smoother handoff (`reset()` + two seeded `fuse_pose()` calls) is ordered correctly against the async backend's reset epoch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zosPukwMRmSpzVUUWga5J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed manual pose-based relocalization so the requested pose is correctly applied, including when other localization methods are configured.
  - Prevented the lidar processing pipeline from stalling during manual relocalization.
  - Restored reliable switching between pose-based and GNSS-based relocalization at runtime.

- **Documentation**
  - Documented localization behavior and supported runtime switching between relocalization modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->