### PR TITLE
Expose the TSDF layer's rendering knobs in the dual-map pipeline

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -588,7 +588,10 @@ surface regularization, so leaving this at `1.0` makes the field block a few
 tenths of a percent of the information and reproduces `lidar3d-gicp.yaml`. The
 per-layer `weight` key inside a matcher's layer list is a legacy no-op in
 mp2p_icp and cannot be used for this. The `MOLA_TSDF_*` variables tune the
-field itself and are documented in the YAML.
+field itself and are documented in the YAML, `MOLA_TSDF_COLORMAP` /
+`MOLA_TSDF_COLOR_BY` / `MOLA_TSDF_RENDER_AS_MESH` its rendering (the last one
+draws a marching-tetrahedra surface instead of points: for figures, not for a
+live run).
 
 Measured on 13 Oxford Spires sequences against `lidar3d-gicp.yaml` under the
 same profile: pooled vertical drift +1.415 -> +0.166 mm/m (13/13 sequences

--- a/agents.md
+++ b/agents.md
@@ -588,10 +588,10 @@ surface regularization, so leaving this at `1.0` makes the field block a few
 tenths of a percent of the information and reproduces `lidar3d-gicp.yaml`. The
 per-layer `weight` key inside a matcher's layer list is a legacy no-op in
 mp2p_icp and cannot be used for this. The `MOLA_TSDF_*` variables tune the
-field itself and are documented in the YAML, `MOLA_TSDF_COLORMAP` /
-`MOLA_TSDF_COLOR_BY` / `MOLA_TSDF_RENDER_AS_MESH` its rendering (the last one
-draws a marching-tetrahedra surface instead of points: for figures, not for a
-live run).
+field itself and are documented in the YAML, `MOLA_TSDF_POINT_SIZE` /
+`MOLA_TSDF_COLORMAP` / `MOLA_TSDF_COLOR_BY` / `MOLA_TSDF_RENDER_AS_MESH` its
+rendering (the last one draws a marching-tetrahedra surface instead of points:
+for figures, not for a live run).
 
 Measured on 13 Oxford Spires sequences against `lidar3d-gicp.yaml` under the
 same profile: pooled vertical drift +1.415 -> +0.166 mm/m (13/13 sequences

--- a/pipelines/lidar3d-gicp-dual-tsdf.yaml
+++ b/pipelines/lidar3d-gicp-dual-tsdf.yaml
@@ -688,7 +688,16 @@ localmap_generator:
           bootstrap_max_plane_deviation: ${MOLA_TSDF_BOOTSTRAP_MAX_DEV|0.5}
         likelihoodOpts: ~
         renderOpts:
-          point_size: 2.0
+          point_size: ${MOLA_TSDF_POINT_SIZE|2.0}
+          # The surface is drawn where the field changes sign, interpolated
+          # between the two voxels, so it is not quantized to the grid.
+          # Colored by "z" or by "weight" (how much evidence backs it);
+          # cmNONE falls back to the uniform points_color.
+          colormap: ${MOLA_TSDF_COLORMAP|cmHOT}
+          recolorize_by: "${MOLA_TSDF_COLOR_BY|z}"
+          # Draws a shaded surface instead of points: much prettier, much
+          # slower. For figures and for a close look, not for a live run.
+          render_as_mesh: ${MOLA_TSDF_RENDER_AS_MESH|false}
 
 observations_generator:
   # Generators:


### PR DESCRIPTION
Depends on MOLAorg/mola#217, which makes `mola::TSDF` draw its surface from the interpolated zero crossings of the field instead of from voxel centers, and adds a colormap and an optional marching-tetrahedra mesh.

This surfaces the new options in `pipelines/lidar3d-gicp-dual-tsdf.yaml`, with the same defaults as the map class:

- `MOLA_TSDF_POINT_SIZE`
- `MOLA_TSDF_COLORMAP` (default `cmHOT`, `cmNONE` for a uniform color)
- `MOLA_TSDF_COLOR_BY` (`z` or `weight`)
- `MOLA_TSDF_RENDER_AS_MESH` (default `false`: prettier and much slower, for figures rather than live runs)

Example:

```bash
MOLA_ODOMETRY_PIPELINE_YAML=.../pipelines/lidar3d-gicp-dual-tsdf.yaml \
MOLA_TSDF_RENDER_AS_MESH=true \
  mola-lo-gui-oxford-spires /path/to/sequences/2024-03-12-keble-college-01/
```

Nothing about the odometry itself changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable TSDF visualization options for point size, color map, coloring mode, and mesh rendering.
  - Added environment-variable controls for customizing TSDF display behavior and rendering defaults.
  - Mesh rendering displays an interpolated surface instead of points and is intended primarily for figure generation rather than live runs.

- **Documentation**
  - Documented the available TSDF rendering variables, supported options, defaults, and mesh-rendering considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->