### PR TITLE
Add drop_stale_scans: a lossless input queue for offline runs

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -315,6 +315,25 @@ keeps end-to-end latency near a single processing period (so the state-estimator
 prediction is queried only a little into the future) for both LO and LIO.
 `params_.max_lidar_queue_before_drop` now only bounds the IMU wait list.
 
+### Lossless mode: `drop_stale_scans: false` (`MOLA_DROP_STALE_SCANS`)
+
+That trade (data for latency) is the wrong one offline, where every scan must be
+processed and two runs over the same data must agree; how many scans get dropped
+otherwise depends on the replay rate and on host load. With
+`drop_stale_scans: false` (in all `pipelines/*.yaml`):
+
+- `submitReadyLidarScanToWorker()` waits for `worker_lidar_.pendingTasks() == 0`
+  instead of letting `POLICY_DROP_OLD` evict the queued scan, so the producer is
+  throttled to the pipeline's own rate.
+- `releaseLidarScansToWorker()` submits **every** ready scan in order, not only
+  the newest.
+- The `max_lidar_queue_before_drop` trim of the IMU wait list is skipped.
+
+`mola-lidar-odometry-cli` defaults it to false (`setenv(..., 0)`, so an explicit
+setting still wins), like `MOLA_ASYNC_BACKEND`. For `mola-cli` replays set it in
+the environment; note `time_warp_scale` above ~5 outruns the pipeline, and
+without this the excess simply becomes dropped scans.
+
 ## Adaptive-threshold sustained-failure recovery is ON by default
 
 `recover_on_sustained_failure` (all `pipelines/*.yaml`, `adaptive_threshold`
@@ -788,6 +807,7 @@ pipeline YAML, not read directly in C++.)
 | `MOLA_DEBUG_DUMP_ICP_LOG_FROM_TIMESTAMP` | double | 0 | `module/src/LidarOdometry_ProcessScan.cpp` | Start of a timestamp range for forcing ICP debug-log dumps (paired with `..._TO_TIMESTAMP`) |
 | `MOLA_DEBUG_DUMP_ICP_LOG_TO_TIMESTAMP` | double | 0 | `module/src/LidarOdometry_ProcessScan.cpp` | End of the timestamp range above |
 | `MOLA_LO_DEBUG_ICP_QUALITY` | bool | false | `module/src/LidarOdometry_ProcessScan.cpp` | Trace ICP quality metrics per scan |
+| `MOLA_DROP_STALE_SCANS` | bool | true | all `pipelines/*.yaml` | false = lossless input queue (producer blocks instead of the queue evicting the older scan). `mola-lidar-odometry-cli` defaults it to false |
 | `LO_PIPELINE_YAML` | string | (unset) | `test/test_lidar_odometry_rawlog.cpp`, `test/test_lidar_odometry_rosbag2.cpp` | Path to the LO pipeline YAML used by the test |
 | `LO_STATE_ESTIM_YAML` | string | (unset) | same tests | Path to the state-estimator YAML used by the test |
 | `LO_TEST_RAWLOG` | string | (unset) | `test/test_lidar_odometry_rawlog.cpp` | Path to the input rawlog dataset |

--- a/apps/mola-lidar-odometry-cli.cpp
+++ b/apps/mola-lidar-odometry-cli.cpp
@@ -778,6 +778,11 @@ int main_odometry(Cli & cli)
   // ask for it. Datasets whose YAML does not read this variable are unaffected.
   setenv("MOLA_ASYNC_BACKEND", "false", 0 /* do not overwrite */);
 
+  // Same reasoning for the LiDAR input queue: its "keep only the freshest scan"
+  // default trades data for latency, which is the wrong trade offline, where
+  // every scan must be processed and two runs over the same data must agree.
+  setenv("MOLA_DROP_STALE_SCANS", "false", 0 /* do not overwrite */);
+
   // Make mandatory to specify state estimation config file, so defaults and initialize() are not skipped
   {
     const auto seParamsFile = cli.arg_stateEstimatorParams.getValue();

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -584,6 +584,22 @@ public:
 
     SimpleMapOptions simplemap;
 
+    // === INPUT QUEUE ====
+    /** When a new scan arrives while the worker is still busy, the default is to
+     *  keep only the freshest one. That is the right behavior on a robot, where
+     *  a stale scan is worth less than keeping up with the world, and the wrong
+     *  one for an offline batch run, whose whole point is that every scan gets
+     *  processed and the result is reproducible: how many scans are dropped then
+     *  depends on the replay rate and on whatever else the machine happens to be
+     *  doing, so two runs over the same data are not comparable.
+     *
+     *  Setting this to false makes the producer block until the worker is free,
+     *  instead of the queue evicting the older scan. The replay is then lossless
+     *  at any replay rate. Nothing else changes: the pipeline itself is
+     *  untouched, and the run simply takes as long as it takes.
+     */
+    bool drop_stale_scans = true;
+
     // === OUTPUT TRAJECTORY ====
     struct TrajectoryOutputOptions
     {

--- a/module/include/mola_lidar_odometry/LidarOdometry.h
+++ b/module/include/mola_lidar_odometry/LidarOdometry.h
@@ -1504,6 +1504,16 @@ private:
   ScanImuWaitList worker_lidar_wait_for_imu_list_;
   std::mutex worker_lidar_wait_for_imu_list_mtx_;
 
+  /// Serializes the whole wait-then-enqueue sequence used when
+  /// Parameters::drop_stale_scans is false. onNewObservation() is not
+  /// serialized by the framework, so the LiDAR and the IMU callback can reach
+  /// the submit path from two threads at once: both would see an empty queue,
+  /// both would enqueue, and POLICY_DROP_OLD would evict one of them, which is
+  /// the very drop this mode exists to prevent. Held across a whole release
+  /// batch, so submission order matches the scans' own order as well. Unused in
+  /// the default mode, where the pool's policy is the intended behavior.
+  std::mutex lossless_submit_mtx_;
+
   /// Newest timestamp (seconds, sensor clock) present in pending_imu_. A
   /// waiting scan may only be released to the worker once this reaches the
   /// scan's own IMU coverage end time, i.e. once every IMU sample the scan will
@@ -1851,6 +1861,13 @@ private:
    *          than on sampled busy counters. */
   std::future<void> submitReadyLidarScanToWorker(
     const CObservation::ConstPtr & o, std::optional<double> imuCoverageEndTime);
+
+  /** The Parameters::drop_stale_scans==false path of the above: waits for the
+   *  worker queue to drain, then enqueues, so nothing is ever evicted.
+   *  \note The caller must already hold lossless_submit_mtx_. */
+  std::future<void> submitLidarScanLossless_locked(
+    const CObservation::ConstPtr & o, std::optional<double> imuCoverageEndTime);
+
   /// Number of LiDAR scans currently running or queued on worker_lidar_ (0, 1, or 2).
   int pendingLidarScanCount() const;
 

--- a/module/src/LidarOdometry_Initialize.cpp
+++ b/module/src/LidarOdometry_Initialize.cpp
@@ -220,6 +220,14 @@ void LidarOdometry::initialize_frontend(const Yaml & c)
     YAML_LOAD_OPT(params_, pipeline_profiler_enabled, bool);
     YAML_LOAD_OPT(params_, icp_profiler_enabled, bool);
     YAML_LOAD_OPT(params_, icp_profiler_full_history, bool);
+    YAML_LOAD_OPT(params_, drop_stale_scans, bool);
+
+    if (!params_.drop_stale_scans) {
+      MRPT_LOG_INFO(
+        "drop_stale_scans=false: the input queue will BLOCK instead of keeping only the "
+        "freshest scan. Intended for offline batch runs, where a lossless, reproducible "
+        "replay matters more than keeping up with the clock.");
+    }
 
     if (cfg.has("simplemap")) {
       params_.simplemap.initialize(cfg["simplemap"], params_);

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -313,10 +313,13 @@ std::future<void> LidarOdometry::releaseLidarScansToWorker(const double upToImuT
   if (!params_.drop_stale_scans) {
     // Lossless mode: submit every scan that became ready, in chronological
     // order. Each submit below blocks until the worker is free, so none of them
-    // can be superseded by the next one.
+    // can be superseded by the next one. The lock spans the whole batch, so a
+    // concurrent caller cannot slip a scan of its own in between two of these
+    // and reorder them.
+    auto lck = mrpt::lockHelper(lossless_submit_mtx_);
     std::future<void> last;
     for (const auto & e : readyScans) {
-      last = submitReadyLidarScanToWorker(e.obs, e.imu_coverage_end_time);
+      last = submitLidarScanLossless_locked(e.obs, e.imu_coverage_end_time);
     }
     return last;
   }
@@ -342,26 +345,38 @@ std::future<void> LidarOdometry::submitReadyLidarScanToWorker(
   // detects it; running scans are never aborted, only queued ones can be
   // dropped this way.
   if (!params_.drop_stale_scans) {
-    // Lossless mode: wait for the queue to drain instead of letting the
-    // eviction happen, which throttles the producer down to the pipeline's own
-    // rate. That is what a reproducible replay needs.
-    while (worker_lidar_.pendingTasks() > 0) {
-      const bool aborting = [this]() {
-        auto lck = mrpt::lockHelper(is_busy_mtx_);
-        return destructor_called_;
-      }();
-      if (aborting) {
-        return {};
-      }
-      std::this_thread::sleep_for(std::chrono::microseconds(500));
-    }
-  } else if (worker_lidar_.pendingTasks() > 0) {
+    auto lck = mrpt::lockHelper(lossless_submit_mtx_);
+    return submitLidarScanLossless_locked(o, imuCoverageEndTime);
+  }
+
+  if (worker_lidar_.pendingTasks() > 0) {
     // The eviction is about to happen: account for it.
     addDropStats(true);
     profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
     MRPT_LOG_THROTTLE_WARN_FMT(
       1.0, "Dropping LiDAR scan (worker busy: keeping only the freshest); dropped frames: %.02f%%",
       getDropStats() * 100.0);
+  }
+
+  return worker_lidar_.enqueue(
+    &LidarOdometry::onLidar, this, o, mrpt::Clock::nowDouble(), imuCoverageEndTime);
+}
+
+std::future<void> LidarOdometry::submitLidarScanLossless_locked(
+  const CObservation::ConstPtr & o, std::optional<double> imuCoverageEndTime)
+{
+  // Wait for the queue to drain instead of letting POLICY_DROP_OLD evict the
+  // scan already waiting in it, which throttles the producer down to the
+  // pipeline's own rate. That is what a reproducible replay needs.
+  while (worker_lidar_.pendingTasks() > 0) {
+    const bool aborting = [this]() {
+      auto lck = mrpt::lockHelper(is_busy_mtx_);
+      return destructor_called_;
+    }();
+    if (aborting) {
+      return {};
+    }
+    std::this_thread::sleep_for(std::chrono::microseconds(500));
   }
 
   return worker_lidar_.enqueue(

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -32,7 +32,9 @@
 #include <mrpt/obs/CObservationRobotPose.h>
 
 // Std:
+#include <chrono>
 #include <regex>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -249,12 +251,15 @@ void LidarOdometry::sendLidarScanToProcessQueue(const CObservation::ConstPtr & o
 
     // Safety cap: if IMU data lags badly, keep the wait list from growing without
     // bound by dropping the oldest still-waiting scans (they would be the most
-    // stale ones anyway):
-    const auto nDropped =
-      worker_lidar_wait_for_imu_list_.trim_to(params_.max_lidar_queue_before_drop);
-    for (std::size_t i = 0; i < nDropped; i++) {
-      addDropStats(true);
-      profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
+    // stale ones anyway). Skipped in lossless mode, where the producer is
+    // throttled at submit time and the list is bounded by the IMU lag alone:
+    if (params_.drop_stale_scans) {
+      const auto nDropped =
+        worker_lidar_wait_for_imu_list_.trim_to(params_.max_lidar_queue_before_drop);
+      for (std::size_t i = 0; i < nDropped; i++) {
+        addDropStats(true);
+        profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
+      }
     }
     waitListSize = worker_lidar_wait_for_imu_list_.size();
   }
@@ -301,13 +306,24 @@ std::future<void> LidarOdometry::releaseLidarScansToWorker(const double upToImuT
     return worker_lidar_wait_for_imu_list_.take_ready(upToImuTime);
   }();
 
-  // On an IMU catch-up burst several scans can qualify at once, but only the
-  // newest matters ("keep freshest"): drop-account the older ones directly
-  // instead of submitting each only to have it superseded by the next.
   if (readyScans.empty()) {
     return {};  // an invalid future: nothing was submitted
   }
 
+  if (!params_.drop_stale_scans) {
+    // Lossless mode: submit every scan that became ready, in chronological
+    // order. Each submit below blocks until the worker is free, so none of them
+    // can be superseded by the next one.
+    std::future<void> last;
+    for (const auto & e : readyScans) {
+      last = submitReadyLidarScanToWorker(e.obs, e.imu_coverage_end_time);
+    }
+    return last;
+  }
+
+  // On an IMU catch-up burst several scans can qualify at once, but only the
+  // newest matters ("keep freshest"): drop-account the older ones directly
+  // instead of submitting each only to have it superseded by the next.
   for (std::size_t i = 0; i + 1 < readyScans.size(); i++) {
     addDropStats(true);
     profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
@@ -322,10 +338,25 @@ std::future<void> LidarOdometry::submitReadyLidarScanToWorker(
   // worker_lidar_ uses POLICY_DROP_OLD: with a single worker thread, enqueue()
   // itself discards any older, not-yet-started scan once one is already queued
   // behind the one currently running. The pool gives no callback for that
-  // eviction, so detect it here (before enqueueing) purely for the drop-stats
-  // accounting; running scans are never aborted, only queued ones can be
+  // eviction, so a nonzero pendingTasks() here (before enqueueing) is what
+  // detects it; running scans are never aborted, only queued ones can be
   // dropped this way.
-  if (worker_lidar_.pendingTasks() > 0) {
+  if (!params_.drop_stale_scans) {
+    // Lossless mode: wait for the queue to drain instead of letting the
+    // eviction happen, which throttles the producer down to the pipeline's own
+    // rate. That is what a reproducible replay needs.
+    while (worker_lidar_.pendingTasks() > 0) {
+      const bool aborting = [this]() {
+        auto lck = mrpt::lockHelper(is_busy_mtx_);
+        return destructor_called_;
+      }();
+      if (aborting) {
+        return {};
+      }
+      std::this_thread::sleep_for(std::chrono::microseconds(500));
+    }
+  } else if (worker_lidar_.pendingTasks() > 0) {
+    // The eviction is about to happen: account for it.
     addDropStats(true);
     profiler_.registerUserMeasure("onNewObservation.drop_observation", 1);
     MRPT_LOG_THROTTLE_WARN_FMT(

--- a/module/src/LidarOdometry_SensorCallbacks.cpp
+++ b/module/src/LidarOdometry_SensorCallbacks.cpp
@@ -33,6 +33,7 @@
 
 // Std:
 #include <chrono>
+#include <mutex>
 #include <regex>
 #include <thread>
 #include <utility>
@@ -299,6 +300,16 @@ void LidarOdometry::releaseReadyLidarScansToWorker()
 
 std::future<void> LidarOdometry::releaseLidarScansToWorker(const double upToImuTime)
 {
+  // In lossless mode the lock is taken BEFORE the scans leave the wait list and
+  // held until the last of them is enqueued: taking it any later would let a
+  // concurrent caller remove a newer batch and submit it ahead of this one, so
+  // the worker would see the scans out of chronological order. The default mode
+  // has nothing to serialize, since the pool's own policy is the intent there.
+  std::unique_lock<std::mutex> losslessLock;
+  if (!params_.drop_stale_scans) {
+    losslessLock = std::unique_lock<std::mutex>(lossless_submit_mtx_);
+  }
+
   // Collect every waiting scan whose whole span is already covered by received
   // IMU data, in chronological order, then submit outside the wait-list lock:
   const std::vector<ScanImuWaitList::Entry> readyScans = [&]() {
@@ -311,12 +322,9 @@ std::future<void> LidarOdometry::releaseLidarScansToWorker(const double upToImuT
   }
 
   if (!params_.drop_stale_scans) {
-    // Lossless mode: submit every scan that became ready, in chronological
-    // order. Each submit below blocks until the worker is free, so none of them
-    // can be superseded by the next one. The lock spans the whole batch, so a
-    // concurrent caller cannot slip a scan of its own in between two of these
-    // and reorder them.
-    auto lck = mrpt::lockHelper(lossless_submit_mtx_);
+    // Submit every scan that became ready, in chronological order. Each submit
+    // below blocks until the worker is free, so none can be superseded by the
+    // next one either.
     std::future<void> last;
     for (const auto & e : readyScans) {
       last = submitLidarScanLossless_locked(e.obs, e.imu_coverage_end_time);

--- a/pipelines/extras/lidar3d-dual-map.yaml
+++ b/pipelines/extras/lidar3d-dual-map.yaml
@@ -13,6 +13,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 0 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # How often to update the local map model:
   local_map_updates:
     enabled: "${MOLA_MAPPING_ENABLED|true}"

--- a/pipelines/extras/lidar3d-edges.yaml
+++ b/pipelines/extras/lidar3d-edges.yaml
@@ -13,6 +13,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 0 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # How often to update the local map model:
   local_map_updates:
     enabled: "${MOLA_MAPPING_ENABLED|true}"

--- a/pipelines/extras/lidar3d-hybrid-pw.yaml
+++ b/pipelines/extras/lidar3d-hybrid-pw.yaml
@@ -47,6 +47,11 @@ params:
 
   min_time_between_scans: 1e-3 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
 

--- a/pipelines/extras/lidar3d-kissicp-like.yaml
+++ b/pipelines/extras/lidar3d-kissicp-like.yaml
@@ -9,6 +9,11 @@ params:
 
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 0 # 0.2  # [seconds]
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # Maximum time between two scans to consider the validity of the velocity model:
   max_time_to_use_velocity_model: 2.0 # [seconds]
 

--- a/pipelines/extras/rgbd.yaml
+++ b/pipelines/extras/rgbd.yaml
@@ -21,6 +21,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 1e-3 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.999
   absolute_minimum_observation_radius: 10.0

--- a/pipelines/lidar2d.yaml
+++ b/pipelines/lidar2d.yaml
@@ -28,6 +28,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 1e-3 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.999
   absolute_minimum_observation_radius: 20.0

--- a/pipelines/lidar3d-default-voxelavg.yaml
+++ b/pipelines/lidar3d-default-voxelavg.yaml
@@ -36,6 +36,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 1e-3 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}

--- a/pipelines/lidar3d-dlio-like-only-downsample-voxelavg.yaml
+++ b/pipelines/lidar3d-dlio-like-only-downsample-voxelavg.yaml
@@ -58,6 +58,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 1e-3 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}

--- a/pipelines/lidar3d-dlio-like-only-downsample.yaml
+++ b/pipelines/lidar3d-dlio-like-only-downsample.yaml
@@ -47,6 +47,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 1e-3 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}

--- a/pipelines/lidar3d-dlio-like-revert-downsample.yaml
+++ b/pipelines/lidar3d-dlio-like-revert-downsample.yaml
@@ -68,6 +68,11 @@ params:
 
   min_time_between_scans: 1e-3
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
   # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.

--- a/pipelines/lidar3d-dlio-like-revert-keyframe.yaml
+++ b/pipelines/lidar3d-dlio-like-revert-keyframe.yaml
@@ -67,6 +67,11 @@ params:
 
   min_time_between_scans: 1e-3
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
   # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.

--- a/pipelines/lidar3d-dlio-like-worldframe-decimate.yaml
+++ b/pipelines/lidar3d-dlio-like-worldframe-decimate.yaml
@@ -106,6 +106,11 @@ params:
 
   min_time_between_scans: 1e-3
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
   # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.

--- a/pipelines/lidar3d-dlio-like.yaml
+++ b/pipelines/lidar3d-dlio-like.yaml
@@ -66,6 +66,11 @@ params:
 
   min_time_between_scans: 1e-3
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}
   # Quantile of the per-point norms taken as ESTIMATED_OBSERVATION_RADIUS.

--- a/pipelines/lidar3d-fastlio-matching.yaml
+++ b/pipelines/lidar3d-fastlio-matching.yaml
@@ -25,6 +25,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 1e-3 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}

--- a/pipelines/lidar3d-gicp-optimize-twist.yaml
+++ b/pipelines/lidar3d-gicp-optimize-twist.yaml
@@ -29,6 +29,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 1e-3 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}

--- a/pipelines/lidar3d-gicp-single-filter.yaml
+++ b/pipelines/lidar3d-gicp-single-filter.yaml
@@ -52,6 +52,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 1e-3 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}

--- a/pipelines/lidar3d-gicp.yaml
+++ b/pipelines/lidar3d-gicp.yaml
@@ -30,6 +30,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 1e-3 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}

--- a/pipelines/lidar3d-icp-blend.yaml
+++ b/pipelines/lidar3d-icp-blend.yaml
@@ -26,6 +26,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 1e-3 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}

--- a/pipelines/lidar3d-icp.yaml
+++ b/pipelines/lidar3d-icp.yaml
@@ -28,6 +28,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 1e-3 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}

--- a/pipelines/lidar3d-ndt-blend.yaml
+++ b/pipelines/lidar3d-ndt-blend.yaml
@@ -32,6 +32,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 1e-3 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}

--- a/pipelines/lidar3d-ndt.yaml
+++ b/pipelines/lidar3d-ndt.yaml
@@ -28,6 +28,11 @@ params:
   # Optionally, drop lidar data too close in time:
   min_time_between_scans: 1e-3 # [seconds]
 
+  # Whether a scan arriving while the worker is still busy replaces the one
+  # already queued (real-time behavior) or waits for it (lossless). Set to false
+  # for offline batch runs, where every scan must be processed.
+  drop_stale_scans: ${MOLA_DROP_STALE_SCANS|true}
+
   # Parameters for max sensor range automatic estimation:
   observation_radius_filter_coefficient: 0.95
   absolute_minimum_observation_radius: ${MOLA_ABS_MIN_SENSOR_RANGE|5.0}


### PR DESCRIPTION
## The problem

`LidarOdometry`'s input queue keeps only the freshest scan when a new one
arrives while the worker is busy. On a robot that is the right trade: a stale
scan is worth less than keeping up with the world.

Offline it is the wrong trade, and quietly so. How many scans get dropped
depends on the replay rate and on whatever else the machine is doing, so two
runs over the same data are not comparable, and nothing in the output says the
comparison is invalid unless you go looking for the drop counter. Measured in
this workspace: a `mola-cli` replay of KITTI 00 at a high `time_warp_scale`
dropped **70%** of the sequence; even at real time, an unrelated `make -j` on
the same machine cost **48 of 4541** scans.

## The change

A new `drop_stale_scans` parameter (default `true`, i.e. no behavior change).
With `drop_stale_scans: false`:

- `submitReadyLidarScanToWorker()` waits for the worker queue to drain instead
  of letting `POLICY_DROP_OLD` evict the scan already waiting in it, which
  throttles the producer down to the pipeline's own rate.
- `releaseLidarScansToWorker()` submits **every** scan that became ready, in
  chronological order, rather than only the newest of an IMU catch-up burst.
- The `max_lidar_queue_before_drop` trim of the IMU wait list is skipped: with
  the producer throttled, that list is bounded by the IMU lag alone.

The pipeline itself is untouched. A lossless run simply takes as long as it
takes.

Exposed as `${MOLA_DROP_STALE_SCANS|true}` in every shipped pipeline, and
`mola-lidar-odometry-cli` defaults it to `false` for itself with a
non-overwriting `setenv`, the same way it already does for
`MOLA_ASYNC_BACKEND` -- it is a batch tool with no real-time deadline, so an
explicit setting still wins but the reproducible default is the one you get.

`initialize()` logs one INFO line when the lossless path is active, so a run
that took an unexpectedly long time says why.

## Notes

`mola-lidar-odometry-cli` already waits for `isBusy()` after each dataset
entry, so its exposure was only through the IMU wait list: a catch-up burst
there still dropped all but the newest scan. That path is now covered too.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwmDrVzbh2jUwJdzyqnzoF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable LiDAR scan handling across supported pipelines through `drop_stale_scans`.
  * Real-time mode remains the default, prioritizing the freshest scan when processing is busy.
  * Optional lossless mode processes every scan in order for offline replay and batch processing.
  * Scan handling can be configured with the `MOLA_DROP_STALE_SCANS` environment variable.

* **Documentation**
  * Added guidance on scan-handling modes and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->